### PR TITLE
Fix IdentifyMissingTests tool

### DIFF
--- a/src/PlaywrightSharp.Tests/BrowserContextBasicTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextBasicTests.cs
@@ -238,7 +238,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains(second, context.Pages);
         }
 
-        [PlaywrightTest("browsercontext-basic.spec.ts", "BrowserContext.pages()", "should close all belonging pages once closing context")]
+        [PlaywrightTest("browsercontext-basic.spec.ts", "should close all belonging pages once closing context")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldCloseAllBelongingPagesOnceClosingContext()
         {

--- a/src/PlaywrightSharp.Tests/BrowserContextDeviceTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextDeviceTests.cs
@@ -17,7 +17,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("browsercontext-device.spec.ts", "should work")]
+        [PlaywrightTest("browsercontext-device.spec.ts", "device", "should work")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWork()
         {
@@ -29,7 +29,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("iPhone", await page.EvaluateAsync<string>("navigator.userAgent"));
         }
 
-        [PlaywrightTest("browsercontext-device.spec.ts", "should support clicking")]
+        [PlaywrightTest("browsercontext-device.spec.ts", "device", "should support clicking")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldSupportClicking()
         {
@@ -43,7 +43,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("Clicked", await page.EvaluateAsync<string>("() => result"));
         }
 
-        [PlaywrightTest("browsercontext-device.spec.ts", "should scroll to click")]
+        [PlaywrightTest("browsercontext-device.spec.ts", "device", "should scroll to click")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldScrollToClick()
         {

--- a/src/PlaywrightSharp.Tests/BrowserContextPageEventTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextPageEventTests.cs
@@ -213,7 +213,7 @@ namespace PlaywrightSharp.Tests
             Assert.Null(await popupEventTask.Result.Page.GetOpenerAsync());
         }
 
-        [PlaywrightTest("browsercontext-page-event.spec.ts", "should report when a new page is created and closed")]
+        [PlaywrightTest("browsercontext-page-event.spec.ts", "should work with Ctrl-clicking")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipFirefox: true)]
         public async Task ShouldWorkWithCtrlClicking()
         {

--- a/src/PlaywrightSharp.Tests/BrowserContextViewportMobileTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserContextViewportMobileTests.cs
@@ -18,7 +18,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should support mobile emulation")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should support mobile emulation")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldSupportMobileEmulation()
         {
@@ -31,7 +31,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(400, await page.EvaluateAsync<int>("window.innerWidth"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should support touch emulation")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should support touch emulation")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldSupportTouchEmulation()
         {
@@ -56,7 +56,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("Received touch", await page.EvaluateAsync<string>(dispatchTouch));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should be detectable by Modernizr")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should be detectable by Modernizr")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldBeDetectableByModernizr()
         {
@@ -66,7 +66,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("YES", await page.EvaluateAsync<string>("document.body.textContent.trim()"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should detect touch when applying viewport with touches")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should detect touch when applying viewport with touches")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldDetectTouchWhenApplyingViewportWithTouches()
         {
@@ -86,7 +86,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(await page.EvaluateAsync<bool>("() => Modernizr.touchevents"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should support landscape emulation")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should support landscape emulation")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldSupportLandscapeEmulation()
         {
@@ -101,7 +101,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(await page2.EvaluateAsync<bool>("() => matchMedia('(orientation: landscape)').matches"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should support window.orientation emulation")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should support window.orientation emulation")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldSupportWindowOrientationEmulation()
         {
@@ -122,7 +122,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(90, await page.EvaluateAsync<int?>("() => window.orientation"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should fire orientationchange event")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "should fire orientationchange event")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldFireOrientationChangeEvent()
         {
@@ -161,7 +161,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("2", event2.Message.Text);
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "default mobile viewports to 980 width")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "default mobile viewports to 980 width")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task DefaultMobileViewportsTo980Width()
         {
@@ -180,7 +180,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(980, await page.EvaluateAsync<int>("() => window.innerWidth"));
         }
 
-        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "respect meta viewport tag")]
+        [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "mobile viewport", "respect meta viewport tag")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task RespectMetaViewportTag()
         {

--- a/src/PlaywrightSharp.Tests/BrowserTypeConnectTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserTypeConnectTests.cs
@@ -14,7 +14,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should be able to reconnect to a browser")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should be able to reconnect to a browser")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldBeAbleToReconnectToABrowser()
         {
@@ -37,61 +37,61 @@ namespace PlaywrightSharp.Tests
             */
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should be able to connect two browsers at the same time")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should be able to connect two browsers at the same time")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldBeAbleToConnectTwoBrowsersAtTheSameTime()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "disconnected event should be emitted when browser is closed or server is closed")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "disconnected event should be emitted when browser is closed or server is closed")]
         [Fact(Skip = "SKIP WIRE")]
         public void DisconnectedEventShouldBeEmittedWhenBrowserIsClosedOrServerIsClosed()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should handle exceptions during connect")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should handle exceptions during connect")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldHandleExceptionsDuringConnect()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should set the browser connected state")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should set the browser connected state")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldSetTheBrowserConnectedState()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should throw when used after isConnected returns false")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should throw when used after isConnected returns false")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldThrowWhenUsedAfterIsConnectedReturnsFalse()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should reject navigation when browser closes")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should reject navigation when browser closes")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldRejectNavigationWhenBrowserCloses()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should reject waitForSelector when browser closes")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should reject waitForSelector when browser closes")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldRejectWaitForSelectorWhenBrowserCloses()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should emit close events on pages and contexts")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should emit close events on pages and contexts")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldEmitCloseEventsOnPagesAndContexts()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should terminate network waiters")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should terminate network waiters")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldTerminateNetworkWaiters()
         {
         }
 
-        [PlaywrightTest("browsertype-connect.spec.ts", "should respect selectors")]
+        [PlaywrightTest("browsertype-connect.spec.ts", "connect", "should respect selectors")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldRespectSelectors()
         {

--- a/src/PlaywrightSharp.Tests/BrowserTypeLaunchTests.cs
+++ b/src/PlaywrightSharp.Tests/BrowserTypeLaunchTests.cs
@@ -58,7 +58,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should throw if page argument is passed")]
+        [PlaywrightTest("browsertype-launch.spec.ts", "should throw if page argument is passed")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldThrowIfPageArgumentIsPassed()
         {

--- a/src/PlaywrightSharp.Tests/DownloadTests.cs
+++ b/src/PlaywrightSharp.Tests/DownloadTests.cs
@@ -34,7 +34,7 @@ namespace PlaywrightSharp.Tests
             });
         }
 
-        [PlaywrightTest("download.spec.ts", "should report downloads with acceptDownloads: false")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report downloads with acceptDownloads: false")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportDownloadsWithAcceptDownloadsFalse()
         {
@@ -54,7 +54,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("acceptDownloads: true", exception.Message);
         }
 
-        [PlaywrightTest("download.spec.ts", "should report downloads with acceptDownloads: true")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report downloads with acceptDownloads: true")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportDownloadsWithAcceptDownloadsTrue()
         {
@@ -73,7 +73,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("Hello world", File.ReadAllText(path));
         }
 
-        [PlaywrightTest("download.spec.ts", "should save to user-specified path")]
+        [PlaywrightTest("download.spec.ts", "download event", "should save to user-specified path")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldSaveToUserSpecifiedPath()
         {
@@ -95,7 +95,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should save to user-specified path without updating original path")]
+        [PlaywrightTest("download.spec.ts", "download event", "should save to user-specified path without updating original path")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldSaveToUserSpecifiedPathWithoutUpdatingOriginalPath()
         {
@@ -122,7 +122,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should save to two different paths with multiple saveAs calls")]
+        [PlaywrightTest("download.spec.ts", "download event", "should save to two different paths with multiple saveAs calls")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldSaveToTwoDifferentPathsWithMultipleSaveAsCalls()
         {
@@ -149,7 +149,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should save to overwritten filepath")]
+        [PlaywrightTest("download.spec.ts", "download event", "should save to overwritten filepath")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldSaveToOverwrittenFilepath()
         {
@@ -172,7 +172,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should create subdirectories when saving to non-existent user-specified path")]
+        [PlaywrightTest("download.spec.ts", "download event", "should create subdirectories when saving to non-existent user-specified path")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldCreateSubdirectoriesWhenSavingToNonExistentUserSpecifiedPath()
         {
@@ -194,13 +194,13 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should save when connected remotely")]
+        [PlaywrightTest("download.spec.ts", "download event", "should save when connected remotely")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldSaveWhenConnectedRemotely()
         {
         }
 
-        [PlaywrightTest("download.spec.ts", "should error when saving with downloads disabled")]
+        [PlaywrightTest("download.spec.ts", "download event", "should error when saving with downloads disabled")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldErrorWhenSavingWithDownloadsDisabled()
         {
@@ -220,7 +220,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("Pass { acceptDownloads: true } when you are creating your browser context", exception.Message);
         }
 
-        [PlaywrightTest("download.spec.ts", "should error when saving after deletion")]
+        [PlaywrightTest("download.spec.ts", "download event", "should error when saving after deletion")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldErrorWhenSavingAfterDeletion()
         {
@@ -240,13 +240,13 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("Download already deleted. Save before deleting.", exception.Message);
         }
 
-        [PlaywrightTest("download.spec.ts", "should error when saving after deletion when connected remotely")]
+        [PlaywrightTest("download.spec.ts", "download event", "should error when saving after deletion when connected remotely")]
         [Fact(Skip = "SKIP WIRE")]
         public void ShouldErrorWhenSavingAfterDeletionWhenConnectedRemotely()
         {
         }
 
-        [PlaywrightTest("download.spec.ts", "should report non-navigation downloads")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report non-navigation downloads")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportNonNavigationDownloads()
         {
@@ -274,7 +274,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should report download path within page.on('download', …) handler for Files")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report download path within page.on('download', …) handler for Files")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportDownloadPathWithinPageOnDownloadHandlerForFiles()
         {
@@ -293,7 +293,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should report download path within page.on('download', …) handler for Blobs")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report download path within page.on('download', …) handler for Blobs")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportDownloadPathWithinPageOnDownloadHandlerForBlobs()
         {
@@ -312,7 +312,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should report alt-click downloads")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report alt-click downloads")]
         [SkipBrowserAndPlatformFact(skipFirefox: true, skipWebkit: true)]
         public async Task ShouldReportAltClickDownloads()
         {
@@ -337,7 +337,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("Hello world", File.ReadAllText(path));
         }
 
-        [PlaywrightTest("download.spec.ts", "should report new window downloads")]
+        [PlaywrightTest("download.spec.ts", "download event", "should report new window downloads")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReportNewWindowDownloads()
         {
@@ -356,7 +356,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("Hello world", File.ReadAllText(path));
         }
 
-        [PlaywrightTest("download.spec.ts", "should delete file")]
+        [PlaywrightTest("download.spec.ts", "download event", "should delete file")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldDeleteFile()
         {
@@ -377,7 +377,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should expose stream")]
+        [PlaywrightTest("download.spec.ts", "download event", "should expose stream")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldExposeStream()
         {
@@ -396,7 +396,7 @@ namespace PlaywrightSharp.Tests
             await page.CloseAsync();
         }
 
-        [PlaywrightTest("download.spec.ts", "should delete downloads on context destruction")]
+        [PlaywrightTest("download.spec.ts", "download event", "should delete downloads on context destruction")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldDeleteDownloadsOnContextDestruction()
         {
@@ -423,7 +423,7 @@ namespace PlaywrightSharp.Tests
             Assert.False(new FileInfo(path2).Exists);
         }
 
-        [PlaywrightTest("download.spec.ts", "should delete downloads on browser gone")]
+        [PlaywrightTest("download.spec.ts", "download event", "should delete downloads on browser gone")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldDeleteDownloadsOnBrowserGone()
         {

--- a/src/PlaywrightSharp.Tests/ElementHandleScreenshotTests.cs
+++ b/src/PlaywrightSharp.Tests/ElementHandleScreenshotTests.cs
@@ -22,7 +22,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWork()
         {
@@ -38,7 +38,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-bounding-box.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should take into account padding and border")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should take into account padding and border")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeIntoAccountPaddingAndBorder()
         {
@@ -62,7 +62,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-padding-border.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should capture full element when larger than viewport in parallel")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should capture full element when larger than viewport in parallel")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldCaptureFullElementWhenLargerThanViewportInParallel()
         {
@@ -95,7 +95,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-larger-than-viewport.png", screenshotTasks.ElementAt(2).Result));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should capture full element when larger than viewport")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should capture full element when larger than viewport")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldCaptureFullElementWhenLargerThanViewport()
         {
@@ -127,7 +127,7 @@ namespace PlaywrightSharp.Tests
             await TestUtils.VerifyViewportAsync(Page, 500, 500);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should scroll element into view")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should scroll element into view")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldScrollElementIntoView()
         {
@@ -157,7 +157,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-scrolled-into-view.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should scroll 15000px into view")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should scroll 15000px into view")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldScroll15000pxIntoView()
         {
@@ -183,7 +183,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-scrolled-into-view.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work with a rotated element")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work with a rotated element")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWithARotatedElement()
         {
@@ -206,7 +206,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-rotate.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should fail to screenshot a detached element")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should fail to screenshot a detached element")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldFailToScreenshotADetachedElement()
         {
@@ -218,7 +218,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("Element is not attached to the DOM", exception.Message);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should timeout waiting for visible")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should timeout waiting for visible")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTimeoutWaitingForVisible()
         {
@@ -229,7 +229,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("element is not visible", exception.Message);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should wait for visible")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should wait for visible")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWaitForVisible()
         {
@@ -251,7 +251,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-bounding-box.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work for an element with fractional dimensions")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work for an element with fractional dimensions")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkForAnElementWithFractionalDimensions()
         {
@@ -261,7 +261,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-fractional.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work with a mobile viewport")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work with a mobile viewport")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWorkWithAMobileViewport()
         {
@@ -283,7 +283,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-mobile.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work with device scale factor")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work with device scale factor")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWorkWithDeviceScaleFactor()
         {
@@ -305,7 +305,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-mobile-dsf.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work for an element with an offset")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should work for an element with an offset")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkForAnElementWithAnOffset()
         {
@@ -315,7 +315,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-element-fractional-offset.png", screenshot));
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should take screenshots when default viewport is null")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should take screenshots when default viewport is null")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeScreenshotsWhenDefaultViewportIsNull()
         {
@@ -339,7 +339,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(sizeBefore, sizeAfter);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should take fullPage screenshots when default viewport is null")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should take fullPage screenshots when default viewport is null")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeFullPageScreenshotsWhenDefaultViewportIsNull()
         {
@@ -359,7 +359,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(sizeBefore, sizeAfter);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should restore default viewport after fullPage screenshot")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should restore default viewport after fullPage screenshot")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldRestoreDefaultViewportAfterFullPageScreenshot()
         {
@@ -376,20 +376,20 @@ namespace PlaywrightSharp.Tests
             await TestUtils.VerifyViewportAsync(page, 456, 789);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should restore viewport after page screenshot and exception")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should restore viewport after page screenshot and exception")]
         [Fact(Skip = "Skip USES_HOOKS")]
         public void ShouldRestoreViewportAfterPageScreenshotAndException()
         {
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should restore viewport after page screenshot and timeout")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should restore viewport after page screenshot and timeout")]
         [Fact(Skip = "Skip USES_HOOKS")]
         public void ShouldRestoreViewportAfterPageScreenshotAndTimeout()
         {
         }
 
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should take element screenshot when default viewport is null and restore back")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should take element screenshot when default viewport is null and restore back")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeElementScreenshotWhenDefaultViewportIsNullAndRestoreBack()
         {
@@ -426,13 +426,13 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(sizeBefore, sizeAfter);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should restore viewport after element screenshot and exception")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should restore viewport after element screenshot and exception")]
         [Fact(Skip = "Skip USES_HOOKS")]
         public void ShouldRestoreViewportAfterElementScreenshotAndException()
         {
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "should take screenshot of disabled button")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "should take screenshot of disabled button")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeScreenshotOfDisabledButton()
         {
@@ -444,7 +444,7 @@ namespace PlaywrightSharp.Tests
             Assert.NotEmpty(screenshot);
         }
 
-        [PlaywrightTest("elementhandle-screenshot.spec.ts", "path option should create subdirectories")]
+        [PlaywrightTest("elementhandle-screenshot.spec.ts", "element screenshot", "path option should create subdirectories")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PathOptionShouldCreateSubdirectories()
         {

--- a/src/PlaywrightSharp.Tests/FixturesTests.cs
+++ b/src/PlaywrightSharp.Tests/FixturesTests.cs
@@ -47,7 +47,7 @@ namespace PlaywrightSharp.Tests
         [Fact(Skip = "We don't need to test signals")]
         public void ShouldCloseTheBrowserOnSIGINTAndSIGTERM() { }
 
-        [PlaywrightTest("fixtures.spec.ts", "should report browser close signal")]
+        [PlaywrightTest("fixtures.spec.ts", "caller file path")]
         [Fact(Skip = "We don't need to test stacktrace")]
         public void CallerFilePath() { }
     }

--- a/src/PlaywrightSharp.Tests/FrameEvaluateTests.cs
+++ b/src/PlaywrightSharp.Tests/FrameEvaluateTests.cs
@@ -154,7 +154,7 @@ namespace PlaywrightSharp.Tests
             Assert.NotNull(await Page.Frames[1].QuerySelectorAsync("DIV"));
         }
 
-        [PlaywrightTest("frame-evaluate.spec.ts", "should work in iframes that failed initial navigation")]
+        [PlaywrightTest("frame-evaluate.spec.ts", "should work in iframes that interrupted initial javascript url navigation")]
         [SkipBrowserAndPlatformFact(skipChromium: true, skipFirefox: true)]
         public async Task ShouldWorkInIframesThatInterruptedInitialJavascriptUrlNavigation()
         {

--- a/src/PlaywrightSharp.Tests/PageAccessibilityContentEditableTests.cs
+++ b/src/PlaywrightSharp.Tests/PageAccessibilityContentEditableTests.cs
@@ -53,7 +53,7 @@ namespace PlaywrightSharp.Tests
             Assert.Empty(node.Name);
         }
 
-        [PlaywrightTest("page-accessibility.spec.ts", "contenteditable", "non editable textbox with role and tabIndex and label should not have children")]
+        [PlaywrightTest("page-accessibility.spec.ts", "non editable textbox with role and tabIndex and label should not have children")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipFirefox: true)]
         public async Task NonEditableTextboxWithRoleAndTabIndexAndLabelShouldNotHaveChildren()
         {
@@ -95,7 +95,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(node, (await Page.Accessibility.SnapshotAsync()).Children.First());
         }
 
-        [PlaywrightTest("page-accessibility.spec.ts", "contenteditable", "checkbox with and tabIndex and label should not have children")]
+        [PlaywrightTest("page-accessibility.spec.ts", "checkbox with and tabIndex and label should not have children")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipFirefox: true)]
         public async Task CheckboxWithAndTabIndexAndLabelShouldNotHaveChildren()
         {
@@ -114,7 +114,7 @@ namespace PlaywrightSharp.Tests
                 (await Page.Accessibility.SnapshotAsync()).Children.First());
         }
 
-        [PlaywrightTest("page-accessibility.spec.ts", "contenteditable", "checkbox without label should not have children")]
+        [PlaywrightTest("page-accessibility.spec.ts", "checkbox without label should not have children")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipFirefox: true)]
         public async Task CheckboxWithoutLabelShouldNotHaveChildren()
         {

--- a/src/PlaywrightSharp.Tests/PageBasicTests.cs
+++ b/src/PlaywrightSharp.Tests/PageBasicTests.cs
@@ -41,7 +41,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains(nameof(PageBasicTests), exception.StackTrace);
         }
 
-        [PlaywrightTest("page-basic.spec.ts", "Page.press should work")]
+        [PlaywrightTest("page-basic.spec.ts", "page.press should work")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PagePressShouldWork()
         {
@@ -50,7 +50,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("a", await Page.EvaluateAsync<string>("() => document.querySelector('textarea').value"));
         }
 
-        [PlaywrightTest("page-basic.spec.ts", "Frame.press should work")]
+        [PlaywrightTest("page-basic.spec.ts", "frame.press should work")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task FramePressShouldWork()
         {

--- a/src/PlaywrightSharp.Tests/PageDragTests.cs
+++ b/src/PlaywrightSharp.Tests/PageDragTests.cs
@@ -14,7 +14,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("page-drag.spec.ts", "should work")]
+        [PlaywrightTest("page-drag.spec.ts", "Drag and drop", "should work")]
         [Fact(Skip = "Skipped in Playwright")]
         public async Task ShouldWork()
         {

--- a/src/PlaywrightSharp.Tests/PageExposeFunctionTests.cs
+++ b/src/PlaywrightSharp.Tests/PageExposeFunctionTests.cs
@@ -223,7 +223,7 @@ namespace PlaywrightSharp.Tests
                 }", TestConstants.ServerUrl + "/one-style.html"));
         }
 
-        [PlaywrightTest("browsercontext-expose-function.spec.ts", "should throw for duplicate registrations")]
+        [PlaywrightTest("page-expose-function.spec.ts", "should throw for duplicate registrations")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldThrowForDuplicateRegistrations()
         {

--- a/src/PlaywrightSharp.Tests/PageGoToTests.cs
+++ b/src/PlaywrightSharp.Tests/PageGoToTests.cs
@@ -170,7 +170,7 @@ namespace PlaywrightSharp.Tests
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
         }
 
-        [PlaywrightTest("page-goto.spec.ts", "should work with subframes return 204")]
+        [PlaywrightTest("page-goto.spec.ts", "should work with subframes return 204 with domcontentloaded")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldFailWhenServerReturns204()
         {
@@ -310,7 +310,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains(TestConstants.EmptyPage, exception.Message);
         }
 
-        [PlaywrightTest("page-goto.spec.ts", "should fail when exceeding maximum navigation timeout")]
+        [PlaywrightTest("page-goto.spec.ts", "should fail when exceeding default maximum navigation timeout")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldFailWhenExceedingDefaultMaximumNavigationTimeout()
         {

--- a/src/PlaywrightSharp.Tests/PageNetworkRequestTest.cs
+++ b/src/PlaywrightSharp.Tests/PageNetworkRequestTest.cs
@@ -73,7 +73,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains(response.Request.GetHeaderValues("user-agent"), (f) => f.Contains(expected));
         }
 
-        [PlaywrightTest("page-network-request.spec.ts", "Request.headers", "should get the same headers as the server")]
+        [PlaywrightTest("page-network-request.spec.ts", "should get the same headers as the server")]
         [Fact(Skip = "We don't need to test this")]
         public void ShouldGetTheSameHeadersAsTheServer()
         {
@@ -224,7 +224,7 @@ namespace PlaywrightSharp.Tests
             Assert.False(requests["style.css"].IsNavigationRequest);
         }
 
-        [PlaywrightTest("page-network-request.spec.ts", "Request.isNavigationRequest", "should return navigation bit when navigating to image")]
+        [PlaywrightTest("page-network-request.spec.ts", "should return navigation bit when navigating to image")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldReturnNavigationBitWhenNavigatingToImage()
         {

--- a/src/PlaywrightSharp.Tests/PageScreenshotTests.cs
+++ b/src/PlaywrightSharp.Tests/PageScreenshotTests.cs
@@ -22,7 +22,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWork()
         {
@@ -36,7 +36,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should clip rect")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should clip rect")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldClipRect()
         {
@@ -58,7 +58,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-rect.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should clip rect with fullPage")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should clip rect with fullPage")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldClipRectWithFullPage()
         {
@@ -77,7 +77,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-rect.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should clip elements to the viewport")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should clip elements to the viewport")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldClipElementsToTheViewport()
         {
@@ -94,7 +94,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-offscreen-clip.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should throw on clip outside the viewport")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should throw on clip outside the viewport")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldThrowOnClipOutsideTheViewport()
         {
@@ -112,7 +112,7 @@ namespace PlaywrightSharp.Tests
             Assert.Contains("Clipped area is either empty or outside the resulting image", exception.Message);
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should run in parallel")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should run in parallel")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldRunInParallel()
         {
@@ -140,7 +140,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("grid-cell-1.png", tasks[0].Result));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should take fullPage screenshots")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should take fullPage screenshots")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldTakeFullPageScreenshots()
         {
@@ -154,7 +154,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-grid-fullpage.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should restore viewport after fullPage screenshot")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should restore viewport after fullPage screenshot")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldRestoreViewportAfterFullPageScreenshot()
         {
@@ -170,7 +170,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal(500, Page.ViewportSize.Height);
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should run in parallel in multiple pages")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should run in parallel in multiple pages")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldRunInParallelInMultiplePages()
         {
@@ -219,7 +219,7 @@ namespace PlaywrightSharp.Tests
             await TaskUtils.WhenAll(closeTasks);
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should allow transparency")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should allow transparency")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldAllowTransparency()
         {
@@ -234,7 +234,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("transparent.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should render white background on jpeg file")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should render white background on jpeg file")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldRenderWhiteBackgroundOnJpegFile()
         {
@@ -246,7 +246,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("white.jpg", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with odd clip size on Retina displays")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with odd clip size on Retina displays")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWithOddClipSizeOnRetinaDisplays()
         {
@@ -262,7 +262,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-clip-odd-size.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with a mobile viewport")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with a mobile viewport")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWorkWithAMobileViewport()
         {
@@ -282,7 +282,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-mobile.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with a mobile viewport and clip")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with a mobile viewport and clip")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWorkWithAMobileViewportAndClip()
         {
@@ -309,7 +309,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-mobile-clip.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with a mobile viewport and fullPage")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with a mobile viewport and fullPage")]
         [SkipBrowserAndPlatformFact(skipFirefox: true)]
         public async Task ShouldWorkWithAMobileViewportAndFullPage()
         {
@@ -329,7 +329,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-mobile-fullpage.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work for canvas")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work for canvas")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkForCanvas()
         {
@@ -344,7 +344,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-canvas.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work for webgl")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work for webgl")]
         [SkipBrowserAndPlatformFact(skipFirefox: true, skipWebkit: true)]
         public async Task ShouldWorkForWebgl()
         {
@@ -359,7 +359,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-webgl.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work for translateZ")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work for translateZ")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkForTranslateZ()
         {
@@ -374,7 +374,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-translateZ.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work while navigating")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work while navigating")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWhileNavigating()
         {
@@ -397,7 +397,7 @@ namespace PlaywrightSharp.Tests
             }
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with device scale factor")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with device scale factor")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWithDeviceScaleFactor()
         {
@@ -417,7 +417,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-device-scale-factor.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "should work with iframe in shadow")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "should work with iframe in shadow")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldWorkWithiFrameInShadow()
         {
@@ -436,7 +436,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-iframe.png", screenshot));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "path option should work")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "path option should work")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PathOptionShouldWork()
         {
@@ -449,7 +449,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", outputPath));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "path option should create subdirectories")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "path option should create subdirectories")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PathOptionShouldCreateSubdirectories()
         {
@@ -462,7 +462,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("screenshot-sanity.png", outputPath));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "path option should detect joeg")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "path option should detect joeg")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PathOptionShouldDetectJpeg()
         {
@@ -475,7 +475,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(ScreenshotHelper.PixelMatch("white.jpg", outputPath));
         }
 
-        [PlaywrightTest("page-screenshot.spec.ts", "path option should throw for unsupported mime type")]
+        [PlaywrightTest("page-screenshot.spec.ts", "page screenshot", "path option should throw for unsupported mime type")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task PathOptionShouldThrowForUnsupportedMimeType()
         {

--- a/src/PlaywrightSharp.Tests/PermissionsTests.cs
+++ b/src/PlaywrightSharp.Tests/PermissionsTests.cs
@@ -16,7 +16,7 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should be prompt by default")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should be prompt by default")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldBePromptByDefault()
         {
@@ -24,7 +24,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("prompt", await GetPermissionAsync(Page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should deny permission when not listed")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should deny permission when not listed")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldDenyPermissionWhenNotListed()
         {
@@ -33,11 +33,11 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("denied", await GetPermissionAsync(Page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should fail when bad permission is given")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should fail when bad permission is given")]
         [Fact(Skip = "We don't need this test")]
         public void ShouldFailWhenBadPermissionIsGiven() { }
 
-        [PlaywrightTest("permissions.spec.ts", "should grant geolocation permission when listed")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should grant geolocation permission when listed")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldGrantGeolocationPermissionWhenListed()
         {
@@ -46,7 +46,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(Page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should grant notifications permission when listed")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should grant notifications permission when listed")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldGrantNotificationsPermissionWhenListed()
         {
@@ -55,7 +55,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(Page, "notifications"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should accumulate when adding")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should accumulate when adding")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldAccumulateWhenAdding()
         {
@@ -66,7 +66,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(Page, "notifications"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should clear permissions")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should clear permissions")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldClearPermissions()
         {
@@ -80,7 +80,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(Page, "notifications"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should grant permission when listed for all domains")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should grant permission when listed for all domains")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldGrantPermissionWhenListedForAllDomains()
         {
@@ -89,7 +89,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(Page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should grant permission when creating context")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should grant permission when creating context")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldGrantPermissionWhenCreatingContext()
         {
@@ -103,7 +103,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("granted", await GetPermissionAsync(page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should reset permissions")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should reset permissions")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldResetPermissions()
         {
@@ -114,7 +114,7 @@ namespace PlaywrightSharp.Tests
             Assert.Equal("prompt", await GetPermissionAsync(Page, "geolocation"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should trigger permission onchange")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should trigger permission onchange")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldTriggerPermissionOnchange()
         {
@@ -141,7 +141,7 @@ namespace PlaywrightSharp.Tests
                 await Page.EvaluateAsync<string[]>("window.events"));
         }
 
-        [PlaywrightTest("permissions.spec.ts", "should trigger permission onchange")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should isolate permissions between browser contexts")]
         [SkipBrowserAndPlatformFact(skipWebkit: true)]
         public async Task ShouldIsolatePermissionsBetweenBrowserContexts()
         {
@@ -165,7 +165,7 @@ namespace PlaywrightSharp.Tests
         }
 
 
-        [PlaywrightTest("permissions.spec.ts", "should support clipboard read")]
+        [PlaywrightTest("permissions.spec.ts", "permissions", "should support clipboard read")]
         [Fact(Skip = "Skipped in Playwright")]
         public void ShouldSupportClipboardRead()
         {

--- a/src/PlaywrightSharp.Tests/ScreencastTests.cs
+++ b/src/PlaywrightSharp.Tests/ScreencastTests.cs
@@ -20,25 +20,25 @@ namespace PlaywrightSharp.Tests
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "videoSize should require videosPath")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "videoSize should require videosPath")]
         [Fact(Skip = "We are not using old properties")]
         public void VideoSizeShouldRequireVideosPath()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should work with old options")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should work with old options")]
         [Fact(Skip = "We are not using old properties")]
         public void ShouldWorkWithOldOptions()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should throw without recordVideo.dir")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should throw without recordVideo.dir")]
         [Fact(Skip = "We don't need to test this")]
         public void ShouldThrowWithoutRecordVideoDir()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should capture static page")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should capture static page")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipWindows: true)]
         public async Task ShouldCaptureStaticPage()
         {
@@ -58,7 +58,7 @@ namespace PlaywrightSharp.Tests
             Assert.NotEmpty(new DirectoryInfo(tempDirectory.Path).GetFiles("*.webm"));
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should expose video path")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should expose video path")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldExposeVideoPath()
         {
@@ -79,7 +79,7 @@ namespace PlaywrightSharp.Tests
             Assert.True(new FileInfo(path).Exists);
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should expose video path blank page")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should expose video path blank page")]
         [Fact(Timeout = TestConstants.DefaultTestTimeout)]
         public async Task ShouldExposeVideoPathBlankPage()
         {
@@ -99,49 +99,49 @@ namespace PlaywrightSharp.Tests
             Assert.True(new FileInfo(path).Exists);
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should expose video path blank popup")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should expose video path blank popup")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldExposeVideoPathBlankPopup()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should capture navigation")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should capture navigation")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldCaptureNavigation()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should capture css transformation")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should capture css transformation")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldCaptureCssTransformation()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should work for popups")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should work for popups")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldWorkForPopups()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should scale frames down to the requested size")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should scale frames down to the requested size")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldScaleFramesDownToTheRequestedSize()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should use viewport as default size")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should use viewport as default size")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldUseViewportAsDefaultSize()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should be 1280x720 by default")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should be 1280x720 by default")]
         [Fact(Skip = "We don't need to test video details")]
         public void ShouldBe1280x720ByDefault()
         {
         }
 
-        [PlaywrightTest("screencast.spec.ts", "should capture static page in persistent context")]
+        [PlaywrightTest("screencast.spec.ts", "screencast", "should capture static page in persistent context")]
         [SkipBrowserAndPlatformFact(skipWebkit: true, skipFirefox: true)]
         public async Task ShouldCaptureStaticPageInPersistentContext()
         {

--- a/src/tests/PlaywrightSharp.Xunit/PlaywrightTestAttribute.cs
+++ b/src/tests/PlaywrightSharp.Xunit/PlaywrightTestAttribute.cs
@@ -49,5 +49,17 @@ namespace PlaywrightSharp.Xunit
         /// The describe of the test, the decorated code is based on, if one exists.
         /// </summary>
         public string Describe { get; }
+
+        public override string ToString()
+        {
+            if (Describe == null)
+            {
+                return $"{FileName}: {TestName}";
+            }
+            else
+            {
+                return $"{FileName}: {Describe}: {TestName}";
+            }
+        }
     }
 }

--- a/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
+++ b/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
@@ -134,7 +134,7 @@ namespace PlaywrightSharp.Tooling
             {
                 ScaffoldTest.FindTestsInFile(
                     fileInfo.FullName,
-                    (testName) =>
+                    (testDescribe, testName) =>
                     {
                         _testPairs.Add(new(basePath + fileInfo.Name.Substring(0, fileInfo.Name.IndexOf('.')), testName));
                     });

--- a/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
+++ b/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
@@ -67,25 +67,26 @@ namespace PlaywrightSharp.Tooling
 
             List<PlaywrightTestAttribute> missingTests = new();
             List<KeyValuePair<PlaywrightTestAttribute, List<PlaywrightTestAttribute>>> invalidMaps = new();
-            foreach (var atx in attributes)
+            foreach (var x in _testPairs)
             {
                 totalTests++;
 
                 // a test can either be a full match, a partial (i.e. just the test name) or no match
-                var potentialMatch = _testPairs.Where(x => string.Equals(x.TestName, atx.TestName, StringComparison.InvariantCultureIgnoreCase));
+                var potentialMatch = attributes.Where(atx => string.Equals(x.TestName, atx.TestName, StringComparison.InvariantCultureIgnoreCase))
+                                               .Where(atx => string.Equals(x.Describe, atx.Describe, StringComparison.InvariantCultureIgnoreCase));
                 if (!potentialMatch.Any())
                 {
                     noMatches++;
-                    missingTests.Add(atx);
+                    missingTests.Add(x);
                 }
-                else if (potentialMatch.Any(x => string.Equals(x.TrimmedName, atx.TrimmedName, StringComparison.InvariantCultureIgnoreCase)))
+                else if (potentialMatch.Any(atx => string.Equals(x.TrimmedName, atx.TrimmedName, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     fullMatches++;
                     continue;
                 }
                 else
                 {
-                    invalidMaps.Add(new KeyValuePair<PlaywrightTestAttribute, List<PlaywrightTestAttribute>>(atx, potentialMatch.ToList()));
+                    invalidMaps.Add(new KeyValuePair<PlaywrightTestAttribute, List<PlaywrightTestAttribute>>(x, potentialMatch.ToList()));
                     potentialMatches++;
                 }
             }

--- a/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
+++ b/src/tools/PlaywrightSharp.Tooling/IdentifyMissingTests.cs
@@ -36,7 +36,7 @@ namespace PlaywrightSharp.Tooling
     /// </summary>
     internal static class IdentifyMissingTests
     {
-        private static readonly List<(string FileName, string TestName)> _testPairs = new();
+        private static readonly List<PlaywrightTestAttribute> _testPairs = new();
 
         /// <summary>
         /// Runs the scenario.
@@ -65,8 +65,8 @@ namespace PlaywrightSharp.Tooling
             int noMatches = 0;
             int totalTests = 0;
 
-            List<(string FileName, string TestName)> missingTests = new();
-            List<KeyValuePair<(string FileName, string TestName), List<(string FileName, string TestName)>>> invalidMaps = new();
+            List<PlaywrightTestAttribute> missingTests = new();
+            List<KeyValuePair<PlaywrightTestAttribute, List<PlaywrightTestAttribute>>> invalidMaps = new();
             foreach (var atx in attributes)
             {
                 totalTests++;
@@ -76,16 +76,16 @@ namespace PlaywrightSharp.Tooling
                 if (!potentialMatch.Any())
                 {
                     noMatches++;
-                    missingTests.Add((atx.FileName, atx.TestName));
+                    missingTests.Add(atx);
                 }
-                else if (potentialMatch.Any(x => string.Equals(x.FileName, atx.TrimmedName, StringComparison.InvariantCultureIgnoreCase)))
+                else if (potentialMatch.Any(x => string.Equals(x.TrimmedName, atx.TrimmedName, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     fullMatches++;
                     continue;
                 }
                 else
                 {
-                    invalidMaps.Add(new KeyValuePair<(string, string), List<(string, string)>>((atx.TrimmedName, atx.TestName), potentialMatch.ToList()));
+                    invalidMaps.Add(new KeyValuePair<PlaywrightTestAttribute, List<PlaywrightTestAttribute>>(atx, potentialMatch.ToList()));
                     potentialMatches++;
                 }
             }
@@ -100,10 +100,10 @@ namespace PlaywrightSharp.Tooling
 
             foreach (var invalidTest in invalidMaps)
             {
-                Console.WriteLine($"{invalidTest.Key.FileName}: {invalidTest.Key.TestName}");
-                foreach (var (fileName, testName) in invalidTest.Value)
+                Console.WriteLine($"{invalidTest.Key}");
+                foreach (var value in invalidTest.Value)
                 {
-                    Console.WriteLine($"\t{fileName}: {testName}");
+                    Console.WriteLine($"\t{value}");
                 }
             }
 
@@ -113,7 +113,7 @@ namespace PlaywrightSharp.Tooling
 
             foreach (var invalidTest in missingTests)
             {
-                Console.WriteLine($"{invalidTest.FileName}: {invalidTest.TestName}");
+                Console.WriteLine($"{invalidTest}");
             }
 
             Console.WriteLine($"Found/Mismatched/Missing: {fullMatches}/{potentialMatches}/{noMatches} out of {totalTests}");
@@ -136,7 +136,7 @@ namespace PlaywrightSharp.Tooling
                     fileInfo.FullName,
                     (testDescribe, testName) =>
                     {
-                        _testPairs.Add(new(basePath + fileInfo.Name.Substring(0, fileInfo.Name.IndexOf('.')), testName));
+                        _testPairs.Add(new PlaywrightTestAttribute(basePath + fileInfo.Name, testDescribe, testName));
                     });
             }
         }


### PR DESCRIPTION
Initial:
* `FindTestsInFile` parses `it` but not `describe`
* * common names such as `should work` get mingled
* `IdentifyMissingTests` enumerates existing `PlaywrightTest` attributes, then compares them with upstream tests
* * finds `PlaywrightTest` attributes without corresponding upstream test
* * does not find upstream tests without corresponding `PlaywrightTest` attribute
* `Found/Mismatched/Missing: 703/565/56 out of 1324`

Fixed `missing-tests` tool:
* `FindTestsInFile` parses both `it` and `describe` (and associates `it` with the innermost surrounding `describe`)
* `IdentifyMissingTests` enumerates upstream tests, then compares them with existing `PlaywrightTest` attributes
* * finds upstream tests without corresponding `PlaywrightTest` attribute
* `Found/Mismatched/Missing: 578/572/645 out of 1795`
* Commits originally made in https://github.com/hardkoded/puppeteer-sharp/pull/1663

Fixed `PlaywrightTest` attributes:
* `Found/Mismatched/Missing: 703/583/509 out of 1795`