### PR TITLE
chore(roll): update assembly version to next

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.13.1</AssemblyVersion>
+    <AssemblyVersion>1.14.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)-next-1</PackageVersion>
     <DriverVersion>1.13.0-1626733671000</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.13.0</AssemblyVersion>
-    <PackageVersion>$(AssemblyVersion)-next-2</PackageVersion>
+    <AssemblyVersion>1.13.1</AssemblyVersion>
+    <PackageVersion>$(AssemblyVersion)-next-1</PackageVersion>
     <DriverVersion>1.13.0-1626733671000</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>


### PR DESCRIPTION
Moving the assembly version to `1.14` after 1.13 release.