### PR TITLE
chore: fix .NET SDK warning

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -44,7 +44,7 @@ stages:
       displayName: Download the browsers
       inputs:
         command: 'run'
-        arguments: '-p $(Build.SourcesDirectory)/src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath $(Build.SourcesDirectory)'
+        arguments: '--project $(Build.SourcesDirectory)/src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath $(Build.SourcesDirectory)'
 
     - task: DotNetCoreCLI@2
       displayName: Build Playwright CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Installing Browsers and dependencies...
         shell: pwsh
         run: |
-          dotnet run -p .\src\Playwright\Playwright.csproj -f net5.0 -- install
-          dotnet run -p .\src\Playwright\Playwright.csproj -f net5.0 -- install-deps
+          dotnet run --project .\src\Playwright\Playwright.csproj -f net5.0 -- install
+          dotnet run --project .\src\Playwright\Playwright.csproj -f net5.0 -- install-deps
       - name: Running tests...
         if: ${{ matrix.os != 'ubuntu-latest' }}
         shell: pwsh
@@ -86,8 +86,8 @@ jobs:
       - name: Installing Browsers and dependencies...
         shell: pwsh
         run: |
-          dotnet run -p .\src\Playwright\Playwright.csproj -f net5.0 -- install
-          dotnet run -p .\src\Playwright\Playwright.csproj -f net5.0 -- install-deps
+          dotnet run --project .\src\Playwright\Playwright.csproj -f net5.0 -- install
+          dotnet run --project .\src\Playwright\Playwright.csproj -f net5.0 -- install-deps
       - name: Running tests... 
         shell: bash
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ This will run the following commands:
 ```ps
 git submodule update --init
 dotnet tool install --global dotnet-format
-dotnet run -p ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
+dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
 ```
 
 #### Dotnet Format
@@ -141,5 +141,5 @@ cd playwright
 git checkout commitsha
 cd ..
 node "playwright/utils/doclint/generateDotnetApi.js" "src/Playwright"
-dotnet run -p ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
+dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
 ```

--- a/build.ps1
+++ b/build.ps1
@@ -51,7 +51,7 @@ function Invoke-DownloadDriver() {
   Invoke-InitializeSubmodule $false
   if ($prereqs) { Invoke-InstallRequirements }
   Write-Host "🚀 Downloading drivers..." -NoNewline
-  dotnet run -p ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
+  dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .
 }
 
 function Invoke-Roll() {

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -75,6 +75,6 @@
     </PackageReference>
   </ItemGroup>
   <Target Name="EnsurePrerequisitsRan" BeforeTargets="DedupeDriver">
-    <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run -p ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />
+    <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />
   </Target>
 </Project>


### PR DESCRIPTION
Fix NETSDK1174 warning when building with the .NET 6 SDK (specifically, `6.0.100-preview.7.21379.14`).

```sh
Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.
```
