### PR TITLE
chore: rename PlaywrightStream to Stream to ensure naming consistency

### DIFF
--- a/src/Playwright/Core/Artifact.cs
+++ b/src/Playwright/Core/Artifact.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Playwright.Core
 
         public Task SaveAsAsync(string path) => _channel.SaveAsAsync(path);
 
-        public async Task<Stream> CreateReadStreamAsync()
+        public async Task<System.IO.Stream> CreateReadStreamAsync()
         {
             var stream = (await _channel.GetStreamAsync().ConfigureAwait(false)).Stream;
             string base64 = await stream.ReadAsync().ConfigureAwait(false);

--- a/src/Playwright/Core/Download.cs
+++ b/src/Playwright/Core/Download.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Playwright.Core
 
         public Task SaveAsAsync(string path) => _artifact.SaveAsAsync(path);
 
-        public Task<Stream> CreateReadStreamAsync() => _artifact.CreateReadStreamAsync();
+        public Task<System.IO.Stream> CreateReadStreamAsync() => _artifact.CreateReadStreamAsync();
 
         public Task CancelAsync() => _artifact.CancelAsync();
     }

--- a/src/Playwright/Core/Stream.cs
+++ b/src/Playwright/Core/Stream.cs
@@ -27,18 +27,17 @@ using Microsoft.Playwright.Transport.Channels;
 
 namespace Microsoft.Playwright.Core
 {
-    // Using this name to avoid collitions with System.IO.Stream.
-    internal class PlaywrightStream : ChannelOwnerBase, IChannelOwner<PlaywrightStream>
+    internal class Stream : ChannelOwnerBase, IChannelOwner<Stream>
     {
         private readonly StreamChannel _channel;
 
-        internal PlaywrightStream(IChannelOwner parent, string guid) : base(parent, guid)
+        internal Stream(IChannelOwner parent, string guid) : base(parent, guid)
         {
             _channel = new(guid, parent.Connection, this);
         }
 
         ChannelBase IChannelOwner.Channel => _channel;
 
-        IChannel<PlaywrightStream> IChannelOwner<PlaywrightStream>.Channel => _channel;
+        IChannel<Stream> IChannelOwner<Stream>.Channel => _channel;
     }
 }

--- a/src/Playwright/Transport/Channels/StreamChannel.cs
+++ b/src/Playwright/Transport/Channels/StreamChannel.cs
@@ -28,9 +28,9 @@ using Microsoft.Playwright.Core;
 
 namespace Microsoft.Playwright.Transport.Channels
 {
-    internal class StreamChannel : Channel<PlaywrightStream>
+    internal class StreamChannel : Channel<Stream>
     {
-        public StreamChannel(string guid, Connection connection, PlaywrightStream owner) : base(guid, connection, owner)
+        public StreamChannel(string guid, Connection connection, Stream owner) : base(guid, connection, owner)
         {
         }
 

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Playwright.Transport
                     result = new Selectors(parent, guid);
                     break;
                 case ChannelOwnerType.Stream:
-                    result = new PlaywrightStream(parent, guid);
+                    result = new Stream(parent, guid);
                     break;
                 default:
                     TraceMessage("Missing type " + type);


### PR DESCRIPTION
This brings the naming inline with `protocol.yml` and the channels and their base objects are now consistent. This will make it easier to generate.