### PR TITLE
fix: improve flakiness due to TLS versions

### DIFF
--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -182,14 +182,7 @@ namespace Microsoft.Playwright.Tests
             else
             {
                 Assert.AreEqual(name, details.Issuer);
-                if (TestConstants.IsLinux)
-                {
-                    Assert.AreEqual("TLS 1.3", details.Protocol);
-                }
-                else
-                {
-                    Assert.AreEqual("TLS 1.2", details.Protocol);
-                }
+                StringAssert.Contains("TLS 1.", details.Protocol);
             }
         }
 


### PR DESCRIPTION
TLS version mismatch on platforms is causing the test to be flaky yet the assertion provides no extra value