### PR TITLE
chore: remove redundant attributes

### DIFF
--- a/src/Playwright.Tests/BeforeUnloadTests.cs
+++ b/src/Playwright.Tests/BeforeUnloadTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BeforeUnloadTests : PageTestEx
     {
         [PlaywrightTest("beforeunload.spec.ts", "should run beforeunload if asked for")]

--- a/src/Playwright.Tests/BrowserContextAddCookiesTests.cs
+++ b/src/Playwright.Tests/BrowserContextAddCookiesTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextAddCookiesTests : PageTestEx
     {
         [PlaywrightTest("browsercontext-add-cookies.spec.ts", "should work")]

--- a/src/Playwright.Tests/BrowserContextBaseUrlTests.cs
+++ b/src/Playwright.Tests/BrowserContextBaseUrlTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextBaseUrlTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-base-url.spec.ts", "should construct a new URL when a baseURL in browser.newContext is passed to page.goto")]

--- a/src/Playwright.Tests/BrowserContextBasicTests.cs
+++ b/src/Playwright.Tests/BrowserContextBasicTests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextBasicTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-basic.spec.ts", "should create new context")]

--- a/src/Playwright.Tests/BrowserContextCSPTests.cs
+++ b/src/Playwright.Tests/BrowserContextCSPTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextCSPTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-csp.spec.ts", "should bypass CSP meta tag")]

--- a/src/Playwright.Tests/BrowserContextClearCookiesTests.cs
+++ b/src/Playwright.Tests/BrowserContextClearCookiesTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextClearCookiesTests : PageTestEx
     {
         [PlaywrightTest("browsercontext-clearcookies.spec.ts", "should clear cookies")]

--- a/src/Playwright.Tests/BrowserContextCookiesTests.cs
+++ b/src/Playwright.Tests/BrowserContextCookiesTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextCookiesTests : PageTestEx
     {
         [PlaywrightTest("browsercontext-cookies.spec.ts", "should return no cookies in pristine browser context")]

--- a/src/Playwright.Tests/BrowserContextDeviceTests.cs
+++ b/src/Playwright.Tests/BrowserContextDeviceTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextDeviceTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-device.spec.ts", "should work")]

--- a/src/Playwright.Tests/BrowserContextExposeFunctionTests.cs
+++ b/src/Playwright.Tests/BrowserContextExposeFunctionTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextExposeFunctionTests : ContextTestEx
     {
         [PlaywrightTest("browsercontext-expose-function.spec.ts", "expose binding should work")]

--- a/src/Playwright.Tests/BrowserContextHttpCredentialsTests.cs
+++ b/src/Playwright.Tests/BrowserContextHttpCredentialsTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextCredentialsTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-credentials.spec.ts", "should fail without credentials")]

--- a/src/Playwright.Tests/BrowserContextLocaleTests.cs
+++ b/src/Playwright.Tests/BrowserContextLocaleTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextLocaleTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-locale.spec.ts", "should affect accept-language header")]

--- a/src/Playwright.Tests/BrowserContextNetworkEventTests.cs
+++ b/src/Playwright.Tests/BrowserContextNetworkEventTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextNetworkEventTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-network-event.spec.ts", "BrowserContext.Events.Request")]

--- a/src/Playwright.Tests/BrowserContextPageEventTests.cs
+++ b/src/Playwright.Tests/BrowserContextPageEventTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextPageEventTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-page-event.spec.ts", "should have url")]

--- a/src/Playwright.Tests/BrowserContextRouteTests.cs
+++ b/src/Playwright.Tests/BrowserContextRouteTests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextRouteTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-route.spec.ts", "should intercept")]

--- a/src/Playwright.Tests/BrowserContextStrictSelectorsTests.cs
+++ b/src/Playwright.Tests/BrowserContextStrictSelectorsTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextStrictSelectorsTests : BrowserTestEx
     {
         [PlaywrightTest()]

--- a/src/Playwright.Tests/BrowserContextTimezoneIdTests.cs
+++ b/src/Playwright.Tests/BrowserContextTimezoneIdTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextTimezoneIdTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-timezone-id.spec.ts", "should work")]

--- a/src/Playwright.Tests/BrowserContextUserAgentTests.cs
+++ b/src/Playwright.Tests/BrowserContextUserAgentTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextUserAgentTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-user-agent.spec.ts", "should work")]

--- a/src/Playwright.Tests/BrowserContextViewportMobileTests.cs
+++ b/src/Playwright.Tests/BrowserContextViewportMobileTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextViewportMobileTests : BrowserTestEx
     {
         [PlaywrightTest("browsercontext-viewport-mobile.spec.ts", "should support mobile emulation")]

--- a/src/Playwright.Tests/BrowserContextViewportTests.cs
+++ b/src/Playwright.Tests/BrowserContextViewportTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserContextViewportTests : PageTestEx
     {
         [PlaywrightTest("browsercontext-viewport.spec.ts", "should get the proper default viewport size")]

--- a/src/Playwright.Tests/BrowserTests.cs
+++ b/src/Playwright.Tests/BrowserTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>browser.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserTests : BrowserTestEx
     {
         [PlaywrightTest("browser.spec.ts", "should create new page")]

--- a/src/Playwright.Tests/BrowserTypeBasicTests.cs
+++ b/src/Playwright.Tests/BrowserTypeBasicTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserTypeBasicTests : PlaywrightTestEx
     {
         [PlaywrightTest("browsertype-basic.spec.ts", "browserType.executablePath should work")]

--- a/src/Playwright.Tests/BrowserTypeConnectTests.cs
+++ b/src/Playwright.Tests/BrowserTypeConnectTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>browsertype-connect.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserTypeConnectTests : PlaywrightTestEx
     {
         private BrowserServer _browserServer;

--- a/src/Playwright.Tests/BrowserTypeLaunchTests.cs
+++ b/src/Playwright.Tests/BrowserTypeLaunchTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>browsertype-launch.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class BrowserTypeLaunchTests : PlaywrightTestEx
     {
         [PlaywrightTest("browsertype-launch.spec.ts", "should reject all promises when browser is closed")]

--- a/src/Playwright.Tests/CapabilitiesTests.cs
+++ b/src/Playwright.Tests/CapabilitiesTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>capabilities.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class CapabilitiesTests : PageTestEx
     {
         [PlaywrightTest("capabilities.spec.ts", "Web Assembly should work")]

--- a/src/Playwright.Tests/ChromiumCSSCoverageTests.cs
+++ b/src/Playwright.Tests/ChromiumCSSCoverageTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ChromiumCSSCoverageTests : PageTestEx
     {
         [PlaywrightTest("chromium-css-coverage.spec.ts", "CSS Coverage", "should work")]

--- a/src/Playwright.Tests/ChromiumJSCoverageTests.cs
+++ b/src/Playwright.Tests/ChromiumJSCoverageTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ChromiumJSCoverageTests : PageTestEx
     {
         [PlaywrightTest("chromium-js-coverage.spec.ts", "JS Coverage", "should work")]

--- a/src/Playwright.Tests/DefaultBrowserContext1Tests.cs
+++ b/src/Playwright.Tests/DefaultBrowserContext1Tests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class DefaultBrowserContext1Tests : PlaywrightTestEx
     {
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "context.cookies() should work")]

--- a/src/Playwright.Tests/DefaultBrowsercontext2Tests.cs
+++ b/src/Playwright.Tests/DefaultBrowsercontext2Tests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     /// <playwright-file>defaultbrowsercontext-2.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class DefaultBrowsercontext2Tests : PlaywrightTestEx
     {
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support hasTouch option")]

--- a/src/Playwright.Tests/DownloadTests.cs
+++ b/src/Playwright.Tests/DownloadTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>download.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class DownloadTests : PageTestEx
     {
         [SetUp]

--- a/src/Playwright.Tests/DownloadsPathTests.cs
+++ b/src/Playwright.Tests/DownloadsPathTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class DownloadsPathTests : PlaywrightTestEx
     {
         private IBrowser _browser { get; set; }

--- a/src/Playwright.Tests/ElementHandleBoundingBoxTests.cs
+++ b/src/Playwright.Tests/ElementHandleBoundingBoxTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleBoundingBoxTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-bounding-box.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleClickTests.cs
+++ b/src/Playwright.Tests/ElementHandleClickTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleClickTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-click.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleContentFrameTests.cs
+++ b/src/Playwright.Tests/ElementHandleContentFrameTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleContentFrameTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-content-frame.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleConvenienceTests.cs
+++ b/src/Playwright.Tests/ElementHandleConvenienceTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>elementhandle-convenience.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleConvenienceTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-convenience.spec.ts", "should have a nice preview")]

--- a/src/Playwright.Tests/ElementHandleEvalOnSelectorTests.cs
+++ b/src/Playwright.Tests/ElementHandleEvalOnSelectorTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleEvalOnSelectorTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-eval-on-selector.spec.ts", "should work for all")]

--- a/src/Playwright.Tests/ElementHandleMiscTests.cs
+++ b/src/Playwright.Tests/ElementHandleMiscTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleMiscTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-misc.spec.ts", "should hover")]

--- a/src/Playwright.Tests/ElementHandleOwnerFrameTests.cs
+++ b/src/Playwright.Tests/ElementHandleOwnerFrameTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleOwnerFrameTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-owner-frame.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleQuerySelectorTests.cs
+++ b/src/Playwright.Tests/ElementHandleQuerySelectorTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleQuerySelectorTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-query-selector.spec.ts", "should query existing element")]

--- a/src/Playwright.Tests/ElementHandleScreenshotTests.cs
+++ b/src/Playwright.Tests/ElementHandleScreenshotTests.cs
@@ -33,7 +33,6 @@ using SixLabors.ImageSharp;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>elementhandle-screenshot.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleScreenshotTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-screenshot.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleScrollIntoViewTests.cs
+++ b/src/Playwright.Tests/ElementHandleScrollIntoViewTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleScrollIntoViewTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-scroll-into-view.spec.ts", "should work")]

--- a/src/Playwright.Tests/ElementHandleSelectTextTests.cs
+++ b/src/Playwright.Tests/ElementHandleSelectTextTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleSelectTextTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-select-text.spec.ts", "should select textarea")]

--- a/src/Playwright.Tests/ElementHandleWaitForElementStateTests.cs
+++ b/src/Playwright.Tests/ElementHandleWaitForElementStateTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>elementhandle-wait-for-element-state.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class ElementHandleWaitForElementStateTests : PageTestEx
     {
         [PlaywrightTest("elementhandle-wait-for-element-state.spec.ts", "should wait for visible")]

--- a/src/Playwright.Tests/EmulationFocusTests.cs
+++ b/src/Playwright.Tests/EmulationFocusTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class EmulationFocusTests : PageTestEx
     {
         [PlaywrightTest("emulation-focus.spec.ts", "should think that it is focused by default")]

--- a/src/Playwright.Tests/EvalOnSelectorAllTests.cs
+++ b/src/Playwright.Tests/EvalOnSelectorAllTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class EvalOnSelectorAllTests : PageTestEx
     {
         [PlaywrightTest("eval-on-selector-all.spec.ts", "should work with css selector")]

--- a/src/Playwright.Tests/EvalOnSelectorTests.cs
+++ b/src/Playwright.Tests/EvalOnSelectorTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class EvalOnSelectorTests : PageTestEx
     {
         [PlaywrightTest("eval-on-selector.spec.ts", "should work with css selector")]

--- a/src/Playwright.Tests/FirefoxLauncherTests.cs
+++ b/src/Playwright.Tests/FirefoxLauncherTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Playwright.Tests.Firefox
 {
     ///<playwright-file>firefox/launcher.spec.ts</playwright-file>
     ///<playwright-describe>launcher</playwright-describe>
-    [Parallelizable(ParallelScope.Self)]
     public class FirefoxLauncherTests : PlaywrightTestEx
     {
         [PlaywrightTest("firefox/launcher.spec.ts", "should pass firefox user preferences")]

--- a/src/Playwright.Tests/FixturesTests.cs
+++ b/src/Playwright.Tests/FixturesTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>fixtures.spec.ts</playwright-file>
     ///<playwright-describe>Fixtures</playwright-describe>
-    [Parallelizable(ParallelScope.Self)]
     public class FixturesTests : PlaywrightTestEx
     {
         [PlaywrightTest("fixtures.spec.ts", "should close the browser when the node process closes")]

--- a/src/Playwright.Tests/FrameEvaluateTests.cs
+++ b/src/Playwright.Tests/FrameEvaluateTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class FrameEvaluateTests : PageTestEx
     {
         [PlaywrightTest("frame-evaluate.spec.ts", "should have different execution contexts")]

--- a/src/Playwright.Tests/FrameFrameElementTests.cs
+++ b/src/Playwright.Tests/FrameFrameElementTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class FrameFrameElementTests : PageTestEx
     {
         [PlaywrightTest("frame-frame-element.spec.ts", "should work")]

--- a/src/Playwright.Tests/FrameGoToTests.cs
+++ b/src/Playwright.Tests/FrameGoToTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class FrameGoToTests : PageTestEx
     {
         [PlaywrightTest("frame-goto.spec.ts", "should navigate subframes")]

--- a/src/Playwright.Tests/FrameHierarchyTests.cs
+++ b/src/Playwright.Tests/FrameHierarchyTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class FrameHierarchyTests : PageTestEx
     {
         [PlaywrightTest("frame-hierarchy.spec.ts", "should handle nested frames")]

--- a/src/Playwright.Tests/GeolocationTests.cs
+++ b/src/Playwright.Tests/GeolocationTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class GeolocationTests : PageTestEx
     {
         [PlaywrightTest("geolocation.spec.ts", "should work")]

--- a/src/Playwright.Tests/HeadfulTests.cs
+++ b/src/Playwright.Tests/HeadfulTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>headful.spec.ts</playwright-file>
 
-    [Parallelizable(ParallelScope.Self)]
     public class HeadfulTests : PlaywrightTestEx
     {
         [PlaywrightTest("headful.spec.ts", "should have default url when launching browser")]

--- a/src/Playwright.Tests/IgnoreHttpsErrorsTests.cs
+++ b/src/Playwright.Tests/IgnoreHttpsErrorsTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>ignorehttpserrors.spec.ts</playwright-file>
     ///<playwright-describe>ignoreHTTPSErrors</playwright-describe>
-    [Parallelizable(ParallelScope.Self)]
     public class IgnoreHttpsErrorsTests : BrowserTestEx
     {
         [PlaywrightTest("ignorehttpserrors.spec.ts", "should work")]

--- a/src/Playwright.Tests/InterceptionTests.cs
+++ b/src/Playwright.Tests/InterceptionTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class GlobTests : PageTestEx
     {
         [PlaywrightTest("interception.spec.ts", "should work with glob")]

--- a/src/Playwright.Tests/JSHandleAsElementTests.cs
+++ b/src/Playwright.Tests/JSHandleAsElementTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class JSHandleAsElementTests : PageTestEx
     {
         [PlaywrightTest("jshandle-as-element.spec.ts", "should work")]

--- a/src/Playwright.Tests/JSHandleJsonValueTests.cs
+++ b/src/Playwright.Tests/JSHandleJsonValueTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class JSHandleJsonValueTests : PageTestEx
     {
         [PlaywrightTest("jshandle-json-value.spec.ts", "should work")]

--- a/src/Playwright.Tests/JSHandlePropertiesTests.cs
+++ b/src/Playwright.Tests/JSHandlePropertiesTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class JSHandlePropertiesTests : PageTestEx
     {
         [PlaywrightTest("jshandle-properties.spec.ts", "getProperties should work")]

--- a/src/Playwright.Tests/JSHandleToStringTests.cs
+++ b/src/Playwright.Tests/JSHandleToStringTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class JSHandleToStringTests : PageTestEx
     {
         [PlaywrightTest("jshandle-to-string.spec.ts", "should work for primitives")]

--- a/src/Playwright.Tests/LauncherTests.cs
+++ b/src/Playwright.Tests/LauncherTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LauncherTests : PlaywrightTestEx
     {
         [PlaywrightTest("launcher.spec.ts", "should require top-level Errors")]

--- a/src/Playwright.Tests/Locator/LocatorClickTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorClickTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests.Locator
 {
-    [Parallelizable(ParallelScope.Self)]
 
     public class LocatorClickTests : PageTestEx
     {

--- a/src/Playwright.Tests/Locator/LocatorConvenienceTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorConvenienceTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests.Locator
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LocatorConvenienceTests : PageTestEx
     {
         [PlaywrightTest("locator-convenience.spec.ts", "should have a nice preview")]

--- a/src/Playwright.Tests/Locator/LocatorElementHandleTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorElementHandleTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests.Locator
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LocatorElementHandleTests : PageTestEx
     {
         [PlaywrightTest("locator-element-handle.spec.ts", "should query existing element")]

--- a/src/Playwright.Tests/Locator/LocatorEvaluateTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorEvaluateTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests.Locator
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LocatorEvaluateTests : PageTestEx
     {
         [PlaywrightTest("locator-element-handle.spec.ts", "should work")]

--- a/src/Playwright.Tests/Locator/LocatorMiscTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorMiscTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests.Locator
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LocatorMiscTests : PageTestEx
     {
         [PlaywrightTest("locator-misc-1.spec.ts", "should hover")]

--- a/src/Playwright.Tests/LoggerTests.cs
+++ b/src/Playwright.Tests/LoggerTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class LoggerTests : PlaywrightTestEx
     {
         [PlaywrightTest("logger.spec.ts", "should log")]

--- a/src/Playwright.Tests/PageAccessibilityTests.cs
+++ b/src/Playwright.Tests/PageAccessibilityTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAccessibilityTests : PageTestEx
     {
         [PlaywrightTest("page-accessibility.spec.ts", "should work with regular text")]

--- a/src/Playwright.Tests/PageAddInitScriptTests.cs
+++ b/src/Playwright.Tests/PageAddInitScriptTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAddInitScriptTests : PageTestEx
     {
         [PlaywrightTest("page-add-init-script.spec.ts", "should evaluate before anything else on the page")]

--- a/src/Playwright.Tests/PageAddScriptTagTests.cs
+++ b/src/Playwright.Tests/PageAddScriptTagTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAddScriptTagTests : PageTestEx
     {
         [PlaywrightTest("page-add-script-tag.spec.ts", "should throw an error if no options are provided")]

--- a/src/Playwright.Tests/PageAddStyleTagTests.cs
+++ b/src/Playwright.Tests/PageAddStyleTagTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAddStyleTagTests : PageTestEx
     {
         [PlaywrightTest("page-add-style-tag.spec.ts", "should throw an error if no options are provided")]

--- a/src/Playwright.Tests/PageAutoWaitingBasicTests.cs
+++ b/src/Playwright.Tests/PageAutoWaitingBasicTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAutoWaitingBasicTests : PageTestEx
     {
         [PlaywrightTest("page-autowaiting-basic.spec.ts", "should await navigation when clicking anchor")]

--- a/src/Playwright.Tests/PageAutoWaitingNotHangTests.cs
+++ b/src/Playwright.Tests/PageAutoWaitingNotHangTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageAutoWaitingNotHangTests : PageTestEx
     {
         [PlaywrightTest("page-autowaiting-no-hang.spec.ts", "clicking on links which do not commit navigation")]

--- a/src/Playwright.Tests/PageBasicTests.cs
+++ b/src/Playwright.Tests/PageBasicTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageBasicTests : PageTestEx
     {
         [PlaywrightTest("page-basic.spec.ts", "should reject all promises when page is closed")]

--- a/src/Playwright.Tests/PageCheckTests.cs
+++ b/src/Playwright.Tests/PageCheckTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageCheckTests : PageTestEx
     {
         [PlaywrightTest("page-check.spec.ts", "should check the box")]

--- a/src/Playwright.Tests/PageClickReactTests.cs
+++ b/src/Playwright.Tests/PageClickReactTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickReactTests : PageTestEx
     {
         [PlaywrightTest("page-click-react.spec.ts", "should retarget when element is recycled during hit testing")]

--- a/src/Playwright.Tests/PageClickTests.cs
+++ b/src/Playwright.Tests/PageClickTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickTests : PageTestEx
     {
         [PlaywrightTest("page-click.spec.ts", "should click the button")]

--- a/src/Playwright.Tests/PageClickTimeout1Tests.cs
+++ b/src/Playwright.Tests/PageClickTimeout1Tests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickTimeout1Tests : PageTestEx
     {
         [PlaywrightTest("page-click-timeout-1.spec.ts", "should avoid side effects after timeout")]

--- a/src/Playwright.Tests/PageClickTimeout2Tests.cs
+++ b/src/Playwright.Tests/PageClickTimeout2Tests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickTimeout2Tests : PageTestEx
     {
         [PlaywrightTest("page-click-timeout-2.spec.ts", "should timeout waiting for display:none to be gone")]

--- a/src/Playwright.Tests/PageClickTimeout3Tests.cs
+++ b/src/Playwright.Tests/PageClickTimeout3Tests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickTimeout3Tests : PageTestEx
     {
         [PlaywrightTest("page-click-timeout-3.spec.ts", "should fail when element jumps during hit testing")]

--- a/src/Playwright.Tests/PageClickTimeout4Tests.cs
+++ b/src/Playwright.Tests/PageClickTimeout4Tests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageClickTimeout4Tests : PageTestEx
     {
         [PlaywrightTest("page-click-timeout-4.spec.ts", "should timeout waiting for stable position")]

--- a/src/Playwright.Tests/PageCloseTests.cs
+++ b/src/Playwright.Tests/PageCloseTests.cs
@@ -26,7 +26,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageCloseTests : PageTestEx
     {
     }

--- a/src/Playwright.Tests/PageDialogTests.cs
+++ b/src/Playwright.Tests/PageDialogTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageDialogTests : PageTestEx
     {
         [PlaywrightTest("page-dialog.spec.ts", "should fire")]

--- a/src/Playwright.Tests/PageDispatchEventTests.cs
+++ b/src/Playwright.Tests/PageDispatchEventTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>dispatchevent.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageDispatchEventTests : PageTestEx
     {
         [PlaywrightTest("page-dispatchevent.spec.ts", "should dispatch click event")]

--- a/src/Playwright.Tests/PageDragTests.cs
+++ b/src/Playwright.Tests/PageDragTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageDragTests : PageTestEx
     {
         [PlaywrightTest("page-drag.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageEmulateMediaTests.cs
+++ b/src/Playwright.Tests/PageEmulateMediaTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEmulateMediaTests : PageTestEx
     {
         [PlaywrightTest("page-emulate-media.spec.ts", "should emulate scheme work")]

--- a/src/Playwright.Tests/PageEvaluateHandleTests.cs
+++ b/src/Playwright.Tests/PageEvaluateHandleTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEvaluateHandleTests : PageTestEx
     {
         [PlaywrightTest("page-evaluate-handle.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageEvaluateTests.cs
+++ b/src/Playwright.Tests/PageEvaluateTests.cs
@@ -34,7 +34,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEvaluateTests : PageTestEx
     {
         [PlaywrightTest("page-evaluate.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageEventConsoleTests.cs
+++ b/src/Playwright.Tests/PageEventConsoleTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
 
     public class PageEventConsoleTests2 : PageTestEx
     {

--- a/src/Playwright.Tests/PageEventCrashTests.cs
+++ b/src/Playwright.Tests/PageEventCrashTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEventCrashTests : PageTestEx
     {
         // We skip all browser because crash uses internals.

--- a/src/Playwright.Tests/PageEventNetworkTests.cs
+++ b/src/Playwright.Tests/PageEventNetworkTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEventNetworkTests : PageTestEx
     {
         [PlaywrightTest("page-event-network.spec.ts", "Page.Events.Request")]

--- a/src/Playwright.Tests/PageEventPageErrorTests.cs
+++ b/src/Playwright.Tests/PageEventPageErrorTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEventPageErrorTests : PageTestEx
     {
         [PlaywrightTest("page-event-pageerror.spec.ts", "should fire")]

--- a/src/Playwright.Tests/PageEventPopupTests.cs
+++ b/src/Playwright.Tests/PageEventPopupTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEventPopupTests : PageTestEx
     {
         [PlaywrightTest("page-event-popup.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageEventRequestTests.cs
+++ b/src/Playwright.Tests/PageEventRequestTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageEventRequestTests : PageTestEx
     {
         [PlaywrightTest("page-event-request.spec.ts", "should fire for navigation requests")]

--- a/src/Playwright.Tests/PageExposeFunctionTests.cs
+++ b/src/Playwright.Tests/PageExposeFunctionTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>page-expose-function.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageExposeFunctionTests : PageTestEx
     {
         [PlaywrightTest("page-expose-function.spec.ts", "exposeBinding should work")]

--- a/src/Playwright.Tests/PageFillTests.cs
+++ b/src/Playwright.Tests/PageFillTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageFillTests : PageTestEx
     {
         [PlaywrightTest("page-fill.spec.ts", "should fill textarea")]

--- a/src/Playwright.Tests/PageFocusTests.cs
+++ b/src/Playwright.Tests/PageFocusTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageFocusTests : PageTestEx
     {
         [PlaywrightTest("page-focus.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageGotoTests.cs
+++ b/src/Playwright.Tests/PageGotoTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageGotoTests : PageTestEx
     {
         [PlaywrightTest("page-goto.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageHistoryTests.cs
+++ b/src/Playwright.Tests/PageHistoryTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageHistoryTests : PageTestEx
     {
         [PlaywrightTest("page-history.spec.ts", "page.goBack should work")]

--- a/src/Playwright.Tests/PageKeyboardTests.cs
+++ b/src/Playwright.Tests/PageKeyboardTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageKeyboardTests : PageTestEx
     {
         [PlaywrightTest("page-keyboard.spec.ts", "should type into a textarea")]

--- a/src/Playwright.Tests/PageMouseTests.cs
+++ b/src/Playwright.Tests/PageMouseTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageMouseTests : PageTestEx
     {
         [PlaywrightTest("page-mouse.spec.ts", "should click the document")]

--- a/src/Playwright.Tests/PageNavigationTests.cs
+++ b/src/Playwright.Tests/PageNavigationTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageNavigationTests : PageTestEx
     {
         [PlaywrightTest("page-navigation.spec.ts", "should work with _blank target")]

--- a/src/Playwright.Tests/PageNetworkIdleTests.cs
+++ b/src/Playwright.Tests/PageNetworkIdleTests.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>page-network-idle.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageNetworkIdleTests : PageTestEx
     {
         [PlaywrightTest("page-network-idle.spec.ts", "should navigate to empty page with networkidle")]

--- a/src/Playwright.Tests/PageNetworkRequestTest.cs
+++ b/src/Playwright.Tests/PageNetworkRequestTest.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>network-request.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageNetworkRequestTest : PageTestEx
     {
         [PlaywrightTest("page-network-request.spec.ts", "should work for main frame navigation request")]

--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageNetworkResponseTests : PageTestEx
     {
         [PlaywrightTest("page-network-response.spec.ts", "should return body")]

--- a/src/Playwright.Tests/PageRequestContinueTests.cs
+++ b/src/Playwright.Tests/PageRequestContinueTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageRequestContinueTests : PageTestEx
     {
         [PlaywrightTest("page-request-continue.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageRequestFulfillTests.cs
+++ b/src/Playwright.Tests/PageRequestFulfillTests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class RequestFulfillTests : PageTestEx
     {
         [PlaywrightTest("page-request-fulfill.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -36,7 +36,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageRouteTests : PageTestEx
     {
         [PlaywrightTest("page-route.spec.ts", "should intercept")]

--- a/src/Playwright.Tests/PageScreenshotTests.cs
+++ b/src/Playwright.Tests/PageScreenshotTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>page-screenshot.spec.ts</playwright-file>
 
-    [Parallelizable(ParallelScope.Self)]
     public class PageScreenshotTests : PageTestEx
     {
         [PlaywrightTest("page-screenshot.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageScrollTests.cs
+++ b/src/Playwright.Tests/PageScrollTests.cs
@@ -26,7 +26,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageScrollTests : PageTestEx
     {
     }

--- a/src/Playwright.Tests/PageSelectOptionTests.cs
+++ b/src/Playwright.Tests/PageSelectOptionTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageSelectOptionTests : PageTestEx
     {
         [PlaywrightTest("page-select-option.spec.ts", "should select single option")]

--- a/src/Playwright.Tests/PageSetContentTests.cs
+++ b/src/Playwright.Tests/PageSetContentTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageSetContentTests : PageTestEx
     {
         const string _expectedOutput = "<html><head></head><body><div>hello</div></body></html>";

--- a/src/Playwright.Tests/PageSetExtraHttpHeadersTests.cs
+++ b/src/Playwright.Tests/PageSetExtraHttpHeadersTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageSetExtraHTTPHeadersTests : PageTestEx
     {
         [PlaywrightTest("page-set-extra-http-headers.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageSetInputFilesTests.cs
+++ b/src/Playwright.Tests/PageSetInputFilesTests.cs
@@ -34,7 +34,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>page-set-input-files.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageSetInputFilesTests : PageTestEx
     {
         [PlaywrightTest("page-set-input-files.spec.ts", "should upload the file")]

--- a/src/Playwright.Tests/PageWaitForFunctionTests.cs
+++ b/src/Playwright.Tests/PageWaitForFunctionTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForFunctionTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-function.spec.ts", "should timeout")]

--- a/src/Playwright.Tests/PageWaitForLoadStateTests.cs
+++ b/src/Playwright.Tests/PageWaitForLoadStateTests.cs
@@ -34,7 +34,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>page-wait-for-load-state.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForLoadStateTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-load-state.ts", "should pick up ongoing navigation")]

--- a/src/Playwright.Tests/PageWaitForNavigationTests.cs
+++ b/src/Playwright.Tests/PageWaitForNavigationTests.cs
@@ -33,7 +33,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForNavigationTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-navigation.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageWaitForRequestTests.cs
+++ b/src/Playwright.Tests/PageWaitForRequestTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForRequestTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-request.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageWaitForResponseTests.cs
+++ b/src/Playwright.Tests/PageWaitForResponseTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForResponseTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-response.spec.ts", "should work")]

--- a/src/Playwright.Tests/PageWaitForSelector1Tests.cs
+++ b/src/Playwright.Tests/PageWaitForSelector1Tests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForSelector1Tests : PageTestEx
     {
         private const string AddElement = "tag => document.body.appendChild(document.createElement(tag))";

--- a/src/Playwright.Tests/PageWaitForSelector2Tests.cs
+++ b/src/Playwright.Tests/PageWaitForSelector2Tests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForSelector2Tests : PageTestEx
     {
         private const string AddElement = "tag => document.body.appendChild(document.createElement(tag))";

--- a/src/Playwright.Tests/PageWaitForUrlTests.cs
+++ b/src/Playwright.Tests/PageWaitForUrlTests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PageWaitForUrlTests : PageTestEx
     {
         [PlaywrightTest("page-wait-for-url.spec.ts", "should work")]

--- a/src/Playwright.Tests/PauseTests.cs
+++ b/src/Playwright.Tests/PauseTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PauseTests : PageTestEx
     {
         [Test]

--- a/src/Playwright.Tests/PdfTests.cs
+++ b/src/Playwright.Tests/PdfTests.cs
@@ -32,7 +32,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>pdf.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class PdfTests : PageTestEx
     {
         [PlaywrightTest("pdf.spec.ts", "should be able to save file")]

--- a/src/Playwright.Tests/PermissionsTests.cs
+++ b/src/Playwright.Tests/PermissionsTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PermissionsTests : PageTestEx
     {
         [PlaywrightTest("permissions.spec.ts", "should be prompt by default")]

--- a/src/Playwright.Tests/PopupTests.cs
+++ b/src/Playwright.Tests/PopupTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class PopupTests : BrowserTestEx
     {
         [PlaywrightTest("popup.spec.ts", "should inherit user agent from browser context")]

--- a/src/Playwright.Tests/ProxyTests.cs
+++ b/src/Playwright.Tests/ProxyTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class ProxyTests : PlaywrightTestEx
     {
         [PlaywrightTest("proxy.spec.ts", "should use proxy")]

--- a/src/Playwright.Tests/QuerySelectorTests.cs
+++ b/src/Playwright.Tests/QuerySelectorTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class QuerySelectorTests : PageTestEx
     {
         [PlaywrightTest("queryselector.spec.ts", "should query existing elements")]

--- a/src/Playwright.Tests/ResourceTimingTests.cs
+++ b/src/Playwright.Tests/ResourceTimingTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>resource-timing.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class ResourceTimingTests : PageTestEx
     {
         private void VerifyConnectionTimingConsistency(RequestTimingResult timing)

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>screencast.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class ScreencastTests : BrowserTestEx
     {
         [PlaywrightTest("screencast.spec.ts", "videoSize should require videosPath")]

--- a/src/Playwright.Tests/SelectorMiscTests.cs
+++ b/src/Playwright.Tests/SelectorMiscTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class SelectorMiscTests : PageTestEx
     {
         [PlaywrightTest("selectors-misc.spec.ts", "should work for open shadow roots")]

--- a/src/Playwright.Tests/SelectorsCssTests.cs
+++ b/src/Playwright.Tests/SelectorsCssTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class SelectorsCssTests : PageTestEx
     {
         [PlaywrightTest("selectors-css.spec.ts", "should work for open shadow roots")]

--- a/src/Playwright.Tests/SelectorsRegisterTests.cs
+++ b/src/Playwright.Tests/SelectorsRegisterTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>selectors-register.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class SelectorsRegisterTests : PageTestEx
     {
         [PlaywrightTest("selectors-register.spec.ts", "should work")]

--- a/src/Playwright.Tests/SelectorsTextTests.cs
+++ b/src/Playwright.Tests/SelectorsTextTests.cs
@@ -28,7 +28,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class SelectorsTextTests : PageTestEx
     {
         [PlaywrightTest("selectors-text.spec.ts", "query")]

--- a/src/Playwright.Tests/TestConstants.cs
+++ b/src/Playwright.Tests/TestConstants.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 [assembly: NUnit.Framework.Timeout(Microsoft.Playwright.Tests.TestConstants.DefaultTestTimeout)]
+[assembly: NUnit.Framework.Parallelizable(NUnit.Framework.ParallelScope.Fixtures)]
 
 namespace Microsoft.Playwright.Tests
 {

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -35,7 +35,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>tracing.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class TracingTests : ContextTestEx
     {
         [PlaywrightTest("tracing.spec.ts", "should collect trace with resources, but no js")]

--- a/src/Playwright.Tests/WebSocketTests.cs
+++ b/src/Playwright.Tests/WebSocketTests.cs
@@ -30,7 +30,6 @@ using NUnit.Framework;
 namespace Microsoft.Playwright.Tests
 {
     ///<playwright-file>web-socket.spec.ts</playwright-file>
-    [Parallelizable(ParallelScope.Self)]
     public class WebSocketTests : PageTestEx
     {
         [PlaywrightTest("web-socket.spec.ts", "should work")]

--- a/src/Playwright.Tests/WorkersTests.cs
+++ b/src/Playwright.Tests/WorkersTests.cs
@@ -31,7 +31,6 @@ using NUnit.Framework;
 
 namespace Microsoft.Playwright.Tests
 {
-    [Parallelizable(ParallelScope.Self)]
     public class WorkersTests : PageTestEx
     {
         [PlaywrightTest("workers.spec.ts", "Page.workers")]


### PR DESCRIPTION
Replaces all the 130+ attribute statements with a single one applied to [the entire assembly](https://github.com/microsoft/playwright-dotnet/pull/1736/files#diff-82d1fdfb7a79fc5b6c9bf724b69d242d89252dd3850442644bf6e53bf515ea20R30).