### PR TITLE
Enabled channel and slowmo environment variables for testing

### DIFF
--- a/src/Playwright.MSTest/Services/BrowserService.cs
+++ b/src/Playwright.MSTest/Services/BrowserService.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Playwright.MSTest.Services
         {
             Browser = await parentTest!.BrowserType!.LaunchAsync(new()
             {
-                Headless = Environment.GetEnvironmentVariable("HEADED") != "1"
+                Headless = Environment.GetEnvironmentVariable("HEADED") != "1",
+                Channel = Environment.GetEnvironmentVariable("CHANNEL"),
+                SlowMo = float.TryParse(Environment.GetEnvironmentVariable("SLOWMO"), out float slowmo) ? slowmo : null
             });
         }
     }

--- a/src/Playwright.NUnit/BrowserService.cs
+++ b/src/Playwright.NUnit/BrowserService.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Playwright.NUnit
             {
                 Browser = await browserType.LaunchAsync(new()
                 {
-                    Headless = Environment.GetEnvironmentVariable("HEADED") != "1"
+                    Headless = Environment.GetEnvironmentVariable("HEADED") != "1",
+                    Channel = Environment.GetEnvironmentVariable("CHANNEL"),
+                    SlowMo = float.TryParse(Environment.GetEnvironmentVariable("SLOWMO"), out float slowmo) ? slowmo : null
                 })
             });
         }


### PR DESCRIPTION
Enabled 2 additional environment variables for running tests with mstest or nunit. Allows running on a chromium channel and allows slowmo to see what's going on.

**Linux**
```
HEADED=1 CHANNEL=chrome-dev SLOWMO=1000 dotnet test
```

**Windows** 
```
set HEADED=1
set CHANNEL=chrome-dev
set SLOWMO=1000
dotnet test
```