### PR TITLE
fix(CLI): use drivers instead of loading dll

### DIFF
--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -34,8 +34,14 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes><![CDATA[
 ]]></PackageReleaseNotes>
+    <StartupObject>Microsoft.Playwright.CLI.Program</StartupObject>
   </PropertyGroup>
   <Import Project="../Common/SignAssembly.props" />
+  <ItemGroup>
+    <Compile Include="..\Playwright\API\PlaywrightException.cs" Link="Links\PlaywrightException.cs" />
+    <Compile Include="..\Playwright\Helpers\Paths.cs" Link="Links\Paths.cs" />
+    <Compile Include="..\Playwright\Program.cs" Link="Links\Program.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -45,5 +51,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Links\" />
   </ItemGroup>
 </Project>

--- a/src/Playwright/Helpers/Paths.cs
+++ b/src/Playwright/Helpers/Paths.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Playwright.Helpers
             DirectoryInfo assemblyDirectory = new(AppContext.BaseDirectory);
             if (!assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
             {
-                var assemblyLocation = typeof(Playwright).Assembly.Location;
+                var assemblyLocation = typeof(Paths).Assembly.Location;
                 assemblyDirectory = new FileInfo(assemblyLocation).Directory;
             }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Playwright.Helpers
             throw new PlaywrightException($"Driver not found: {executableFile}");
         }
 
-        private static string GetPath(string driversPath)
+        internal static string GetPath(string driversPath)
         {
             string platformId;
             string runnerName;

--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -39,21 +39,22 @@ namespace Microsoft.Playwright
 
         public int Run(string[] args)
         {
-            // we need to use the original command line to avoid getting quotes stripped by the runtime
-            // see https://github.com/microsoft/playwright-dotnet/issues/1653
-            args = Environment.GetCommandLineArgs();
-            var lineArguments = Environment.CommandLine.Replace(args[0], string.Empty);
-
-            string pwPath = null;
             try
             {
-                pwPath = Paths.GetExecutablePath();
+                // we need to use the original command line to avoid getting quotes stripped by the runtime
+                // see https://github.com/microsoft/playwright-dotnet/issues/1653
+                args = Environment.GetCommandLineArgs();
+                var lineArguments = Environment.CommandLine.Replace(args[0], string.Empty);
+                return Run(Paths.GetExecutablePath(), lineArguments);
             }
             catch
             {
                 return PrintError("Microsoft.Playwright assembly was found, but is missing required assets. Please ensure to build your project before running Playwright tool.");
             }
+        }
 
+        public int Run(string pwPath, string lineArguments)
+        {
             var playwrightStartInfo = new ProcessStartInfo(pwPath, lineArguments)
             {
                 UseShellExecute = false,


### PR DESCRIPTION
Closes #1694 

This patch stops the CLI from loading the DLL, which was causing problems with projects targeting .NET Framework 4.8 and instead relies on the `.playwright` folder existing somewhere underneath the root, or specified project path.