### PR TITLE
fix: dont delete Drivers folder on build

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -28,13 +28,6 @@
     <Message Text="[Playwright] Copying files to publish folder..."/>
     <Copy SourceFiles="@(_PublishCopyItems)" DestinationFiles="@(_PublishCopyItems->'$(PublishDir)\.playwright\%(RecursiveDir)%(Filename)%(Extension)')"/>
   </Target>
-  <Target Name="PlaywrightLegacyCleanup" AfterTargets="Clean">
-    <Message Text="[Playwright] Removing up old Drivers folder..."/>
-    <RemoveDir Directories="$(MSBuildProjectDirectory)\Drivers" Condition="Exists('$(MSBuildProjectDirectory)\Drivers')" />
-    <RemoveDir Directories="$(MSBuildProjectDirectory)\DriversRaw" Condition="Exists('$(MSBuildProjectDirectory)\DriversRaw')" />
-    <RemoveDir Directories="$(OutDir)\node" Condition="Exists('$(OutDir)\node')"/>
-    <RemoveDir Directories="$(OutDir)\package" Condition="Exists('$(OutDir)\package')"/>
-  </Target>
   <Target Name="PlaywrightBuildCleanup" AfterTargets="Clean">
     <Message Text="[Playwright] Cleaning up .playwright folder and artifacts..."/>
     <RemoveDir Directories="$(OutDir)\.playwright" Condition="Exists('$(OutDir)\.playwright')"/>


### PR DESCRIPTION
This code attempted to clean up old Drivers and DriversRaw folders that we left inside the root of the project directory.
We do not own the project directory. There might be important files in these folders! Any legacy playwright files
will just have to stay there.

Fixes #1802