### PR TITLE
chore: mark v1.16.1

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.16.2</AssemblyVersion>
+    <AssemblyVersion>1.16.1</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <DriverVersion>1.16.2-1635322350000</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>


### PR DESCRIPTION
Note: the 1.16.2 version was auto-set after running the driver rolling script.