### PR TITLE
fix: deprecate sync method IRequest.Headers

### DIFF
--- a/src/Playwright.Tests/BrowserContextRouteTests.cs
+++ b/src/Playwright.Tests/BrowserContextRouteTests.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Playwright.Tests
                 intercepted = true;
 
                 StringAssert.Contains("empty.html", route.Request.Url);
+#pragma warning disable 0612
                 Assert.False(string.IsNullOrEmpty(route.Request.Headers["user-agent"]));
+#pragma warning restore 0612
                 Assert.AreEqual(HttpMethod.Get.Method, route.Request.Method);
                 Assert.Null(route.Request.PostData);
                 Assert.True(route.Request.IsNavigationRequest);

--- a/src/Playwright.Tests/PageNetworkRequestTest.cs
+++ b/src/Playwright.Tests/PageNetworkRequestTest.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Playwright.Tests
                 _ => "None"
             };
 
+#pragma warning disable 0612
             StringAssert.Contains(expected, response.Request.Headers["user-agent"]);
+#pragma warning restore 0612
         }
 
         [PlaywrightTest("page-network-request.spec.ts", "Request.headers", "should get the same headers as the server")]

--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Playwright.Tests
             });
 
             var response = await Page.GotoAsync(Server.EmptyPage);
+#pragma warning disable 0612
             StringAssert.Contains("bar", response.Headers["foo"]);
+#pragma warning restore 0612
         }
 
         [PlaywrightTest("page-network-response.spec.ts", "should return json")]
@@ -110,7 +112,9 @@ namespace Microsoft.Playwright.Tests
         {
             Server.EnableGzip("/simple.json");
             var response = await Page.GotoAsync(Server.Prefix + "/simple.json");
+#pragma warning disable 0612
             Assert.AreEqual("gzip", response.Headers["content-encoding"]);
+#pragma warning restore 0612
             Assert.AreEqual("{\"foo\": \"bar\"}", (await response.TextAsync()).Trim());
         }
 
@@ -247,7 +251,9 @@ namespace Microsoft.Playwright.Tests
             await Task.WhenAll(responseTask, Page.EvaluateAsync("() => fetch('/headers')"));
             var response = responseTask.Result;
             var allHeaders = await response.AllHeadersAsync();
+#pragma warning disable 0612
             Assert.AreEqual(response.Headers, allHeaders);
+#pragma warning restore 0612
         }
     }
 }

--- a/src/Playwright.Tests/PageRequestContinueTests.cs
+++ b/src/Playwright.Tests/PageRequestContinueTests.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Playwright.Tests
         {
             await Page.RouteAsync("**/*", (route) =>
             {
+#pragma warning disable 0612
                 var headers = new Dictionary<string, string>(route.Request.Headers.ToDictionary(x => x.Key, x => x.Value)) { ["FOO"] = "bar" };
+#pragma warning restore 0612
                 route.ContinueAsync(new() { Headers = headers });
             });
             await Page.GotoAsync(Server.EmptyPage);

--- a/src/Playwright.Tests/PageRequestFulfillTests.cs
+++ b/src/Playwright.Tests/PageRequestFulfillTests.cs
@@ -52,7 +52,9 @@ namespace Microsoft.Playwright.Tests
             });
             var response = await Page.GotoAsync(Server.EmptyPage);
             Assert.AreEqual((int)HttpStatusCode.Created, response.Status);
+#pragma warning disable 0612
             Assert.AreEqual("bar", response.Headers["foo"]);
+#pragma warning restore 0612
             Assert.AreEqual("Yo, page!", await Page.EvaluateAsync<string>("() => document.body.textContent"));
         }
 
@@ -144,7 +146,9 @@ namespace Microsoft.Playwright.Tests
 
             var response = await Page.GotoAsync(Server.EmptyPage);
             Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+#pragma warning disable 0612
             Assert.AreEqual("true", response.Headers["foo"]);
+#pragma warning restore 0612
             Assert.AreEqual("Yo, page!", await Page.EvaluateAsync<string>("() => document.body.textContent"));
         }
 
@@ -181,7 +185,9 @@ namespace Microsoft.Playwright.Tests
             await Page.RouteAsync(Server.CrossProcessPrefix + "/something", (route) =>
             {
                 playwrightRequest = route.Request;
+#pragma warning disable 0612
                 route.ContinueAsync(new() { Headers = route.Request.Headers.ToDictionary(x => x.Key, x => x.Value) });
+#pragma warning restore 0612
             });
 
             string textAfterRoute = await Page.EvaluateAsync<string>(@"async url => {
@@ -218,7 +224,9 @@ namespace Microsoft.Playwright.Tests
             }", Server.CrossProcessPrefix + "/something");
 
             Assert.AreEqual("done", text);
+#pragma warning disable 0612
             Assert.AreEqual(Server.Prefix, interceptedRequest.Headers["origin"]);
+#pragma warning restore 0612
         }
     }
 }

--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Playwright.Tests
             await Page.RouteAsync("**/empty.html", (route) =>
             {
                 StringAssert.Contains("empty.html", route.Request.Url);
+#pragma warning disable 0612
                 Assert.False(string.IsNullOrEmpty(route.Request.Headers["user-agent"]));
+#pragma warning restore 0612
                 Assert.AreEqual(HttpMethod.Get.Method, route.Request.Method);
                 Assert.Null(route.Request.PostData);
                 Assert.True(route.Request.IsNavigationRequest);
@@ -128,7 +130,9 @@ namespace Microsoft.Playwright.Tests
             Server.SetRedirect("/rrredirect", "/empty.html");
             await Page.RouteAsync("**/*", (route) =>
             {
+#pragma warning disable 0612
                 var headers = new Dictionary<string, string>(route.Request.Headers.ToDictionary(x => x.Key, x => x.Value)) { ["foo"] = "bar" };
+#pragma warning restore 0612
                 route.ContinueAsync(new() { Headers = headers });
             });
             await Page.GotoAsync(Server.Prefix + "/rrredirect");
@@ -139,7 +143,9 @@ namespace Microsoft.Playwright.Tests
         {
             await Page.RouteAsync("**/*", (route) =>
             {
+#pragma warning disable 0612
                 var headers = new Dictionary<string, string>(route.Request.Headers.ToDictionary(x => x.Key, x => x.Value)) { ["foo"] = "bar" };
+#pragma warning restore 0612
                 headers.Remove("origin");
                 route.ContinueAsync(new() { Headers = headers });
             });
@@ -163,7 +169,9 @@ namespace Microsoft.Playwright.Tests
             });
             await Page.GotoAsync(Server.Prefix + "/one-style.html");
             StringAssert.Contains("/one-style.css", requests[1].Url);
+#pragma warning disable 0612
             StringAssert.Contains("/one-style.html", requests[1].Headers["referer"]);
+#pragma warning restore 0612
         }
 
         [PlaywrightTest("page-route.spec.ts", "should properly return navigation response when URL has cookies")]
@@ -196,7 +204,9 @@ namespace Microsoft.Playwright.Tests
             });
             await Page.RouteAsync("**/*", (route) =>
             {
+#pragma warning disable 0612
                 Assert.AreEqual("bar", route.Request.Headers["foo"]);
+#pragma warning restore 0612
                 route.ContinueAsync();
             });
             var response = await Page.GotoAsync(Server.EmptyPage);
@@ -226,11 +236,15 @@ namespace Microsoft.Playwright.Tests
             {
                 if (TestConstants.IsChromium)
                 {
+#pragma warning disable 0612
                     Assert.AreEqual(Server.EmptyPage + ", " + Server.EmptyPage, route.Request.Headers["referer"]);
+#pragma warning restore 0612
                 }
                 else
                 {
+#pragma warning disable 0612
                     Assert.AreEqual(Server.EmptyPage, route.Request.Headers["referer"]);
+#pragma warning restore 0612
                 }
                 route.ContinueAsync();
             });
@@ -282,7 +296,9 @@ namespace Microsoft.Playwright.Tests
         {
             await Page.SetExtraHTTPHeadersAsync(new Dictionary<string, string> { ["referer"] = "http://google.com/" });
             await Page.RouteAsync("**/*", (route) => route.ContinueAsync());
+#pragma warning disable 0612
             var requestTask = Server.WaitForRequest("/grid.html", request => request.Headers["referer"]);
+#pragma warning restore 0612
             await TaskUtils.WhenAll(
                 requestTask,
                 Page.GotoAsync(Server.Prefix + "/grid.html")

--- a/src/Playwright/API/Generated/IRequest.cs
+++ b/src/Playwright/API/Generated/IRequest.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Playwright
         /// cref="IRequest.AllHeadersAsync"/> instead.
         /// </para>
         /// </summary>
+        [System.Obsolete]
         Dictionary<string, string> Headers { get; }
 
         /// <summary>

--- a/src/Playwright/API/Generated/IResponse.cs
+++ b/src/Playwright/API/Generated/IResponse.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Playwright
         /// cref="IResponse.AllHeadersAsync"/> instead.
         /// </para>
         /// </summary>
+        [System.Obsolete]
         Dictionary<string, string> Headers { get; }
 
         /// <summary>


### PR DESCRIPTION
Depends on https://github.com/microsoft/playwright/pull/9977
﻿
