### PR TITLE
NET 6.0 Support

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 6.0.100
     - name: Check formatting
       run: dotnet tool update dotnet-format --tool-path ./dotnet-format/ && ./dotnet-format/dotnet-format -f ./src/ --check -v:diag

--- a/.github/workflows/integrity-checks.yml
+++ b/.github/workflows/integrity-checks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install prerequisites and download drivers
         shell: pwsh
         run: .\build.ps1 driver -prereqs

--- a/.github/workflows/integrity-checks.yml
+++ b/.github/workflows/integrity-checks.yml
@@ -19,7 +19,11 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Setup .NET Core
+      - name: Setup .NET 5
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -21,7 +21,11 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Setup .NET Core
+      - name: Setup .NET 5
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install prerequisites and download drivers
         shell: pwsh
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test_net5:
-    name: Quick Test Harness Tests using .NET 5
+    name: Quick Test Harness Tests using .NET 6
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install prerequisites and download drivers
         shell: pwsh
         run: |
@@ -33,8 +33,8 @@ jobs:
         run: dotnet build ./src
       - name: Installing Browsers and dependencies...
         run: |
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install-deps
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install-deps
       - name: Running tests... 
         run: |
-          xvfb-run dotnet test ./src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj -c Debug -f net5.0 --logger "trx"
+          xvfb-run dotnet test ./src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj -c Debug -f net6.0 --logger "trx"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,7 +11,7 @@ on:
       - release-*
 
 jobs:
-  test_net5:
+  test_net6:
     name: Quick Test Harness Tests using .NET 6
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -20,7 +20,11 @@ jobs:
         with:
           submodules: true
           fetch-depth: 1
-      - name: Setup .NET Core
+      - name: Setup .NET 5
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install prerequisites and download drivers
         shell: pwsh
         run: |
@@ -38,20 +38,20 @@ jobs:
         run: dotnet build ./src
       - name: Installing Browsers and dependencies...
         run: |
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install-deps
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install-deps
       - name: Running tests...
         if: ${{ matrix.os != 'ubuntu-latest' }}
         env:
           BROWSER: ${{ matrix.product }}
         run: 
-          dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx;LogFileName=TestResults.xml" -- NUnit.NumberOfTestWorkers=1
+          dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger "trx;LogFileName=TestResults.xml" -- NUnit.NumberOfTestWorkers=1
       - name: Running tests... (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:
           BROWSER: ${{ matrix.product }}
         run: |
-          xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx" -- NUnit.NumberOfTestWorkers=1
+          xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger "trx" -- NUnit.NumberOfTestWorkers=1
 
   test_net31:
     name: Chromium on Ubuntu using .NET 3.1
@@ -65,10 +65,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Setup .NET 5.0 # needed for our build steps
+      - name: Setup .NET 6.0 # needed for our build steps
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install prerequisites and download drivers
         shell: pwsh
         run: |
@@ -80,8 +80,8 @@ jobs:
           dotnet build -f netcoreapp3.1 ./src/Playwright.Tests/Playwright.Tests.csproj
       - name: Installing Browsers and dependencies...
         run: |
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install
-          dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install-deps
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install
+          dotnet run --project ./src/Playwright/Playwright.csproj -f net6.0 -- install-deps
       - name: Running tests... 
         env:
           BROWSER: CHROMIUM

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
       - release-*
 
 jobs:
-  test_net5:
-    name: ${{ matrix.product }} on ${{ matrix.os }} using .NET 5
+  test_net6:
+    name: ${{ matrix.product }} on ${{ matrix.os }} using .NET 6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,11 @@ jobs:
         with:
           submodules: true
           fetch-depth: 1
-      - name: Setup .NET Core
+      - name: Setup .NET 5
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x

--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -5,7 +5,7 @@
     <PackageId>Microsoft.Playwright.CLI</PackageId>
     <Summary>The Playwright CLI dotnet tool.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <DebugSymbols>true</DebugSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>

--- a/src/Playwright.MSTest/Playwright.MSTest.csproj
+++ b/src/Playwright.MSTest/Playwright.MSTest.csproj
@@ -8,7 +8,7 @@
       Playwright enables reliable end-to-end testing for modern web apps. This package brings in additional helpers
       and fixtures to enable using it within MSTest.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net48</TargetFrameworks>
     <DebugSymbols>true</DebugSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -8,7 +8,7 @@
       Playwright enables reliable end-to-end testing for modern web apps. This package brings in additional helpers
       and fixtures to enable using it within NUnit.
     </Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net48</TargetFrameworks>
     <DebugSymbols>true</DebugSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
+++ b/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <RootNamespace>Microsoft.Playwright.Tests.TestServer</RootNamespace>

--- a/src/Playwright.Tests/Helpers/JsonExtensions.cs
+++ b/src/Playwright.Tests/Helpers/JsonExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Playwright.Helpers
             => new()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters =
                 {
                     new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase),

--- a/src/Playwright.Tests/NetworkPostDataTests.cs
+++ b/src/Playwright.Tests/NetworkPostDataTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Playwright.Tests
 
             await Task.WhenAll(task, actualTask);
 
-            string expectedJsonValue = JsonSerializer.Serialize(value, new()
+            string expectedJsonValue = JsonSerializer.Serialize(value, new JsonSerializerOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 WriteIndented = true

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
         <PackageReference Include="NETStandard.Library" Version="2.0.3" />
         <PackageReference Include="System.CodeDom" Version="5.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net6.0;</TargetFrameworks>
         <IsTestProject>true</IsTestProject>
         <ReleaseVersion>0.0.0</ReleaseVersion>
         <NoWarn>1701;1702</NoWarn>

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Playwright.Tests
                         var line = reader.ReadLine();
                         if (line == null) break;
                         results.Add(JsonSerializer.Deserialize<TraceEventEntry>(line,
-                            new()
+                            new JsonSerializerOptions
                             {
                                 PropertyNameCaseInsensitive = true,
                             }));

--- a/src/Playwright/Helpers/JsonExtensions.cs
+++ b/src/Playwright/Helpers/JsonExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Playwright.Helpers
             => new()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters =
                 {
                     new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase),

--- a/src/Playwright/Helpers/StringExtensions.cs
+++ b/src/Playwright/Helpers/StringExtensions.cs
@@ -660,7 +660,7 @@ namespace Microsoft.Playwright.Helpers
                 query = query.Substring(1, query.Length - 1);
             }
 
-            foreach (string keyValue in query.Split('&').Where(kv => kv.Contains("=")))
+            foreach (string keyValue in query.Split('&').Where(kv => kv.Contains('=')))
             {
                 string[] pair = keyValue.Split('=');
                 result[pair[0]] = pair[1];

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -6,7 +6,7 @@
     <PackageId>Microsoft.Playwright</PackageId>
     <Summary>The .NET port of Playwright, used to automate Chromium, Firefox and WebKit with a single API.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <DebugSymbols>true</DebugSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DocumentationFile>Microsoft.Playwright.xml</DocumentationFile>

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -136,7 +136,9 @@ namespace Microsoft.Playwright.Transport
                         object obj = propertyDescriptor.GetValue(args);
                         if (obj != null)
                         {
+#pragma warning disable CA1845
                             string name = propertyDescriptor.Name.Substring(0, 1).ToLower() + propertyDescriptor.Name.Substring(1);
+#pragma warning restore CA1845
                             sanitizedArgs.Add(name, obj);
                         }
                     }

--- a/src/Playwright/Transport/WebSocketTransport.cs
+++ b/src/Playwright/Transport/WebSocketTransport.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Playwright.Transport
 
         private async Task DispatchIncomingMessagesAsync()
         {
-#pragma warning disable VSTHRD103
+#pragma warning disable VSTHRD103, CA1849
             var buffer = WebSocket.CreateClientBuffer(DefaultBufferSize, DefaultBufferSize);
             var memoryStream = new MemoryStream();
             string closeReason = string.Empty;

--- a/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
+++ b/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <CodeAnalysisRuleSet>../../Playwright.ruleset</CodeAnalysisRuleSet>
         <ReleaseVersion>0.0.0</ReleaseVersion>
         <IsTool>true</IsTool>


### PR DESCRIPTION
- Updated TFM in projects from `.net5.0` to `.net6.0`
- Fixed CA warnings/Errors 

Builds on OSX-arm64 (M1 MacBookPro) but tons of the tests fail to run because the playwright builds of the browsers haven't been installed by `playwright install` yet. I can't run the dotnet global tool for playwright because it is expecting .NET 5 to be installed but I cannot seem to get it to recognize the recommended workaround for that on the M1 macs https://github.com/dotnet/sdk/issues/20584.

Update: After a hint from @martincostello I was able to run `playwright install` after setting `DOTNET_ROLL_FORWARD=Major` in my shell. I now get one test failure.

Update 2: Now the failing tests are passing, one job appears to have timed out due to taking too long. But the API Integrity check job is failing. I'm not sure if this is due to something I did or if a maintainer needs to step in. 

 I also had to manually run `cp -R ./playwright/tests/assets/ ./src/Playwright.Tests.TestServer/wwwroot/` as the powershell script didn't error, but it also didn't copy all the files over like I expected. Maybe a difference with powershell on OSX vs windows?

Will try and run all the tests on windows-x64 and linux as well.