### PR TITLE
chore: use Join-Path in PS1 script

### DIFF
--- a/src/Playwright/build/playwright.ps1
+++ b/src/Playwright/build/playwright.ps1
@@ -1,4 +1,5 @@
 #!/usr/bin/env pwsh
 
-[Reflection.Assembly]::LoadFile("$($PSScriptRoot)/Microsoft.Playwright.dll") | Out-Null
+$PlaywrightFileName = Join-Path $PSScriptRoot "Microsoft.Playwright.dll"
+[Reflection.Assembly]::LoadFile($PlaywrightFileName) | Out-Null
 [Microsoft.Playwright.Program]::Main($args)


### PR DESCRIPTION
Use [`Join-Path`](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/join-path?view=powershell-7.2) so that the correct path delimiter is used for the executing platform, rather than concatenating two strings and making assumptions.
