### PR TITLE
chore: bump dependencies

### DIFF
--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>exe</OutputType>
+    <OutputType>Exe</OutputType>
     <Title>Microsoft.Playwright.CLI</Title>
     <PackageId>Microsoft.Playwright.CLI</PackageId>
     <Summary>The Playwright CLI dotnet tool.</Summary>
@@ -39,11 +39,11 @@
   </PropertyGroup>
   <Import Project="../Common/SignAssembly.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
+++ b/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.*" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -9,10 +9,10 @@
   <Import Project="../Playwright.Tests/build/Playwright.Tests.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
+++ b/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="key.pfx">

--- a/src/Playwright.Tests/NetworkPostDataTests.cs
+++ b/src/Playwright.Tests/NetworkPostDataTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Playwright.Tests
 
             await Task.WhenAll(task, actualTask);
 
-            string expectedJsonValue = JsonSerializer.Serialize(value, new()
+            string expectedJsonValue = JsonSerializer.Serialize(value, new JsonSerializerOptions()
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 WriteIndented = true

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -13,16 +13,16 @@
     <Import Project="build/Playwright.Tests.targets" />
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
         <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
         <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-        <PackageReference Include="System.CodeDom" Version="5.0.0" />
+        <PackageReference Include="System.CodeDom" Version="6.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="CompareNETObjects" Version="4.73.0" />
+        <PackageReference Include="CompareNETObjects" Version="4.74.0" />
         <Compile Include="..\Playwright\Helpers\StringExtensions.cs" Link="StringExtensions.cs" />
         <Compile Include="..\Playwright\Helpers\DoubleExtensions.cs" Link="DoubleExtensions.cs" />
         <Compile Include="..\Playwright\Helpers\JsonExtensions.cs" Link="JsonExtensions.cs" />

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Playwright.Tests
                         var line = reader.ReadLine();
                         if (line == null) break;
                         results.Add(JsonSerializer.Deserialize<TraceEventEntry>(line,
-                            new()
+                            new JsonSerializerOptions()
                             {
                                 PropertyNameCaseInsensitive = true,
                             }));

--- a/src/Playwright.Tests/Utils/ScaffoldTest.cs
+++ b/src/Playwright.Tests/Utils/ScaffoldTest.cs
@@ -33,6 +33,7 @@ using System.Text.RegularExpressions;
 namespace Microsoft.Playwright.Tests
 {
     [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = "CodeDom is complicated.")]
+    [SuppressMessage("Microsoft.CodeQuality.Analyzers", "CA1416", Justification = "Validate platform compatibility (we only run tests on win/mac/linux).")]
     internal static partial class ScaffoldTest
     {
         private static readonly TextInfo _textInfo = CultureInfo.InvariantCulture.TextInfo;

--- a/src/Playwright/Helpers/JsonExtensions.cs
+++ b/src/Playwright/Helpers/JsonExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Playwright.Helpers
             => new()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters =
                 {
                     new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase),

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>exe</OutputType>
+    <OutputType>Exe</OutputType>
     <Title>Microsoft.Playwright</Title>
     <PackageId>Microsoft.Playwright</PackageId>
     <Summary>The .NET port of Playwright, used to automate Chromium, Firefox and WebKit with a single API.</Summary>
@@ -28,15 +28,23 @@
   <Import Project="../Common/SignAssembly.props" />
   <Import Project="build/Microsoft.Playwright.targets" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="Macross.Json.Extensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Target Name="DedupeDriver" AfterTargets="CopyFilesToOutputDirectory" BeforeTargets="CopyPlaywrightFilesToOutput">
     <ItemGroup>
@@ -48,20 +56,22 @@
       <DriverShell Include="Scripts\playwright.sh" />
       <DriverCmd Include="Scripts\playwright.cmd" />
     </ItemGroup>
-    <Copy SourceFiles="@(DriverPackage)" DestinationFiles="@(DriverPackage->'.playwright\package\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverNodeLicense)" DestinationFiles="@(DriverNodeLicense->'.playwright\node\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverNodeLinux)" DestinationFiles="@(DriverNodeLinux->'.playwright\node\linux\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverNodeMac)" DestinationFiles="@(DriverNodeMac->'.playwright\node\mac\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverNodeWin32_x64)" DestinationFiles="@(DriverNodeWin32_x64->'.playwright\node\win32_x64\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverShell)" DestinationFiles="@(DriverShell->'.playwright\node\linux\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverShell)" DestinationFiles="@(DriverShell->'.playwright\node\mac\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(DriverCmd)" DestinationFiles="@(DriverCmd->'.playwright\node\win32_x64\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverPackage)" DestinationFiles="@(DriverPackage-&gt;'.playwright\package\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverNodeLicense)" DestinationFiles="@(DriverNodeLicense-&gt;'.playwright\node\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverNodeLinux)" DestinationFiles="@(DriverNodeLinux-&gt;'.playwright\node\linux\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverNodeMac)" DestinationFiles="@(DriverNodeMac-&gt;'.playwright\node\mac\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverNodeWin32_x64)" DestinationFiles="@(DriverNodeWin32_x64-&gt;'.playwright\node\win32_x64\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverShell)" DestinationFiles="@(DriverShell-&gt;'.playwright\node\linux\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverShell)" DestinationFiles="@(DriverShell-&gt;'.playwright\node\mac\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(DriverCmd)" DestinationFiles="@(DriverCmd-&gt;'.playwright\node\win32_x64\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <ItemGroup>
     <None Include=".playwright\**" Pack="true" PackagePath=".playwright" />
     <None Include="build\**" Pack="true" PackagePath="buildTransitive" />
     <None Remove=".drivers\**" />
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />
+    <None Remove="Roslynator.Analyzers" />
+    <None Remove="Microsoft.VisualStudio.Threading.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60">

--- a/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
+++ b/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
@@ -10,8 +10,20 @@
     <Import Project="../../Common/Dependencies.props" />
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
-        <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0" />
+        <PackageReference Include="Macross.Json.Extensions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
+        <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+      <None Remove="Roslynator.Analyzers" />
+      <None Remove="Microsoft.VisualStudio.Threading.Analyzers" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
(all generated automatically by the Visual Studio Dependency Upgrade feature)

Extracted from #1884.

Failing bots are unrelated.