### PR TITLE
avoid Enumerable.Prepend

### DIFF
--- a/src/Playwright/Core/Waiter.cs
+++ b/src/Playwright/Core/Waiter.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Playwright.Core
                 {
                     throw _immediateError;
                 }
-                var firstTask = await Task.WhenAny(_failures.Prepend(task)).ConfigureAwait(false);
+                var firstTask = await Task.WhenAny(Enumerable.Repeat(task, 1).Concat(_failures)).ConfigureAwait(false);
                 dispose?.Invoke();
                 await firstTask.ConfigureAwait(false);
                 return await task.ConfigureAwait(false);


### PR DESCRIPTION
as it is one of the APIs which is in `netstandard2.0` but not in `net461`

With this fix I can use Playwright on `net461`.
Here is a simple testcase to reproduce the issue:

```c#
Microsoft.Playwright.Program.Main(new[] { "install" });

var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
var browser = await playwright.Chromium.LaunchAsync();
var context = await browser.NewContextAsync();
var page = await context.NewPageAsync();

page.FrameNavigated += async (sender, frame) =>
{
    await frame.WaitForLoadStateAsync(); // this will throw
};

await page.GotoAsync("https://google.de");
```

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net461</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <LangVersion>latest</LangVersion>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Microsoft.Playwright" Version="1.17.3" />
  </ItemGroup>
</Project>
```

Interestingly I can see the warning in intellisense but not when building:
![image](https://user-images.githubusercontent.com/4009570/149388014-f3b1e0db-2b56-4376-a320-6e3caffa617d.png)

References:
https://github.com/dotnet/standard/issues/457
https://stackoverflow.com/questions/43601101/what-are-the-43-apis-that-are-in-net-standard-2-0-but-not-in-net-framework-4-6
https://docs.microsoft.com/dotnet/api/system.linq.enumerable.prepend?view=net-6.0
