### PR TITLE
chore: roll Playwright to 1.18.0-beta-1642018269000

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+env:
+  DEBUG: pw:dotnet
 
 jobs:
   test-net5:

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.17.1</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)-next-1</PackageVersion>
-    <DriverVersion>1.18.0-alpha-1638917105000</DriverVersion>
+    <DriverVersion>1.18.0-beta-1642018269000</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright.Tests/BrowserTypeConnectTests.cs
+++ b/src/Playwright.Tests/BrowserTypeConnectTests.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Playwright.Tests
             var context = await browser.NewContextAsync();
             var page = await context.NewPageAsync();
 
-            await context.Tracing.StartAsync();
+            await context.Tracing.StartAsync(new() { Sources = true });
             await page.GotoAsync(Server.EmptyPage);
             await page.SetContentAsync("<button>Click</button>");
             await page.ClickAsync("button");
@@ -464,6 +464,7 @@ namespace Microsoft.Playwright.Tests
             ZipFile.ExtractToDirectory(tracePath, tempDirectory.Path);
             Assert.That(tempDirectory.Path + "/trace.trace", Does.Exist);
             Assert.That(tempDirectory.Path + "/trace.network", Does.Exist);
+            Assert.AreEqual(1, Directory.GetFiles(Path.Join(tempDirectory.Path, "resources"), "*.txt").Length);
         }
 
         private class RemoteServer

--- a/src/Playwright.Tests/Locator/LocatorQueryTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorQueryTests.cs
@@ -87,42 +87,42 @@ namespace Microsoft.Playwright.Tests.Locator
         public async Task ShouldFilterByText()
         {
             await Page.SetContentAsync("<div>Foobar</div><div>Bar</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText("Foo").TextContentAsync(), "Foobar");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextString = "Foo" }).TextContentAsync(), "Foobar");
         }
 
         [PlaywrightTest("locator-query.spec.ts", "should filter by text 2")]
         public async Task ShouldFilterByText2()
         {
             await Page.SetContentAsync("<div>foo <span>hello world</span> bar</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText("hello world").TextContentAsync(), "foo hello world bar");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextString = "hello world" }).TextContentAsync(), "foo hello world bar");
         }
 
         [PlaywrightTest("locator-query.spec.ts", "should filter by regex")]
         public async Task ShouldFilterByRegex()
         {
             await Page.SetContentAsync("<div>Foobar</div><div>Bar</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText(new Regex("Foo.*")).InnerTextAsync(), "Foobar");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextRegex = new Regex("Foo.*") }).InnerTextAsync(), "Foobar");
         }
 
         [PlaywrightTest("locator-query.spec.ts", "should filter by text with quotes")]
         public async Task ShouldFilterByTextWithQuotes()
         {
             await Page.SetContentAsync("<div>Hello \"world\"</div><div>Hello world</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText("Hello \"world\"").InnerTextAsync(), "Hello \"world\"");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextString = "Hello \"world\"" }).InnerTextAsync(), "Hello \"world\"");
         }
 
         [PlaywrightTest("locator-query.spec.ts", "should filter by regex with quotes")]
         public async Task ShouldFilterByRegexWithQuotes()
         {
             await Page.SetContentAsync("<div>Hello \"world\"</div><div>Hello world</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText(new Regex("Hello \"world\"")).InnerTextAsync(), "Hello \"world\"");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextRegex = new Regex("Hello \"world\"") }).InnerTextAsync(), "Hello \"world\"");
         }
 
         [PlaywrightTest("locator-query.spec.ts", "should filter by regex and regexp flags")]
         public async Task ShouldFilterByRegexandRegexpFlags()
         {
             await Page.SetContentAsync("<div>Hello \"world\"</div><div>Hello world</div>");
-            StringAssert.Contains(await Page.Locator("div").WithText(new Regex("hElLo \"wOrld\"", RegexOptions.IgnoreCase)).InnerTextAsync(), "Hello \"world\"");
+            StringAssert.Contains(await Page.Locator("div", new() { HasTextRegex = new Regex("hElLo \"wOrld\"", RegexOptions.IgnoreCase) }).InnerTextAsync(), "Hello \"world\"");
         }
     }
 }

--- a/src/Playwright.Tests/PageWaitForRequestTests.cs
+++ b/src/Playwright.Tests/PageWaitForRequestTests.cs
@@ -72,11 +72,12 @@ namespace Microsoft.Playwright.Tests
         }
 
         [PlaywrightTest("page-wait-for-request.spec.ts", "should respect default timeout")]
-        public Task ShouldRespectDefaultTimeout()
+        public async Task ShouldRespectDefaultTimeout()
         {
             Page.SetDefaultTimeout(1);
-            return PlaywrightAssert.ThrowsAsync<TimeoutException>(
+            var exception = await PlaywrightAssert.ThrowsAsync<TimeoutException>(
                 () => Page.WaitForRequestAsync(_ => false));
+            StringAssert.Contains(exception.Message, "Timeout 1ms exceeded while waiting for event \"Request\"");
         }
 
         [PlaywrightTest("page-wait-for-request.spec.ts", "should work with no timeout")]

--- a/src/Playwright.Tests/TapTests.cs
+++ b/src/Playwright.Tests/TapTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Playwright.Tests
             await Page.TapAsync("#b", new() { Trial = true });
 
             string[] result = await handle.JsonValueAsync<string[]>();
-            Assert.AreEqual(result, new string[] { });
+            Assert.AreEqual(result, new string[] { "pointerover", "pointerenter", "pointerout", "pointerleave" });
         }
 
         [PlaywrightTest("tap.spec.ts", "should not send mouse events touchstart is canceled")]

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -73,25 +73,6 @@ namespace Microsoft.Playwright.Tests
             Assert.GreaterOrEqual(events.Where(x => x.Type == "screencast-frame").Count(), 1);
         }
 
-        [PlaywrightTest("tracing.spec.ts", "should exclude internal pages")]
-        [Ignore("Fails due to https://github.com/microsoft/playwright/issues/6743")]
-        public async Task ShouldExcludeInternalPages()
-        {
-            var page = await Context.NewPageAsync();
-            await page.GotoAsync(Server.EmptyPage);
-
-            await Context.Tracing.StartAsync();
-            await Context.StorageStateAsync();
-            await page.CloseAsync();
-
-            using var tmp = new TempDirectory();
-            var tracePath = Path.Combine(tmp.Path, "trace.zip");
-            await Context.Tracing.StopAsync(new() { Path = tracePath });
-            var trace = ParseTrace(tracePath);
-
-            Assert.AreEqual(1, trace.Where(x => x.Metadata != null).Select(x => x.Metadata.PageId).Distinct().Count());
-        }
-
         [PlaywrightTest("tracing.spec.ts", "should collect two traces")]
         public async Task ShouldCollectTwoTraces()
         {

--- a/src/Playwright/API/Generated/IFrame.cs
+++ b/src/Playwright/API/Generated/IFrame.cs
@@ -717,7 +717,8 @@ namespace Microsoft.Playwright
         /// A selector to use when resolving DOM element. See <a href="./selectors.md">working
         /// with selectors</a> for more details.
         /// </param>
-        ILocator Locator(string selector);
+        /// <param name="options">Call options</param>
+        ILocator Locator(string selector, FrameLocatorOptions? options = default);
 
         /// <summary>
         /// <para>Returns frame's name attribute as specified in the tag.</para>

--- a/src/Playwright/API/Generated/IFrameLocator.cs
+++ b/src/Playwright/API/Generated/IFrameLocator.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Playwright
         /// A selector to use when resolving DOM element. See <a href="./selectors.md">working
         /// with selectors</a> for more details.
         /// </param>
-        ILocator Locator(string selector);
+        /// <param name="options">Call options</param>
+        ILocator Locator(string selector, FrameLocatorLocatorOptions? options = default);
 
         /// <summary><para>Returns locator to the n-th matching frame.</para></summary>
         /// <param name="index">

--- a/src/Playwright/API/Generated/ILocator.cs
+++ b/src/Playwright/API/Generated/ILocator.cs
@@ -454,7 +454,8 @@ namespace Microsoft.Playwright
         /// A selector to use when resolving DOM element. See <a href="./selectors.md">working
         /// with selectors</a> for more details.
         /// </param>
-        ILocator Locator(string selector);
+        /// <param name="options">Call options</param>
+        ILocator Locator(string selector, LocatorLocatorOptions? options = default);
 
         /// <summary><para>Returns locator to the n-th matching element.</para></summary>
         /// <param name="index">
@@ -977,24 +978,6 @@ namespace Microsoft.Playwright
         /// </summary>
         /// <param name="options">Call options</param>
         Task WaitForAsync(LocatorWaitForOptions? options = default);
-
-        /// <summary>
-        /// <para>
-        /// Matches elements containing specified text somewhere inside, possibly in a child
-        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
-        /// </para>
-        /// </summary>
-        /// <param name="text">Text to filter by as a string or as a regular expression.</param>
-        ILocator WithText(string text);
-
-        /// <summary>
-        /// <para>
-        /// Matches elements containing specified text somewhere inside, possibly in a child
-        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
-        /// </para>
-        /// </summary>
-        /// <param name="text">Text to filter by as a string or as a regular expression.</param>
-        ILocator WithText(Regex text);
     }
 }
 

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -1151,7 +1151,8 @@ namespace Microsoft.Playwright
         /// A selector to use when resolving DOM element. See <a href="./selectors.md">working
         /// with selectors</a> for more details.
         /// </param>
-        ILocator Locator(string selector);
+        /// <param name="options">Call options</param>
+        ILocator Locator(string selector, PageLocatorOptions? options = default);
 
         /// <summary>
         /// <para>

--- a/src/Playwright/API/Generated/Options/BrowserNewContextOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserNewContextOptions.cs
@@ -102,6 +102,10 @@ namespace Microsoft.Playwright
         /// baseURL: <c>http://localhost:3000/foo/</c> and navigating to <c>./bar.html</c> results
         /// in <c>http://localhost:3000/foo/bar.html</c>
         /// </description></item>
+        /// <item><description>
+        /// baseURL: <c>http://localhost:3000/foo</c> (without trailing slash) and navigating
+        /// to <c>./bar.html</c> results in <c>http://localhost:3000/bar.html</c>
+        /// </description></item>
         /// </list>
         /// </summary>
         [JsonPropertyName("baseURL")]

--- a/src/Playwright/API/Generated/Options/BrowserNewPageOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserNewPageOptions.cs
@@ -102,6 +102,10 @@ namespace Microsoft.Playwright
         /// baseURL: <c>http://localhost:3000/foo/</c> and navigating to <c>./bar.html</c> results
         /// in <c>http://localhost:3000/foo/bar.html</c>
         /// </description></item>
+        /// <item><description>
+        /// baseURL: <c>http://localhost:3000/foo</c> (without trailing slash) and navigating
+        /// to <c>./bar.html</c> results in <c>http://localhost:3000/bar.html</c>
+        /// </description></item>
         /// </list>
         /// </summary>
         [JsonPropertyName("baseURL")]

--- a/src/Playwright/API/Generated/Options/BrowserTypeLaunchPersistentContextOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserTypeLaunchPersistentContextOptions.cs
@@ -125,6 +125,10 @@ namespace Microsoft.Playwright
         /// baseURL: <c>http://localhost:3000/foo/</c> and navigating to <c>./bar.html</c> results
         /// in <c>http://localhost:3000/foo/bar.html</c>
         /// </description></item>
+        /// <item><description>
+        /// baseURL: <c>http://localhost:3000/foo</c> (without trailing slash) and navigating
+        /// to <c>./bar.html</c> results in <c>http://localhost:3000/bar.html</c>
+        /// </description></item>
         /// </list>
         /// </summary>
         [JsonPropertyName("baseURL")]

--- a/src/Playwright/API/Generated/Options/FrameLocatorLocatorOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameLocatorLocatorOptions.cs
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Microsoft.Playwright
+{
+    public class FrameLocatorLocatorOptions
+    {
+        public FrameLocatorLocatorOptions() { }
+
+        public FrameLocatorLocatorOptions(FrameLocatorLocatorOptions clone)
+        {
+            if (clone == null) return;
+            HasTextString = clone.HasTextString;
+            HasTextRegex = clone.HasTextRegex;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextString")]
+        public string? HasTextString { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextRegex")]
+        public Regex? HasTextRegex { get; set; }
+    }
+}
+
+#nullable disable

--- a/src/Playwright/API/Generated/Options/FrameLocatorOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameLocatorOptions.cs
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Microsoft.Playwright
+{
+    public class FrameLocatorOptions
+    {
+        public FrameLocatorOptions() { }
+
+        public FrameLocatorOptions(FrameLocatorOptions clone)
+        {
+            if (clone == null) return;
+            HasTextString = clone.HasTextString;
+            HasTextRegex = clone.HasTextRegex;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextString")]
+        public string? HasTextString { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextRegex")]
+        public Regex? HasTextRegex { get; set; }
+    }
+}
+
+#nullable disable

--- a/src/Playwright/API/Generated/Options/LocatorLocatorOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorLocatorOptions.cs
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Microsoft.Playwright
+{
+    public class LocatorLocatorOptions
+    {
+        public LocatorLocatorOptions() { }
+
+        public LocatorLocatorOptions(LocatorLocatorOptions clone)
+        {
+            if (clone == null) return;
+            HasTextString = clone.HasTextString;
+            HasTextRegex = clone.HasTextRegex;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextString")]
+        public string? HasTextString { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextRegex")]
+        public Regex? HasTextRegex { get; set; }
+    }
+}
+
+#nullable disable

--- a/src/Playwright/API/Generated/Options/PageLocatorOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageLocatorOptions.cs
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Microsoft.Playwright
+{
+    public class PageLocatorOptions
+    {
+        public PageLocatorOptions() { }
+
+        public PageLocatorOptions(PageLocatorOptions clone)
+        {
+            if (clone == null) return;
+            HasTextString = clone.HasTextString;
+            HasTextRegex = clone.HasTextRegex;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextString")]
+        public string? HasTextString { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// Matches elements containing specified text somewhere inside, possibly in a child
+        /// or a descendant element. For example, <c>"Playwright"</c> matches <c>&lt;article&gt;&lt;div&gt;Playwright&lt;/div&gt;&lt;/article&gt;</c>.
+        /// </para>
+        /// </summary>
+        [JsonPropertyName("hasTextRegex")]
+        public Regex? HasTextRegex { get; set; }
+    }
+}
+
+#nullable disable

--- a/src/Playwright/API/Generated/Options/TracingStartOptions.cs
+++ b/src/Playwright/API/Generated/Options/TracingStartOptions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Playwright
             Name = clone.Name;
             Screenshots = clone.Screenshots;
             Snapshots = clone.Snapshots;
+            Sources = clone.Sources;
             Title = clone.Title;
         }
 
@@ -73,6 +74,10 @@ namespace Microsoft.Playwright
         /// <summary><para>Whether to capture DOM snapshot on every action.</para></summary>
         [JsonPropertyName("snapshots")]
         public bool? Snapshots { get; set; }
+
+        /// <summary><para>Whether to include source files for trace actions.</para></summary>
+        [JsonPropertyName("sources")]
+        public bool? Sources { get; set; }
 
         /// <summary><para>Trace name to be shown in the Trace Viewer.</para></summary>
         [JsonPropertyName("title")]

--- a/src/Playwright/API/Supplements/LocalUtils.cs
+++ b/src/Playwright/API/Supplements/LocalUtils.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,31 +22,12 @@
  * SOFTWARE.
  */
 
-using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Playwright.Helpers;
-using Microsoft.Playwright.Transport;
-using Microsoft.Playwright.Transport.Channels;
-using Microsoft.Playwright.Transport.Protocol;
 
-namespace Microsoft.Playwright.Core
+namespace Microsoft.Playwright
 {
-    internal partial class LocalUtils : ChannelOwnerBase, IChannelOwner<LocalUtils>, ILocalUtils
+    public partial interface ILocalUtils
     {
-        private readonly LocalUtilsChannel _channel;
-
-        public LocalUtils(IChannelOwner parent, string guid, JsonElement? initializer) : base(parent, guid)
-        {
-            _channel = new(guid, parent.Connection, this);
-        }
-
-        ChannelBase IChannelOwner.Channel => _channel;
-
-        IChannel<LocalUtils> IChannelOwner<LocalUtils>.Channel => _channel;
-
-        internal Task ZipAsync(string zipFile, List<NameValueEntry> entries)
-            => _channel.ZipAsync(zipFile, entries);
     }
 }

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Playwright.Core
                forcedColors: options.ForcedColors).ConfigureAwait(false)).Object;
 
             context.Options = options;
+            context.LocalUtils = LocalUtils;
 
             BrowserContextsList.Add(context);
             return context;

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Playwright.Core
 
         internal List<BrowserContext> BrowserContextsList { get; } = new();
 
+        internal LocalUtils LocalUtils { get; set; }
+
         public async Task CloseAsync()
         {
             try

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Playwright.Core
                 e.Page?.FireResponse(e.Response);
             };
 
-            _tracing = new Tracing(Channel);
+            _tracing = new Tracing(this);
             _initializer = initializer;
             Browser = parent as IBrowser;
         }
@@ -111,6 +111,8 @@ namespace Microsoft.Playwright.Core
         IChannel<BrowserContext> IChannelOwner<BrowserContext>.Channel => Channel;
 
         public IBrowser Browser { get; }
+
+        internal LocalUtils LocalUtils { get; set; }
 
         public IReadOnlyList<IPage> Pages => PagesList;
 
@@ -293,8 +295,8 @@ namespace Microsoft.Playwright.Core
             }
 
             timeout ??= DefaultTimeout;
-            using var waiter = new Waiter(Channel, $"context.WaitForEventAsync(\"{playwrightEvent.Name}\")");
-            waiter.RejectOnTimeout(Convert.ToInt32(timeout), $"Timeout while waiting for event \"{playwrightEvent.Name}\"");
+            using var waiter = new Waiter(this, $"context.WaitForEventAsync(\"{playwrightEvent.Name}\")");
+            waiter.RejectOnTimeout(Convert.ToInt32(timeout), $"Timeout {timeout}ms exceeded while waiting for event \"{playwrightEvent.Name}\"");
 
             if (playwrightEvent.Name != BrowserContextEvent.Close.Name)
             {

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Playwright.Core
 
         IChannel<BrowserType> IChannelOwner<BrowserType>.Channel => _channel;
 
+        internal PlaywrightImpl Playwright { get; set; }
+
         public string ExecutablePath => _initializer.ExecutablePath;
 
         public string Name => _initializer.Name;
@@ -54,7 +56,7 @@ namespace Microsoft.Playwright.Core
         public async Task<IBrowser> LaunchAsync(BrowserTypeLaunchOptions options = default)
         {
             options ??= new BrowserTypeLaunchOptions();
-            return (await _channel.LaunchAsync(
+            Browser browser = (await _channel.LaunchAsync(
                 headless: options.Headless,
                 channel: options.Channel,
                 executablePath: options.ExecutablePath,
@@ -73,6 +75,8 @@ namespace Microsoft.Playwright.Core
                 slowMo: options.SlowMo,
                 ignoreDefaultArgs: options.IgnoreDefaultArgs,
                 ignoreAllDefaultArgs: options.IgnoreAllDefaultArgs).ConfigureAwait(false)).Object;
+            browser.LocalUtils = Playwright.Utils;
+            return browser;
         }
 
         public async Task<IBrowserContext> LaunchPersistentContextAsync(string userDataDir, BrowserTypeLaunchPersistentContextOptions options = default)
@@ -130,6 +134,7 @@ namespace Microsoft.Playwright.Core
                 RecordHarPath = options.RecordHarPath,
                 RecordHarOmitContent = options.RecordHarOmitContent,
             };
+            context.LocalUtils = Playwright.Utils;
             return context;
         }
 
@@ -208,6 +213,7 @@ namespace Microsoft.Playwright.Core
                 browser = playwright.PreLaunchedBrowser;
                 browser.ShouldCloseConnectionOnClose = true;
                 browser.Disconnected += (_, _) => ClosePipe();
+                browser.LocalUtils = Playwright.Utils;
                 return playwright.PreLaunchedBrowser;
             }
             var task = CreateBrowserAsync();
@@ -228,6 +234,7 @@ namespace Microsoft.Playwright.Core
             {
                 browser.BrowserContextsList.Add(defaultContextValue.ToObject<BrowserContext>(_channel.Connection.GetDefaultJsonSerializerOptions()));
             }
+            browser.LocalUtils = Playwright.Utils;
             return browser;
         }
     }

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Playwright.Core
             void OnPipeClosed()
             {
                 // Emulate all pages, contexts and the browser closing upon disconnect.
-                foreach (BrowserContext context in browser.BrowserContextsList.ToArray())
+                foreach (BrowserContext context in browser?.BrowserContextsList.ToArray() ?? Array.Empty<BrowserContext>())
                 {
                     foreach (Page page in context.PagesList.ToArray())
                     {
@@ -172,7 +172,7 @@ namespace Microsoft.Playwright.Core
                     }
                     context.OnClose();
                 }
-                browser.DidClose();
+                browser?.DidClose();
                 connection.DoClose(closeError != null ? closeError : DriverMessages.BrowserClosedExceptionMessage);
             }
             pipe.Closed += (_, _) => OnPipeClosed();
@@ -197,6 +197,7 @@ namespace Microsoft.Playwright.Core
                 catch (Exception ex)
                 {
                     closeError = ex.ToString();
+                    _channel.Connection.TraceMessage("pw:dotnet", $"Dispatching error: {ex.Message}\n{ex.StackTrace}");
                     ClosePipe();
                 }
             };

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Playwright.Core
 
         private Waiter SetupNavigationWaiter(string @event, float? timeout)
         {
-            var waiter = new Waiter(this, @event);
+            var waiter = new Waiter(this.Page as Page, @event);
             if (this.Page.IsClosed)
             {
                 waiter.RejectImmediately(new PlaywrightException("Navigation failed because page was closed!"));

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -276,6 +276,9 @@ namespace Microsoft.Playwright.Core
                 trial: options?.Trial,
                 strict: options?.Strict);
 
+        internal Task<int> QueryCountAsync(string selector)
+            => _channel.QueryCountAsync(selector);
+
         public Task<string> ContentAsync() => _channel.ContentAsync();
 
         public Task FocusAsync(string selector, FrameFocusOptions options = default)
@@ -517,7 +520,7 @@ namespace Microsoft.Playwright.Core
                 script,
                 arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
-        public ILocator Locator(string selector) => new Locator(this, selector);
+        public ILocator Locator(string selector, FrameLocatorOptions options = null) => new Locator(this, selector, new() { HasTextRegex = options?.HasTextRegex, HasTextString = options?.HasTextString });
 
         public async Task<IElementHandle> QuerySelectorAsync(string selector, FrameQuerySelectorOptions options = null)
             => (await _channel.QuerySelectorAsync(selector, options?.Strict).ConfigureAwait(false))?.Object;
@@ -597,7 +600,7 @@ namespace Microsoft.Playwright.Core
 
         private Waiter SetupNavigationWaiter(string @event, float? timeout)
         {
-            var waiter = new Waiter((this.Page as Page)!.Channel, @event);
+            var waiter = new Waiter(this, @event);
             if (this.Page.IsClosed)
             {
                 waiter.RejectImmediately(new PlaywrightException("Navigation failed because page was closed!"));

--- a/src/Playwright/Core/FrameLocator.cs
+++ b/src/Playwright/Core/FrameLocator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Playwright.Core
 
         IFrameLocator IFrameLocator.FrameLocator(string selector) => new FrameLocator(_frame, $"{_frameSelector} >> control=enter-frame >> {selector}");
 
-        ILocator IFrameLocator.Locator(string selector) => new Locator(_frame, $"{_frameSelector} >> control=enter-frame >> {selector}");
+        ILocator IFrameLocator.Locator(string selector, FrameLocatorLocatorOptions options) => new Locator(_frame, $"{_frameSelector} >> control=enter-frame >> {selector}", new() { HasTextRegex = options?.HasTextRegex, HasTextString = options?.HasTextString });
 
         IFrameLocator IFrameLocator.Nth(int index) => new FrameLocator(_frame, $"{_frameSelector} >> nth={index}");
     }

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -423,8 +423,8 @@ namespace Microsoft.Playwright.Core
             }
 
             timeout ??= _defaultTimeout;
-            using var waiter = new Waiter(_channel, $"page.WaitForEventAsync(\"{typeof(T)}\")");
-            waiter.RejectOnTimeout(Convert.ToInt32(timeout), $"Timeout while waiting for event \"{pageEvent.Name}\"");
+            using var waiter = new Waiter(this, $"page.WaitForEventAsync(\"{typeof(T)}\")");
+            waiter.RejectOnTimeout(Convert.ToInt32(timeout), $"Timeout {timeout}ms exceeded while waiting for event \"{pageEvent.Name}\"");
 
             if (pageEvent.Name != PageEvent.Crash.Name)
             {
@@ -468,8 +468,8 @@ namespace Microsoft.Playwright.Core
         public Task<T> EvalOnSelectorAsync<T>(string selector, string expression, object arg = null, PageEvalOnSelectorOptions options = null)
             => MainFrame.EvalOnSelectorAsync<T>(selector, expression, arg, new() { Strict = options?.Strict });
 
-        public ILocator Locator(string selector)
-            => MainFrame.Locator(selector);
+        public ILocator Locator(string selector, PageLocatorOptions options = default)
+            => MainFrame.Locator(selector, new() { HasTextString = options?.HasTextString, HasTextRegex = options?.HasTextRegex });
 
         public Task<IElementHandle> QuerySelectorAsync(string selector, PageQuerySelectorOptions options = null)
             => MainFrame.QuerySelectorAsync(selector, new() { Strict = options?.Strict });

--- a/src/Playwright/Core/PlaywrightImpl.cs
+++ b/src/Playwright/Core/PlaywrightImpl.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Playwright.Core
             {
                 _devices[entry.Name] = entry.Descriptor;
             }
+            Utils = initializer.Utils;
+
+            _initializer.Chromium.Playwright = this;
+            _initializer.Firefox.Playwright = this;
+            _initializer.Webkit.Playwright = this;
         }
 
         ~PlaywrightImpl() => Dispose(false);
@@ -78,6 +83,8 @@ namespace Microsoft.Playwright.Core
         internal Connection Connection { get; set; }
 
         internal Browser PreLaunchedBrowser => _initializer.PreLaunchedBrowser;
+
+        internal LocalUtils Utils { get; set; }
 
         /// <summary>
         /// Gets a <see cref="IBrowserType"/>.

--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Playwright.Core
                         name: options?.Name,
                         title: options?.Title,
                         screenshots: options?.Screenshots,
-                        snapshots: options?.Snapshots).ConfigureAwait(false);
+                        snapshots: options?.Snapshots,
+                        sources: options?.Sources).ConfigureAwait(false);
             await _context.Channel.StartChunkAsync(options?.Title).ConfigureAwait(false);
         }
 

--- a/src/Playwright/Core/Waiter.cs
+++ b/src/Playwright/Core/Waiter.cs
@@ -39,24 +39,23 @@ namespace Microsoft.Playwright.Core
         private readonly List<Action> _dispose = new();
         private readonly CancellationTokenSource _cts = new();
         private readonly string _waitId = Guid.NewGuid().ToString();
-        private readonly ChannelBase _channel;
+        private readonly IChannelOwner _channelOwner;
         private Exception _immediateError;
 
         private bool _disposed;
         private string _error;
 
-        internal Waiter(ChannelBase channel, string @event)
+        internal Waiter(IChannelOwner channelOwner, string @event)
         {
-            _channel = channel;
+            _channelOwner = channelOwner;
             var beforeArgs = new { info = new { @event = @event, waitId = _waitId, phase = "before" } };
-            var connection = _channel.Connection;
 
-            _ = connection.SendMessageToServerAsync(channel.Guid, "waitForEventInfo", beforeArgs);
+            _ = channelOwner.Connection.SendMessageToServerAsync(channelOwner.Channel.Guid, "waitForEventInfo", beforeArgs);
             _dispose.Add(() =>
             {
                 var afterArgs = new { info = new { waitId = _waitId, phase = "after", error = _error } };
 
-                _ = _channel.Connection.SendMessageToServerAsync(channel.Guid, "waitForEventInfo", afterArgs);
+                _ = channelOwner.Connection.SendMessageToServerAsync(channelOwner.Channel.Guid, "waitForEventInfo", afterArgs);
             });
         }
 
@@ -79,7 +78,7 @@ namespace Microsoft.Playwright.Core
         {
             _logs.Add(log);
             var logArgs = new { info = new { waitId = _waitId, phase = "log", message = log } };
-            _ = _channel.Connection.SendMessageToServerAsync(_channel.Guid, "waitForEventInfo", logArgs);
+            _ = _channelOwner.Connection.SendMessageToServerAsync(_channelOwner.Channel.Guid, "waitForEventInfo", logArgs);
         }
 
         internal void RejectImmediately(Exception exception)

--- a/src/Playwright/Core/Worker.cs
+++ b/src/Playwright/Core/Worker.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Playwright.Core
 
         public async Task<IWorker> WaitForCloseAsync(Func<Task> action = default, float? timeout = default)
         {
-            using var waiter = new Waiter(_channel, "worker.WaitForCloseAsync");
+            using var waiter = new Waiter(this, "worker.WaitForCloseAsync");
             var waiterResult = waiter.GetWaitForEventTask<IWorker>(this, nameof(Close), null);
             var result = waiterResult.Task.WithTimeout(Convert.ToInt32(timeout ?? 0));
             if (action != null)

--- a/src/Playwright/Helpers/StringExtensions.cs
+++ b/src/Playwright/Helpers/StringExtensions.cs
@@ -624,7 +624,7 @@ namespace Microsoft.Playwright.Helpers
                 query = query.Substring(1, query.Length - 1);
             }
 
-            foreach (string keyValue in query.Split('&').Where(kv => kv.Contains("=")))
+            foreach (string keyValue in query.Split('&').Where(kv => kv.Contains('=')))
             {
                 string[] pair = keyValue.Split('=');
                 result[pair[0]] = pair[1];

--- a/src/Playwright/Transport/Channels/BrowserContextChannel.cs
+++ b/src/Playwright/Transport/Channels/BrowserContextChannel.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Playwright.Transport.Channels
         internal Task<StorageState> GetStorageStateAsync()
             => Connection.SendMessageToServerAsync<StorageState>(Guid, "storageState", null);
 
-        internal Task TracingStartAsync(string name, string title, bool? screenshots, bool? snapshots)
+        internal Task TracingStartAsync(string name, string title, bool? screenshots, bool? snapshots, bool? sources)
             => Connection.SendMessageToServerAsync(
                 Guid,
                 "tracingStart",
@@ -244,6 +244,7 @@ namespace Microsoft.Playwright.Transport.Channels
                     ["title"] = title,
                     ["screenshots"] = screenshots,
                     ["snapshots"] = snapshots,
+                    ["sources"] = sources,
                 });
 
         internal Task TracingStopAsync()
@@ -272,7 +273,10 @@ namespace Microsoft.Playwright.Transport.Channels
                 while (sourceEntriesEnumerator.MoveNext())
                 {
                     JsonElement current = sourceEntriesEnumerator.Current;
-                    sourceEntries.Add(result.Value.Deserialize<NameValueEntry>());
+                    sourceEntries.Add(current.Deserialize<NameValueEntry>(new JsonSerializerOptions()
+                    {
+                        PropertyNameCaseInsensitive = true,
+                    }));
                 }
             }
             return (artifact, sourceEntries);

--- a/src/Playwright/Transport/Channels/ChannelOwnerType.cs
+++ b/src/Playwright/Transport/Channels/ChannelOwnerType.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Playwright.Transport.Channels
 
         [EnumMember(Value = "JsonPipe")]
         JsonPipe,
+        [EnumMember(Value = "LocalUtils")]
+        LocalUtils,
 
         [EnumMember(Value = "page")]
         Page,

--- a/src/Playwright/Transport/Channels/ElementHandleChannel.cs
+++ b/src/Playwright/Transport/Channels/ElementHandleChannel.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Playwright.Transport.Channels
                 ["noWaitAfter"] = noWaitAfter,
             };
 
-            return Connection.SendMessageToServerAsync<string>(Guid, "setInputFiles", args);
+            return Connection.SendMessageToServerAsync(Guid, "setInputFiles", args);
         }
 
         internal async Task<string> GetAttributeAsync(string name)

--- a/src/Playwright/Transport/Channels/FrameChannel.cs
+++ b/src/Playwright/Transport/Channels/FrameChannel.cs
@@ -239,6 +239,17 @@ namespace Microsoft.Playwright.Transport.Channels
                 param);
         }
 
+        internal async Task<int> QueryCountAsync(string selector)
+        {
+            var args = new Dictionary<string, object>
+            {
+                ["selector"] = selector,
+            };
+
+            var result = await Connection.SendMessageToServerAsync(Guid, "queryCount", args).ConfigureAwait(false);
+            return result.Value.GetProperty("value").GetInt32();
+        }
+
         internal Task SetContentAsync(string html, float? timeout, WaitUntilState? waitUntil)
         {
             var args = new Dictionary<string, object>
@@ -413,7 +424,7 @@ namespace Microsoft.Playwright.Transport.Channels
             return Connection.SendMessageToServerAsync(Guid, "hover", args);
         }
 
-        internal Task<string[]> PressAsync(string selector, string text, float? delay, float? timeout, bool? noWaitAfter, bool? strict)
+        internal Task PressAsync(string selector, string text, float? delay, float? timeout, bool? noWaitAfter, bool? strict)
         {
             var args = new Dictionary<string, object>
             {
@@ -425,7 +436,7 @@ namespace Microsoft.Playwright.Transport.Channels
                 ["strict"] = strict,
             };
 
-            return Connection.SendMessageToServerAsync<string[]>(Guid, "press", args);
+            return Connection.SendMessageToServerAsync(Guid, "press", args);
         }
 
         internal async Task<string[]> SelectOptionAsync(string selector, IEnumerable<SelectOptionValue> values, bool? noWaitAfter, bool? strict, bool? force, float? timeout)
@@ -550,7 +561,7 @@ namespace Microsoft.Playwright.Transport.Channels
                 ["strict"] = strict,
             };
 
-            return Connection.SendMessageToServerAsync<string>(Guid, "setInputFiles", args);
+            return Connection.SendMessageToServerAsync(Guid, "setInputFiles", args);
         }
 
         internal async Task<string> TextContentAsync(string selector, float? timeout, bool? strict)

--- a/src/Playwright/Transport/Channels/LocalUtilsChannel.cs
+++ b/src/Playwright/Transport/Channels/LocalUtilsChannel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Playwright.Transport.Channels
         internal Task ZipAsync(string zipFile, List<NameValueEntry> entries) =>
             Connection.SendMessageToServerAsync(Guid, "zip", new Dictionary<string, object>
             {
-                  { "zip", zipFile },
+                  { "zipFile", zipFile },
                   { "entries", entries },
             });
     }

--- a/src/Playwright/Transport/Channels/LocalUtilsChannel.cs
+++ b/src/Playwright/Transport/Channels/LocalUtilsChannel.cs
@@ -22,31 +22,25 @@
  * SOFTWARE.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Microsoft.Playwright.Helpers;
-using Microsoft.Playwright.Transport;
-using Microsoft.Playwright.Transport.Channels;
-using Microsoft.Playwright.Transport.Protocol;
+using Microsoft.Playwright.Core;
 
-namespace Microsoft.Playwright.Core
+namespace Microsoft.Playwright.Transport.Channels
 {
-    internal partial class LocalUtils : ChannelOwnerBase, IChannelOwner<LocalUtils>, ILocalUtils
+    internal class LocalUtilsChannel : Channel<LocalUtils>
     {
-        private readonly LocalUtilsChannel _channel;
-
-        public LocalUtils(IChannelOwner parent, string guid, JsonElement? initializer) : base(parent, guid)
+        public LocalUtilsChannel(string guid, Connection connection, LocalUtils owner) : base(guid, connection, owner)
         {
-            _channel = new(guid, parent.Connection, this);
         }
 
-        ChannelBase IChannelOwner.Channel => _channel;
-
-        IChannel<LocalUtils> IChannelOwner<LocalUtils>.Channel => _channel;
-
-        internal Task ZipAsync(string zipFile, List<NameValueEntry> entries)
-            => _channel.ZipAsync(zipFile, entries);
+        internal Task ZipAsync(string zipFile, List<NameValueEntry> entries) =>
+            Connection.SendMessageToServerAsync(Guid, "zip", new Dictionary<string, object>
+            {
+                  { "zip", zipFile },
+                  { "entries", entries },
+            });
     }
 }

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Playwright.Transport
 
         private void DoClose(Exception ex)
         {
-            TraceMessage("pw:dotnet", ex.ToString());
+            TraceMessage("pw:dotnet", $"Connection Close: {ex.Message}\n{ex.StackTrace}");
             DoClose(ex.Message);
         }
 
@@ -419,10 +419,15 @@ namespace Microsoft.Playwright.Transport
         }
 
         [Conditional("DEBUG")]
-        private void TraceMessage(string logLevel, object message)
+        internal void TraceMessage(string logLevel, object message)
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEBUGP")))
+            string actualLogLevel = Environment.GetEnvironmentVariable("DEBUG");
+            if (!string.IsNullOrEmpty(actualLogLevel))
             {
+                if (!actualLogLevel.Contains(logLevel))
+                {
+                    return;
+                }
                 if (!(message is string))
                 {
                     message = JsonSerializer.Serialize(message, GetDefaultJsonSerializerOptions());

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Playwright.Transport
             IChannelOwner result = null;
             var parent = string.IsNullOrEmpty(parentGuid) ? _rootObject : Objects[parentGuid];
 
-#pragma warning disable CA2000
+#pragma warning disable CA2000 // Dispose objects before losing scope
             switch (type)
             {
                 case ChannelOwnerType.Artifact:
@@ -311,6 +311,9 @@ namespace Microsoft.Playwright.Transport
                 case ChannelOwnerType.JsonPipe:
                     result = new JsonPipe(parent, guid, initializer?.ToObject<JsonPipeInitializer>(GetDefaultJsonSerializerOptions()));
                     break;
+                case ChannelOwnerType.LocalUtils:
+                    result = new LocalUtils(parent, guid, initializer);
+                    break;
                 case ChannelOwnerType.Page:
                     result = new Page(parent, guid, initializer?.ToObject<PageInitializer>(GetDefaultJsonSerializerOptions()));
                     break;
@@ -339,10 +342,10 @@ namespace Microsoft.Playwright.Transport
                     TraceMessage("pw:dotnet", "Missing type " + type);
                     break;
             }
+#pragma warning restore CA2000
 
             Objects.TryAdd(guid, result);
             OnObjectCreated(guid, result);
-#pragma warning restore CA2000
         }
 
         private void DoClose(Exception ex)
@@ -418,7 +421,7 @@ namespace Microsoft.Playwright.Transport
         [Conditional("DEBUG")]
         private void TraceMessage(string logLevel, object message)
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEBUGPWD")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEBUGP")))
             {
                 if (!(message is string))
                 {


### PR DESCRIPTION
Fixes #1754
Fixes #1918

I'll follow-up with the last missing backport for rewriting the route handling matching logic: https://github.com/microsoft/playwright/commit/c21d6b791c537dc341b89257726ea651e9234f2b#diff-d7c041137e763edae5c4d18bc8ded9a1ac668078e310712341c444ef3aac423b