### PR TITLE
create Route glob regex immediately

### DIFF
--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -691,5 +691,23 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual(new[] { "DELETE", "electric", "cars" }, resp);
         }
+
+        [PlaywrightTest]
+        public void ShouldThrowOnInvalidRouteUrl()
+        {
+#if NETCOREAPP3_1
+            var regexParseExceptionType = typeof(Regex).Assembly
+                .GetType("System.Text.RegularExpressions.RegexParseException", throwOnError: true);
+#else
+            var regexParseExceptionType = typeof(RegexParseException);
+#endif
+
+            Assert.Throws(regexParseExceptionType, () =>
+                Page.RouteAsync("[", route =>
+                {
+                    route.ContinueAsync();
+                })
+            );
+        }
     }
 }

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -247,13 +247,13 @@ namespace Microsoft.Playwright.Core
         }
 
         public Task RouteAsync(string url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
-            => RouteAsync(url, new Regex(CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
+            => RouteAsync(new Regex(CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
         public Task RouteAsync(Regex url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
-            => RouteAsync(null, url, null, handler, options);
+            => RouteAsync(url, null, handler, options);
 
         public Task RouteAsync(Func<string, bool> url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
-            => RouteAsync(null, null, url, handler, options);
+            => RouteAsync(null, url, handler, options);
 
         public Task SetExtraHTTPHeadersAsync(IEnumerable<KeyValuePair<string, string>> headers)
             => Channel.SetExtraHTTPHeadersAsync(headers);
@@ -279,13 +279,13 @@ namespace Microsoft.Playwright.Core
         }
 
         public Task UnrouteAsync(string urlString, Action<IRoute> handler = default)
-            => UnrouteAsync(urlString, null, null, handler);
+            => UnrouteAsync(new Regex(CombineUrlWithBase(urlString).GlobToRegex()), null, handler);
 
         public Task UnrouteAsync(Regex urlRegex, Action<IRoute> handler = default)
-            => UnrouteAsync(null, urlRegex, null, handler);
+            => UnrouteAsync(urlRegex, null, handler);
 
         public Task UnrouteAsync(Func<string, bool> urlFunc, Action<IRoute> handler = default)
-            => UnrouteAsync(null, null, urlFunc, handler);
+            => UnrouteAsync(null, urlFunc, handler);
 
         public async Task<T> InnerWaitForEventAsync<T>(PlaywrightEvent<T> playwrightEvent, Func<Task> action = default, Func<T, bool> predicate = default, float? timeout = default)
         {
@@ -363,11 +363,10 @@ namespace Microsoft.Playwright.Core
             return url;
         }
 
-        private Task RouteAsync(string urlString, Regex urlRegex, Func<string, bool> urlFunc, Action<IRoute> handler, BrowserContextRouteOptions options)
+        private Task RouteAsync(Regex urlRegex, Func<string, bool> urlFunc, Action<IRoute> handler, BrowserContextRouteOptions options)
             => RouteAsync(new()
             {
                 Regex = urlRegex,
-                Url = urlString,
                 Function = urlFunc,
                 Handler = handler,
                 Times = options?.Times,
@@ -385,11 +384,10 @@ namespace Microsoft.Playwright.Core
             return Task.CompletedTask;
         }
 
-        private Task UnrouteAsync(string urlString, Regex urlRegex, Func<string, bool> urlFunc, Action<IRoute> handler = null)
+        private Task UnrouteAsync(Regex urlRegex, Func<string, bool> urlFunc, Action<IRoute> handler = null)
             => UnrouteAsync(new()
             {
                 Function = urlFunc,
-                Url = urlString,
                 Regex = urlRegex,
                 Handler = handler,
             });
@@ -398,8 +396,7 @@ namespace Microsoft.Playwright.Core
         {
             var newRoutesList = new List<RouteSetting>();
             newRoutesList.AddRange(_routes.Where(r =>
-                (setting.Url != null && r.Url != setting.Url) ||
-                (setting.Regex != null && r.Regex != setting.Regex) ||
+                (setting.Regex != null && !(r.Regex == setting.Regex || (r.Regex.ToString() == setting.Regex.ToString() && r.Regex.Options == setting.Regex.Options))) ||
                 (setting.Function != null && r.Function != setting.Function) ||
                 (setting.Handler != null && r.Handler != setting.Handler)));
             _routes = newRoutesList;

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Playwright.Core
         }
 
         public Task RouteAsync(string url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
-            => RouteAsync(url, null, null, handler, options);
+            => RouteAsync(url, new Regex(CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
         public Task RouteAsync(Regex url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
             => RouteAsync(null, url, null, handler, options);
@@ -330,8 +330,7 @@ namespace Microsoft.Playwright.Core
             {
                 if (
                     ((item.Times ?? 0) == 0 || item.HandledCount >= item.Times) &&
-                    ((item.Url != null && UrlMatches(request.Url, item.Url)) ||
-                    (item.Regex?.IsMatch(request.Url) == true) ||
+                    ((item.Regex?.IsMatch(request.Url) == true) ||
                     (item.Function?.Invoke(request.Url) == true)))
                 {
                     item.Handle(route);

--- a/src/Playwright/Core/RouteSetting.cs
+++ b/src/Playwright/Core/RouteSetting.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Playwright.Core
 {
     internal class RouteSetting
     {
-        public string Url { get; set; }
-
         public Regex Regex { get; set; }
 
         public Func<string, bool> Function { get; set; }


### PR DESCRIPTION
Currently route urls are converted to regular expressions on every route match which could result in a regex parse exception if the url is invalid.

With this change the regex is created once when the url route is added which means that potential regex parse exceptions are thrown immediately instead of later when the route is matched.

This also fixes a case where it wasn't possible to remove a url route when the browsing context has a base url set.

This also synchronized the code style for adding routes in `BrowserContext` and `Page`.