### PR TITLE
reuse Connection JsonSerializerOptions

### DIFF
--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -223,10 +223,10 @@ namespace Microsoft.Playwright.Core
             }
             options ??= new BrowserTypeConnectOverCDPOptions();
             JsonElement result = await _channel.ConnectOverCDPAsync(endpointURL, headers: options.Headers, slowMo: options.SlowMo, timeout: options.Timeout).ConfigureAwait(false);
-            Browser browser = result.GetProperty("browser").ToObject<Browser>(_channel.Connection.GetDefaultJsonSerializerOptions());
+            Browser browser = result.GetProperty("browser").ToObject<Browser>(_channel.Connection.DefaultJsonSerializerOptions);
             if (result.TryGetProperty("defaultContext", out JsonElement defaultContextValue))
             {
-                browser.BrowserContextsList.Add(defaultContextValue.ToObject<BrowserContext>(_channel.Connection.GetDefaultJsonSerializerOptions()));
+                browser.BrowserContextsList.Add(defaultContextValue.ToObject<BrowserContext>(_channel.Connection.DefaultJsonSerializerOptions));
             }
             return browser;
         }

--- a/src/Playwright/Playwright.cs
+++ b/src/Playwright/Playwright.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Playwright
             transport.MessageReceived += (_, message) => connection.Dispatch(JsonSerializer.Deserialize<PlaywrightServerMessage>(message, JsonExtensions.DefaultJsonSerializerOptions));
             transport.LogReceived += (_, log) => Console.Error.WriteLine(log);
             transport.TransportClosed += (_, reason) => connection.DoClose(reason);
-            connection.OnMessage = (message) => transport.SendAsync(JsonSerializer.Serialize(message, connection.GetDefaultJsonSerializerOptions()));
+            connection.OnMessage = (message) => transport.SendAsync(JsonSerializer.Serialize(message, connection.DefaultJsonSerializerOptions));
             connection.Close += (_, e) => transport.Close(e);
             var playwright = await connection.InitializePlaywrightAsync().ConfigureAwait(false);
             playwright.Connection = connection;

--- a/src/Playwright/Transport/Channels/BrowserContextChannel.cs
+++ b/src/Playwright/Transport/Channels/BrowserContextChannel.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Playwright.Transport.Channels
                 case "bindingCall":
                     BindingCall?.Invoke(
                         this,
-                        new() { BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                        new() { BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "route":
-                    var route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.GetDefaultJsonSerializerOptions()).Object;
-                    var request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.GetDefaultJsonSerializerOptions()).Object;
+                    var route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.DefaultJsonSerializerOptions).Object;
+                    var request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.DefaultJsonSerializerOptions).Object;
                     Route?.Invoke(
                         this,
                         new() { Route = route, Request = request });
@@ -81,29 +81,29 @@ namespace Microsoft.Playwright.Transport.Channels
                 case "page":
                     Page?.Invoke(
                         this,
-                        new() { PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()) });
+                        new() { PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions) });
                     break;
                 case "crBackgroundPage":
                     BackgroundPage?.Invoke(
                         this,
-                        new() { PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()) });
+                        new() { PageChannel = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions) });
                     break;
                 case "crServiceWorker":
                     ServiceWorker?.Invoke(
                         this,
-                        new() { WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.GetDefaultJsonSerializerOptions()) });
+                        new() { WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.DefaultJsonSerializerOptions) });
                     break;
                 case "request":
-                    Request?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    Request?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "requestFinished":
-                    RequestFinished?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    RequestFinished?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "requestFailed":
-                    RequestFailed?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    RequestFailed?.Invoke(this, serverParams?.ToObject<BrowserContextChannelRequestEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "response":
-                    Response?.Invoke(this, serverParams?.ToObject<BrowserContextChannelResponseEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    Response?.Invoke(this, serverParams?.ToObject<BrowserContextChannelResponseEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
             }
         }

--- a/src/Playwright/Transport/Channels/FrameChannel.cs
+++ b/src/Playwright/Transport/Channels/FrameChannel.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Playwright.Transport.Channels
             switch (method)
             {
                 case "navigated":
-                    var e = serverParams?.ToObject<FrameNavigatedEventArgs>(Connection.GetDefaultJsonSerializerOptions());
+                    var e = serverParams?.ToObject<FrameNavigatedEventArgs>(Connection.DefaultJsonSerializerOptions);
 
                     if (serverParams.Value.TryGetProperty("newDocument", out var documentElement))
                     {
-                        e.NewDocument = documentElement.ToObject<NavigateDocument>(Connection.GetDefaultJsonSerializerOptions());
+                        e.NewDocument = documentElement.ToObject<NavigateDocument>(Connection.DefaultJsonSerializerOptions);
                     }
 
                     Navigated?.Invoke(this, e);
@@ -59,7 +59,7 @@ namespace Microsoft.Playwright.Transport.Channels
                 case "loadstate":
                     LoadState?.Invoke(
                         this,
-                        serverParams?.ToObject<FrameChannelLoadStateEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                        serverParams?.ToObject<FrameChannelLoadStateEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
             }
         }

--- a/src/Playwright/Transport/Channels/JSHandleChannel.cs
+++ b/src/Playwright/Transport/Channels/JSHandleChannel.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Playwright.Transport.Channels
 
         internal async Task<List<JSElementProperty>> GetPropertiesAsync()
             => (await Connection.SendMessageToServerAsync(Guid, "getPropertyList", null).ConfigureAwait(false))?
-                .GetProperty("properties").ToObject<List<JSElementProperty>>(Connection.GetDefaultJsonSerializerOptions());
+                .GetProperty("properties").ToObject<List<JSElementProperty>>(Connection.DefaultJsonSerializerOptions);
 
         internal class JSElementProperty
         {

--- a/src/Playwright/Transport/Channels/JsonPipeChannel.cs
+++ b/src/Playwright/Transport/Channels/JsonPipeChannel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Playwright.Transport.Channels
                 case "closed":
                     if (serverParams.Value.TryGetProperty("error", out var error))
                     {
-                        Closed?.Invoke(this, error.ToObject<SerializedError>(Connection.GetDefaultJsonSerializerOptions()));
+                        Closed?.Invoke(this, error.ToObject<SerializedError>(Connection.DefaultJsonSerializerOptions));
                     }
                     else
                     {
@@ -56,7 +56,7 @@ namespace Microsoft.Playwright.Transport.Channels
                     }
                     break;
                 case "message":
-                    Message?.Invoke(this, serverParams?.GetProperty("message").ToObject<PlaywrightServerMessage>(Connection.GetDefaultJsonSerializerOptions()));
+                    Message?.Invoke(this, serverParams?.GetProperty("message").ToObject<PlaywrightServerMessage>(Connection.DefaultJsonSerializerOptions));
                     break;
             }
         }

--- a/src/Playwright/Transport/Channels/PageChannel.cs
+++ b/src/Playwright/Transport/Channels/PageChannel.cs
@@ -92,49 +92,49 @@ namespace Microsoft.Playwright.Transport.Channels
                 case "bindingCall":
                     BindingCall?.Invoke(
                         this,
-                        new() { BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                        new() { BidingCall = serverParams?.GetProperty("binding").ToObject<BindingCallChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "route":
-                    var route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.GetDefaultJsonSerializerOptions()).Object;
-                    var request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.GetDefaultJsonSerializerOptions()).Object;
+                    var route = serverParams?.GetProperty("route").ToObject<RouteChannel>(Connection.DefaultJsonSerializerOptions).Object;
+                    var request = serverParams?.GetProperty("request").ToObject<RequestChannel>(Connection.DefaultJsonSerializerOptions).Object;
                     Route?.Invoke(
                         this,
                         new() { Route = route, Request = request });
                     break;
                 case "popup":
-                    Popup?.Invoke(this, new() { Page = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    Popup?.Invoke(this, new() { Page = serverParams?.GetProperty("page").ToObject<PageChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "pageError":
-                    PageError?.Invoke(this, serverParams?.GetProperty("error").GetProperty("error").ToObject<SerializedError>(Connection.GetDefaultJsonSerializerOptions()));
+                    PageError?.Invoke(this, serverParams?.GetProperty("error").GetProperty("error").ToObject<SerializedError>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "fileChooser":
-                    FileChooser?.Invoke(this, serverParams?.ToObject<FileChooserChannelEventArgs>(Connection.GetDefaultJsonSerializerOptions()));
+                    FileChooser?.Invoke(this, serverParams?.ToObject<FileChooserChannelEventArgs>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "frameAttached":
-                    FrameAttached?.Invoke(this, serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.GetDefaultJsonSerializerOptions()).Object);
+                    FrameAttached?.Invoke(this, serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.DefaultJsonSerializerOptions).Object);
                     break;
                 case "frameDetached":
-                    FrameDetached?.Invoke(this, serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.GetDefaultJsonSerializerOptions()).Object);
+                    FrameDetached?.Invoke(this, serverParams?.GetProperty("frame").ToObject<FrameChannel>(Connection.DefaultJsonSerializerOptions).Object);
                     break;
                 case "dialog":
-                    Dialog?.Invoke(this, serverParams?.GetProperty("dialog").ToObject<DialogChannel>(Connection.GetDefaultJsonSerializerOptions()).Object);
+                    Dialog?.Invoke(this, serverParams?.GetProperty("dialog").ToObject<DialogChannel>(Connection.DefaultJsonSerializerOptions).Object);
                     break;
                 case "console":
-                    Console?.Invoke(this, serverParams?.GetProperty("message").ToObject<ConsoleMessage>(Connection.GetDefaultJsonSerializerOptions()));
+                    Console?.Invoke(this, serverParams?.GetProperty("message").ToObject<ConsoleMessage>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "webSocket":
-                    WebSocket?.Invoke(this, serverParams?.GetProperty("webSocket").ToObject<WebSocketChannel>(Connection.GetDefaultJsonSerializerOptions()).Object);
+                    WebSocket?.Invoke(this, serverParams?.GetProperty("webSocket").ToObject<WebSocketChannel>(Connection.DefaultJsonSerializerOptions).Object);
                     break;
                 case "download":
-                    Download?.Invoke(this, serverParams?.ToObject<PageDownloadEvent>(Connection.GetDefaultJsonSerializerOptions()));
+                    Download?.Invoke(this, serverParams?.ToObject<PageDownloadEvent>(Connection.DefaultJsonSerializerOptions));
                     break;
                 case "video":
-                    Video?.Invoke(this, new() { Artifact = serverParams?.GetProperty("artifact").ToObject<ArtifactChannel>(Connection.GetDefaultJsonSerializerOptions()).Object });
+                    Video?.Invoke(this, new() { Artifact = serverParams?.GetProperty("artifact").ToObject<ArtifactChannel>(Connection.DefaultJsonSerializerOptions).Object });
                     break;
                 case "worker":
                     Worker?.Invoke(
                         this,
-                        new() { WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.GetDefaultJsonSerializerOptions()) });
+                        new() { WorkerChannel = serverParams?.GetProperty("worker").ToObject<WorkerChannel>(Connection.DefaultJsonSerializerOptions) });
                     break;
             }
         }
@@ -245,7 +245,6 @@ namespace Microsoft.Playwright.Transport.Channels
 
             if ((await Connection.SendMessageToServerAsync(Guid, "accessibilitySnapshot", args).ConfigureAwait(false)).Value.TryGetProperty("rootAXNode", out var jsonElement))
             {
-                Connection.GetDefaultJsonSerializerOptions();
                 return jsonElement;
             }
 

--- a/src/Playwright/Transport/Channels/ResponseChannel.cs
+++ b/src/Playwright/Transport/Channels/ResponseChannel.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Playwright.Transport.Channels
 
         internal async Task<ResponseServerAddrResult> ServerAddrAsync()
             => (await Connection.SendMessageToServerAsync(Guid, "serverAddr", null).ConfigureAwait(false))
-                ?.GetProperty("value").ToObject<ResponseServerAddrResult>(Connection.GetDefaultJsonSerializerOptions());
+                ?.GetProperty("value").ToObject<ResponseServerAddrResult>(Connection.DefaultJsonSerializerOptions);
 
         internal async Task<ResponseSecurityDetailsResult> SecurityDetailsAsync()
             => (await Connection.SendMessageToServerAsync(Guid, "securityDetails", null).ConfigureAwait(false))
-                ?.GetProperty("value").ToObject<ResponseSecurityDetailsResult>(Connection.GetDefaultJsonSerializerOptions());
+                ?.GetProperty("value").ToObject<ResponseSecurityDetailsResult>(Connection.DefaultJsonSerializerOptions);
 
         internal async Task<RequestSizesResult> SizesAsync() =>
             (await Connection.SendMessageToServerAsync(Guid, "sizes", null).ConfigureAwait(false))?.GetProperty("sizes").ToObject<RequestSizesResult>();

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -54,12 +54,11 @@ namespace Microsoft.Playwright.Transport
         {
             _rootObject = new(null, this, string.Empty);
 
-            var options = JsonExtensions.GetNewDefaultSerializerOptions();
-            options.Converters.Add(new ChannelToGuidConverter(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<JSHandle>(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<ElementHandle>(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<IChannelOwner>(this));
-            DefaultJsonSerializerOptions = options;
+            DefaultJsonSerializerOptions = JsonExtensions.GetNewDefaultSerializerOptions();
+            DefaultJsonSerializerOptions.Converters.Add(new ChannelToGuidConverter(this));
+            DefaultJsonSerializerOptions.Converters.Add(new ChannelOwnerToGuidConverter<JSHandle>(this));
+            DefaultJsonSerializerOptions.Converters.Add(new ChannelOwnerToGuidConverter<ElementHandle>(this));
+            DefaultJsonSerializerOptions.Converters.Add(new ChannelOwnerToGuidConverter<IChannelOwner>(this));
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -53,6 +53,13 @@ namespace Microsoft.Playwright.Transport
         public Connection()
         {
             _rootObject = new(null, this, string.Empty);
+
+            var options = JsonExtensions.GetNewDefaultSerializerOptions();
+            options.Converters.Add(new ChannelToGuidConverter(this));
+            options.Converters.Add(new ChannelOwnerToGuidConverter<JSHandle>(this));
+            options.Converters.Add(new ChannelOwnerToGuidConverter<ElementHandle>(this));
+            options.Converters.Add(new ChannelOwnerToGuidConverter<IChannelOwner>(this));
+            DefaultJsonSerializerOptions = options;
         }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>
@@ -67,6 +74,8 @@ namespace Microsoft.Playwright.Transport
         internal bool IsRemote { get; set; }
 
         internal Func<object, Task> OnMessage { get; set; }
+
+        internal JsonSerializerOptions DefaultJsonSerializerOptions { get; }
 
         public void Dispose()
         {
@@ -174,12 +183,12 @@ namespace Microsoft.Playwright.Transport
                 var enumerate = result.Value.EnumerateObject();
 
                 return enumerate.Any()
-                    ? enumerate.FirstOrDefault().Value.ToObject<T>(GetDefaultJsonSerializerOptions())
+                    ? enumerate.FirstOrDefault().Value.ToObject<T>(DefaultJsonSerializerOptions)
                     : default;
             }
             else
             {
-                return result.Value.ToObject<T>(GetDefaultJsonSerializerOptions());
+                return result.Value.ToObject<T>(DefaultJsonSerializerOptions);
             }
         }
 
@@ -190,16 +199,6 @@ namespace Microsoft.Playwright.Transport
         }
 
         internal void MarkAsRemote() => IsRemote = true;
-
-        internal JsonSerializerOptions GetDefaultJsonSerializerOptions()
-        {
-            var options = JsonExtensions.GetNewDefaultSerializerOptions();
-            options.Converters.Add(new ChannelToGuidConverter(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<JSHandle>(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<ElementHandle>(this));
-            options.Converters.Add(new ChannelOwnerToGuidConverter<IChannelOwner>(this));
-            return options;
-        }
 
         internal Task<PlaywrightImpl> InitializePlaywrightAsync()
         {
@@ -242,7 +241,7 @@ namespace Microsoft.Playwright.Transport
             {
                 if (message.Method == "__create__")
                 {
-                    var createObjectInfo = message.Params.Value.ToObject<CreateObjectInfo>(GetDefaultJsonSerializerOptions());
+                    var createObjectInfo = message.Params.Value.ToObject<CreateObjectInfo>(DefaultJsonSerializerOptions);
                     CreateRemoteObject(message.Guid, createObjectInfo.Type, createObjectInfo.Guid, createObjectInfo.Initializer);
 
                     return;
@@ -273,61 +272,61 @@ namespace Microsoft.Playwright.Transport
             switch (type)
             {
                 case ChannelOwnerType.Artifact:
-                    result = new Artifact(parent, guid, initializer?.ToObject<ArtifactInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Artifact(parent, guid, initializer?.ToObject<ArtifactInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.BindingCall:
-                    result = new BindingCall(parent, guid, initializer?.ToObject<BindingCallInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new BindingCall(parent, guid, initializer?.ToObject<BindingCallInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Playwright:
-                    result = new PlaywrightImpl(parent, guid, initializer?.ToObject<PlaywrightInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new PlaywrightImpl(parent, guid, initializer?.ToObject<PlaywrightInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Browser:
-                    var browserInitializer = initializer?.ToObject<BrowserInitializer>(GetDefaultJsonSerializerOptions());
+                    var browserInitializer = initializer?.ToObject<BrowserInitializer>(DefaultJsonSerializerOptions);
                     result = new Browser(parent, guid, browserInitializer);
                     break;
                 case ChannelOwnerType.BrowserType:
-                    var browserTypeInitializer = initializer?.ToObject<BrowserTypeInitializer>(GetDefaultJsonSerializerOptions());
+                    var browserTypeInitializer = initializer?.ToObject<BrowserTypeInitializer>(DefaultJsonSerializerOptions);
                     result = new Core.BrowserType(parent, guid, browserTypeInitializer);
                     break;
                 case ChannelOwnerType.BrowserContext:
-                    var browserContextInitializer = initializer?.ToObject<BrowserContextInitializer>(GetDefaultJsonSerializerOptions());
+                    var browserContextInitializer = initializer?.ToObject<BrowserContextInitializer>(DefaultJsonSerializerOptions);
                     result = new BrowserContext(parent, guid, browserContextInitializer);
                     break;
                 case ChannelOwnerType.ConsoleMessage:
-                    result = new ConsoleMessage(parent, guid, initializer?.ToObject<ConsoleMessageInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new ConsoleMessage(parent, guid, initializer?.ToObject<ConsoleMessageInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Dialog:
-                    result = new Dialog(parent, guid, initializer?.ToObject<DialogInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Dialog(parent, guid, initializer?.ToObject<DialogInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.ElementHandle:
-                    result = new ElementHandle(parent, guid, initializer?.ToObject<ElementHandleInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new ElementHandle(parent, guid, initializer?.ToObject<ElementHandleInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Frame:
-                    result = new Frame(parent, guid, initializer?.ToObject<FrameInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Frame(parent, guid, initializer?.ToObject<FrameInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.JSHandle:
-                    result = new JSHandle(parent, guid, initializer?.ToObject<JSHandleInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new JSHandle(parent, guid, initializer?.ToObject<JSHandleInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.JsonPipe:
-                    result = new JsonPipe(parent, guid, initializer?.ToObject<JsonPipeInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new JsonPipe(parent, guid, initializer?.ToObject<JsonPipeInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Page:
-                    result = new Page(parent, guid, initializer?.ToObject<PageInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Page(parent, guid, initializer?.ToObject<PageInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Request:
-                    result = new Request(parent, guid, initializer?.ToObject<RequestInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Request(parent, guid, initializer?.ToObject<RequestInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Response:
-                    result = new Response(parent, guid, initializer?.ToObject<ResponseInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Response(parent, guid, initializer?.ToObject<ResponseInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Route:
-                    result = new Route(parent, guid, initializer?.ToObject<RouteInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Route(parent, guid, initializer?.ToObject<RouteInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Worker:
-                    result = new Worker(parent, guid, initializer?.ToObject<WorkerInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new Worker(parent, guid, initializer?.ToObject<WorkerInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.WebSocket:
-                    result = new WebSocket(parent, guid, initializer?.ToObject<WebSocketInitializer>(GetDefaultJsonSerializerOptions()));
+                    result = new WebSocket(parent, guid, initializer?.ToObject<WebSocketInitializer>(DefaultJsonSerializerOptions));
                     break;
                 case ChannelOwnerType.Selectors:
                     result = new Selectors(parent, guid);
@@ -422,7 +421,7 @@ namespace Microsoft.Playwright.Transport
             {
                 if (!(message is string))
                 {
-                    message = JsonSerializer.Serialize(message, GetDefaultJsonSerializerOptions());
+                    message = JsonSerializer.Serialize(message, DefaultJsonSerializerOptions);
                 }
                 string line = $"{logLevel}: {message}";
                 Trace.WriteLine(line);


### PR DESCRIPTION
Currently new connection specifc `JsonSerializerOptions` are always created but they can just be reused instead.