### PR TITLE
chore: set driver environment variables

### DIFF
--- a/src/Playwright.Tests/BrowserTypeConnectTests.cs
+++ b/src/Playwright.Tests/BrowserTypeConnectTests.cs
@@ -47,18 +47,21 @@ namespace Microsoft.Playwright.Tests
             {
                 DirectoryInfo assemblyDirectory = new(AppContext.BaseDirectory);
                 RemoteServer remoteServer = new();
+                var startInfo = new ProcessStartInfo(Driver.GetExecutablePath(), $"launch-server {BrowserType.Name}")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardError = false,
+                    CreateNoWindow = true,
+                };
+                foreach (var pair in Driver.GetEnvironmentVariables())
+                {
+                    startInfo.EnvironmentVariables[pair.Key] = pair.Value;
+                }
                 remoteServer.Process = new()
                 {
-                    StartInfo =
-                    {
-                        FileName = Paths.GetExecutablePath(),
-                        Arguments = $"launch-server {BrowserType.Name}",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardInput = true,
-                        RedirectStandardError = false,
-                        CreateNoWindow = true,
-                    },
+                    StartInfo = startInfo,
                 };
                 remoteServer.Process.Start();
                 remoteServer.WSEndpoint = remoteServer.Process.StandardOutput.ReadLine();

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -27,7 +27,7 @@
         <Compile Include="..\Playwright\Helpers\DoubleExtensions.cs" Link="DoubleExtensions.cs" />
         <Compile Include="..\Playwright\Helpers\JsonExtensions.cs" Link="JsonExtensions.cs" />
         <Compile Include="..\Playwright\Helpers\RegexOptionsExtensions.cs" Link="RegexOptionsExtensions.cs" />
-        <Compile Include="..\Playwright\Helpers\Paths.cs" Link="Paths.cs" />
+        <Compile Include="..\Playwright\Helpers\Driver.cs" Link="Driver.cs" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Playwright\Playwright.csproj" />

--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -24,12 +24,13 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Playwright.Helpers
 {
-    internal static class Paths
+    internal static class Driver
     {
         internal static string GetExecutablePath()
         {
@@ -81,6 +82,24 @@ namespace Microsoft.Playwright.Helpers
             }
 
             return Path.Combine(driversPath, ".playwright", "node", platformId, runnerName);
+        }
+
+        internal static Dictionary<string, string> GetEnvironmentVariables()
+        {
+            var environmentVariables = new Dictionary<string, string>();
+            environmentVariables.Add("PW_CLI_TARGET_LANG", "csharp");
+            environmentVariables.Add("PW_CLI_TARGET_LANG_VERSION", Environment.Version.ToString());
+            environmentVariables.Add("PW_CLI_DISPLAY_VERSION", GetSemVerPackageVersion());
+            return environmentVariables;
+        }
+
+        private static string GetSemVerPackageVersion()
+        {
+            // AssemblyName.Version returns a 4 digit version number, this method
+            // drops the last number which represents the build revision.
+            string version = typeof(Driver).Assembly.GetName().Version.ToString();
+            string[] versionParts = version.Split('.');
+            return $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}";
         }
     }
 }

--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Playwright
             string pwPath = null;
             try
             {
-                pwPath = Paths.GetExecutablePath();
+                pwPath = Driver.GetExecutablePath();
             }
             catch
             {
@@ -58,14 +58,15 @@ namespace Microsoft.Playwright
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
             };
+            foreach (var pair in Driver.GetEnvironmentVariables())
+            {
+                playwrightStartInfo.EnvironmentVariables[pair.Key] = pair.Value;
+            }
 
             using var pwProcess = new Process()
             {
                 StartInfo = playwrightStartInfo,
             };
-
-            playwrightStartInfo.EnvironmentVariables.Add("PW_CLI_TARGET_LANG", "csharp");
-            playwrightStartInfo.EnvironmentVariables.Add("PW_CLI_DISPLAY_VERSION", GetSemVerPackageVersion());
 
             using var outputWaitHandle = new AutoResetEvent(false);
             using var errorWaitHandle = new AutoResetEvent(false);
@@ -109,15 +110,6 @@ namespace Microsoft.Playwright
         {
             Console.Error.WriteLine("\x1b[91m" + error + "\x1b[0m");
             return 1;
-        }
-
-        private static string GetSemVerPackageVersion()
-        {
-            // AssemblyName.Version returns a 4 digit version number, this method
-            // drops the last number which represents the build revision.
-            string version = typeof(Playwright).Assembly.GetName().Version.ToString();
-            string[] versionParts = version.Split('.');
-            return $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}";
         }
     }
 }

--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -115,18 +115,24 @@ namespace Microsoft.Playwright.Transport
         }
 
         private static Process GetProcess()
-            => new()
+        {
+            var startInfo = new ProcessStartInfo(Driver.GetExecutablePath())
             {
-                StartInfo =
-                {
-                    FileName = Paths.GetExecutablePath(),
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardInput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true,
-                },
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
             };
+            foreach (var pair in Driver.GetEnvironmentVariables())
+            {
+                startInfo.EnvironmentVariables[pair.Key] = pair.Value;
+            }
+            return new()
+            {
+                StartInfo = startInfo,
+            };
+        }
 
         private static void ScheduleTransportTask(Func<CancellationToken, Task> func, CancellationToken cancellationToken)
             => Task.Factory.StartNew(() => func(cancellationToken), cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Current);


### PR DESCRIPTION
Fixes #1932

Example values:

```
PW_CLI_TARGET_LANG_VERSION: '6.0.0',
PW_CLI_TARGET_LANG: 'csharp',
PW_CLI_DISPLAY_VERSION: '1.17.1',
```