### PR TITLE
copy node folder based on platform

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_GetPlaywrightCopyItems">
+  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="ProcessFrameworkReferences">
     <PropertyGroup>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == ''">%(RuntimePack.RuntimeIdentifier)</PlaywrightPlatform>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</PlaywrightPlatform>
@@ -27,10 +27,14 @@
         <PlaywrightFolder>package\</PlaywrightFolder>
       </_PlaywrightCopyItems>
     </ItemGroup>
-  </Target>
-  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="_GetPlaywrightCopyItems">
-    <Message Text="[Playwright] Copying drivers from $(MSBuildThisFileDirectory) to $(OutputPath)..." />
-    <Copy SourceFiles="@(_PlaywrightCopyItems)" DestinationFiles="@(_PlaywrightCopyItems->'$(OutDir).playwright\%(PlaywrightFolder)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
+    <ItemGroup>
+      <Content Include="@(_PlaywrightCopyItems)">
+        <Link>.playwright\%(_PlaywrightCopyItems.PlaywrightFolder)%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <PublishState>Included</PublishState>
+        <Visible>false</Visible>
+      </Content>
+    </ItemGroup>
   </Target>
   <Target Name="CopyRuntimeConfigToOutput" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Playwright.runtimeconfig.json')">
@@ -45,10 +49,6 @@
     </ItemGroup>
     <Message Text="[Playwright] Copying shell script from $(MSBuildThisFileDirectory) to $(OutputPath)..." />
     <Copy SourceFiles="@(_CopyItemsShell)" DestinationFiles="@(_CopyItemsShell->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
-  </Target>
-  <Target Name="PlaywrightCopyAfterPublish" AfterTargets="Publish" DependsOnTargets="_GetPlaywrightCopyItems">
-    <Message Text="[Playwright] Copying files to publish folder..."/>
-    <Copy SourceFiles="@(_PlaywrightCopyItems)" DestinationFiles="@(_PlaywrightCopyItems->'$(PublishDir)\.playwright\%(PlaywrightFolder)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
   <Target Name="PlaywrightBuildCleanup" AfterTargets="Clean">
     <Message Text="[Playwright] Cleaning up .playwright folder and artifacts..."/>

--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -1,32 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="CopyFilesToOutputDirectory">
+  <Target Name="_GetPlaywrightCopyItems">
+    <PropertyGroup>
+      <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == ''">%(RuntimePack.RuntimeIdentifier)</PlaywrightPlatform>
+      <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</PlaywrightPlatform>
+      <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</PlaywrightPlatform>
+      <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</PlaywrightPlatform>
+    </PropertyGroup>
     <ItemGroup>
-      <_CopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\**" />
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux\**" Condition="$(PlaywrightPlatform.Contains('linux'))">
+        <PlaywrightFolder>node\linux\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="$(PlaywrightPlatform.Contains('win'))">
+        <PlaywrightFolder>node\win32_x64\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\mac\**" Condition="$(PlaywrightPlatform.Contains('osx'))">
+        <PlaywrightFolder>node\mac\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\**" Condition="'@(_PlaywrightCopyItems->Count())' == '0'">
+        <PlaywrightFolder>node\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\LICENSE">
+        <PlaywrightFolder>node\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\package\**">
+        <PlaywrightFolder>package\</PlaywrightFolder>
+      </_PlaywrightCopyItems>
     </ItemGroup>
+  </Target>
+  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="_GetPlaywrightCopyItems">
     <Message Text="[Playwright] Copying drivers from $(MSBuildThisFileDirectory) to $(OutputPath)..." />
-    <Copy SourceFiles="@(_CopyItems)" DestinationFiles="@(_CopyItems->'$(OutDir).playwright\%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(_PlaywrightCopyItems)" DestinationFiles="@(_PlaywrightCopyItems->'$(OutDir).playwright\%(PlaywrightFolder)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
   <Target Name="CopyRuntimeConfigToOutput" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Playwright.runtimeconfig.json')">
       <_CopyRuntimeConfigItems Include="$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Playwright.runtimeconfig.json" />
     </ItemGroup>
     <Message Text="[Playwright] Copying config from $(MSBuildThisFileDirectory)..\lib\$(TargetFramework) to $(OutDir)..." />
-    <Copy SourceFiles="@(_CopyRuntimeConfigItems)" DestinationFiles="@(_CopyRuntimeConfigItems->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(_CopyRuntimeConfigItems)" DestinationFiles="@(_CopyRuntimeConfigItems->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
   <Target Name="CopyPlaywrightShellToOutput" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
       <_CopyItemsShell Include="$(MSBuildThisFileDirectory)playwright.ps1" />
     </ItemGroup>
     <Message Text="[Playwright] Copying shell script from $(MSBuildThisFileDirectory) to $(OutputPath)..." />
-    <Copy SourceFiles="@(_CopyItemsShell)" DestinationFiles="@(_CopyItemsShell->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(_CopyItemsShell)" DestinationFiles="@(_CopyItemsShell->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
-  <Target Name="PlaywrightCopyAfterPublish" AfterTargets="Publish">
-    <ItemGroup>
-      <_PublishCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\**" />
-    </ItemGroup>
+  <Target Name="PlaywrightCopyAfterPublish" AfterTargets="Publish" DependsOnTargets="_GetPlaywrightCopyItems">
     <Message Text="[Playwright] Copying files to publish folder..."/>
-    <Copy SourceFiles="@(_PublishCopyItems)" DestinationFiles="@(_PublishCopyItems->'$(PublishDir)\.playwright\%(RecursiveDir)%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(_PlaywrightCopyItems)" DestinationFiles="@(_PlaywrightCopyItems->'$(PublishDir)\.playwright\%(PlaywrightFolder)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
   </Target>
   <Target Name="PlaywrightBuildCleanup" AfterTargets="Clean">
     <Message Text="[Playwright] Cleaning up .playwright folder and artifacts..."/>

--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="ProcessFrameworkReferences">
+  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="BeforeBuild">
     <PropertyGroup>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == ''">%(RuntimePack.RuntimeIdentifier)</PlaywrightPlatform>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</PlaywrightPlatform>

--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -7,7 +7,7 @@
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</PlaywrightPlatform>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</PlaywrightPlatform>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(PlaywrightPlatform)' != 'none'">
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux\**" Condition="$(PlaywrightPlatform.Contains('linux'))">
         <PlaywrightFolder>node\linux\</PlaywrightFolder>
       </_PlaywrightCopyItems>


### PR DESCRIPTION
This will by default only copy the node platform folder for the current platform.
The `RuntimeIdentifier` will override it, so you could do:
```
dotnet publish -r linux-x64
dotnet publish -r win-x64
dotnet publish -r osx-x64
```
and it will copy the correct platform folder even when the command is run on another platform. Even
```
dotnet publish -r ubuntu-x64
```
works because `RuntimePack.RuntimeIdentifier` will resolve to `linux-x64`.

To go back to the old behavior of copying all node platforms add the following to your project file:
```xml
<PropertyGroup>
  <PlaywrightPlatform>all</PlaywrightPlatform>
</PropertyGroup>
```` 
If the platform is unknown (which includes `all`) it will also copy everything.

There is also the option of not copying the `.playwright` folder at all by using:
```xml
<PropertyGroup>
  <PlaywrightPlatform>none</PlaywrightPlatform>
</PropertyGroup>
```` 

Fixes https://github.com/microsoft/playwright-dotnet/issues/1845
Fixes #1952
Fixes #1915

Related:
https://github.com/microsoft/playwright-dotnet/issues/1850#issuecomment-989621343
https://github.com/microsoft/playwright-dotnet/issues/1803#issuecomment-953359568