### PR TITLE
avoid double Disconnect / Close events

### DIFF
--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -199,9 +199,12 @@ namespace Microsoft.Playwright.Core
 
         internal void DidClose()
         {
-            IsConnected = false;
-            Disconnected?.Invoke(this, this);
-            _closedTcs.TrySetResult(true);
+            if (IsConnected)
+            {
+                IsConnected = false;
+                Disconnected?.Invoke(this, this);
+                _closedTcs.TrySetResult(true);
+            }
         }
     }
 }

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -138,6 +138,8 @@ namespace Microsoft.Playwright.Core
 
         internal BrowserContextChannel Channel { get; }
 
+        internal bool IsClosed { get; private set; }
+
         internal List<Page> PagesList { get; } = new();
 
         internal Page OwnerPage { get; set; }
@@ -411,13 +413,17 @@ namespace Microsoft.Playwright.Core
 
         internal void OnClose()
         {
-            if (Browser != null)
+            if (!IsClosed)
             {
-                ((Browser)Browser).BrowserContextsList.Remove(this);
-            }
+                IsClosed = true;
+                if (Browser != null)
+                {
+                    ((Browser)Browser).BrowserContextsList.Remove(this);
+                }
 
-            Close?.Invoke(this, this);
-            _closeTcs.TrySetResult(true);
+                Close?.Invoke(this, this);
+                _closeTcs.TrySetResult(true);
+            }
         }
 
         private void Channel_OnPage(object sender, BrowserContextPageEventArgs e)

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -1001,10 +1001,13 @@ namespace Microsoft.Playwright.Core
 
         internal void OnClose()
         {
-            IsClosed = true;
-            Context?.PagesList.Remove(this);
-            RejectPendingOperations(false);
-            Close?.Invoke(this, this);
+            if (!IsClosed)
+            {
+                IsClosed = true;
+                Context?.PagesList.Remove(this);
+                RejectPendingOperations(false);
+                Close?.Invoke(this, this);
+            }
         }
 
         private void Channel_Crashed(object sender, EventArgs e)


### PR DESCRIPTION
The `IBrowser.Disconnect` / `IBrowserContext.Close` / `IPage.Close` events are raised from two different callsites when using websockets which could lead to them being fired twice. Which is why the test was flaky.
Please let me know if you prefer `Interlocked` for that instead.

Fixes #1946