### PR TITLE
fix ProxyTests to not use foo.zone as it is now a site that actually …

### DIFF
--- a/src/Playwright.Tests/ProxyTests.cs
+++ b/src/Playwright.Tests/ProxyTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Playwright.Tests
             var proxy = new Proxy
             {
                 Server = $"localhost:{Server.Port}",
-                Bypass = "non-existent1.com, .non-existent2.com, .zone",
+                Bypass = "non-existent1.com, .non-existent2.com, .another.test",
             };
 
             await using var browser = await BrowserType.LaunchAsync(new() { Proxy = proxy });
@@ -99,7 +99,7 @@ namespace Microsoft.Playwright.Tests
 
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://non-existent1.com/target.html"));
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://sub.non-existent2.com/target.html"));
-            await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://non-existent3.zone/target.html"));
+            await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://foo.is.the.another.test/target.html"));
         }
     }
 }

--- a/src/Playwright.Tests/ProxyTests.cs
+++ b/src/Playwright.Tests/ProxyTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Playwright.Tests
 
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://non-existent1.com/target.html"));
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://sub.non-existent2.com/target.html"));
-            await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://foo.zone/target.html"));
+            await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync("http://non-existent3.zone/target.html"));
         }
     }
 }


### PR DESCRIPTION
…exists

```
Domain Name: foo.zone
Registry Domain ID: 6719081dc20f41e1b41868899cba1e1a-DONUTS
Registrar WHOIS Server: whois.psi-usa.info
Registrar URL: http://www.psi-usa.info
Updated Date: 2022-01-22T18:58:48Z
Creation Date: 2022-01-22T18:34:51Z
```
https://www.whois.com/whois/foo.zone

CI failures before: https://github.com/microsoft/playwright-dotnet/actions/runs/1735462097