### PR TITLE
chore: catch all route methods when page closes

### DIFF
--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Playwright.Core
                 }
             }
 
-            _ = route.ContinueInternalAsync(new());
+            _ = route.ContinueAsync().ConfigureAwait(false);
         }
 
         internal async Task DisableInterceptionAsync()

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -120,6 +120,9 @@ namespace Microsoft.Playwright.Core
             _defaultNavigationTimeout = Context.DefaultNavigationTimeout;
             _defaultTimeout = Context.DefaultTimeout;
             _initializer = initializer;
+
+            Close += (_, _) => ClosedOrCrashedTcs.TrySetResult(true);
+            Crash += (_, _) => ClosedOrCrashedTcs.TrySetResult(true);
         }
 
         public event EventHandler<IConsoleMessage> Console;
@@ -272,6 +275,8 @@ namespace Microsoft.Playwright.Core
                 _ = _channel.SetDefaultNavigationTimeoutNoReplyAsync(value);
             }
         }
+
+        internal TaskCompletionSource<bool> ClosedOrCrashedTcs { get; } = new();
 
         public IFrame Frame(string name)
             => Frames.FirstOrDefault(f => f.Name == name);


### PR DESCRIPTION
Backports: https://github.com/microsoft/playwright/commit/3cc839e01327dbf5b6e2a889da8da373b7efd503
Extracted from: #1938
Relates #1754

We'll follow-up on the unhandled exceptions once we add the bot for it in upcoming patches.