### PR TITLE
cherry-pick(release-1.18): fix: save trace without path

### DIFF
--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -143,6 +143,22 @@ namespace Microsoft.Playwright.Tests
             Assert.AreEqual(sourceTraceFileContent, currentFileContent);
         }
 
+        [PlaywrightTest("tracing.spec.ts", "should not throw when stopping without start but not exporting")]
+        public async Task ShouldNotThrowWhenStoppingWithoutStartButNotExporting()
+        {
+            await Context.Tracing.StopAsync();
+        }
+
+        [PlaywrightTest("tracing.spec.ts", "should not throw when stopping without passing a trace file")]
+        public async Task ShouldNotThrowWhenStoppingWithoutPath()
+        {
+            await Context.Tracing.StartAsync(new()
+            {
+                Snapshots = true,
+            });
+            await Context.Tracing.StopAsync();
+        }
+
         private static (IReadOnlyList<TraceEventEntry> Events, Dictionary<string, byte[]> Resources) ParseTrace(string path)
         {
             Dictionary<string, byte[]> resources = new();

--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Playwright.Core
 
             // Not interested in artifacts.
             if (string.IsNullOrEmpty(filePath))
-                throw new PlaywrightException("Specified path was invalid or empty. Trace could not be saved.");
+                return;
 
             // The artifact may be missing if the browser closed while stopping tracing.
             if (artifact == null)


### PR DESCRIPTION
#1965