### PR TITLE
chore: ensure no unhandled exceptions are thrown

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,12 +39,12 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         env:
           BROWSER: ${{ matrix.browser }}
-        run: dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx;LogFileName=TestResults.xml" -- NUnit.NumberOfTestWorkers=1
+        run: dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx;LogFileName=TestResults.xml"
       - name: Running tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
           BROWSER: ${{ matrix.browser }}
-        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx" -- NUnit.NumberOfTestWorkers=1
+        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net5.0 --logger "trx"
 
   test-net31:
     name: chromium/ubuntu/.NET 3.1
@@ -71,4 +71,4 @@ jobs:
       - name: Running tests
         env:
           BROWSER: CHROMIUM
-        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f netcoreapp3.1 --logger "trx" -- NUnit.NumberOfTestWorkers=1
+        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f netcoreapp3.1 --logger "trx"

--- a/src/Playwright.Tests/BrowserContextCSPTests.cs
+++ b/src/Playwright.Tests/BrowserContextCSPTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Playwright.Tests
             {
                 var page = await context.NewPageAsync();
                 await page.GotoAsync(Server.Prefix + "/csp.html");
-                await page.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }).ContinueWith(_ => Task.CompletedTask);
+                var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }));
+                TestUtils.AssertCSPError(exception.Message);
                 Assert.Null(await page.EvaluateAsync("window.__injected"));
             }
             // By-pass CSP and try one more time.
@@ -61,7 +62,8 @@ namespace Microsoft.Playwright.Tests
             {
                 var page = await context.NewPageAsync();
                 await page.GotoAsync(Server.EmptyPage);
-                await page.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }).ContinueWith(_ => Task.CompletedTask);
+                var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }));
+                TestUtils.AssertCSPError(exception.Message);
                 Assert.Null(await page.EvaluateAsync("window.__injected"));
             }
 
@@ -99,7 +101,8 @@ namespace Microsoft.Playwright.Tests
 
                 // Make sure CSP prohibits addScriptTag in an iframe.
                 var frame = await FrameUtils.AttachFrameAsync(page, "frame1", Server.Prefix + "/csp.html");
-                await frame.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }).ContinueWith(_ => Task.CompletedTask);
+                var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => frame.AddScriptTagAsync(new() { Content = "window.__injected = 42;" }));
+                TestUtils.AssertCSPError(exception.Message);
                 Assert.Null(await frame.EvaluateAsync<int?>("() => window.__injected"));
             }
 

--- a/src/Playwright.Tests/DefaultBrowserContext1Tests.cs
+++ b/src/Playwright.Tests/DefaultBrowserContext1Tests.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Playwright.Tests
             Assert.IsFalse(cookie.Secure);
             Assert.AreEqual(TestConstants.IsChromium ? SameSiteAttribute.Lax : SameSiteAttribute.None, cookie.SameSite);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "context.addCookies() should work")]
@@ -86,8 +86,8 @@ namespace Microsoft.Playwright.Tests
             Assert.IsFalse(cookie.Secure);
             Assert.AreEqual(TestConstants.IsChromium ? SameSiteAttribute.Lax : SameSiteAttribute.None, cookie.SameSite);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "context.clearCookies() should work")]
@@ -119,8 +119,8 @@ namespace Microsoft.Playwright.Tests
             Assert.That(await page.Context.CookiesAsync(), Is.Empty);
             Assert.That(await page.EvaluateAsync<string>(@"() => document.cookie"), Is.Empty);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should(not) block third party cookies")]
@@ -162,8 +162,8 @@ namespace Microsoft.Playwright.Tests
                 Assert.That(cookies, Is.Empty);
             }
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support viewport option")]
@@ -182,8 +182,8 @@ namespace Microsoft.Playwright.Tests
             page = await context.NewPageAsync();
             await TestUtils.VerifyViewportAsync(page, 456, 789);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support deviceScaleFactor option")]
@@ -196,8 +196,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual(3, await page.EvaluateAsync<int>("window.devicePixelRatio"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support userAgent option")]
@@ -216,8 +216,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual("foobar", userAgent);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support bypassCSP option")]
@@ -232,8 +232,8 @@ namespace Microsoft.Playwright.Tests
             await page.AddScriptTagAsync(new() { Content = "window.__injected = 42;" });
             Assert.AreEqual(42, await page.EvaluateAsync<int>("window.__injected"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support javascriptEnabled option")]
@@ -256,8 +256,8 @@ namespace Microsoft.Playwright.Tests
                 StringAssert.Contains("something is not defined", exception.Message);
             }
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support httpCredentials option")]
@@ -276,8 +276,8 @@ namespace Microsoft.Playwright.Tests
             var response = await page.GotoAsync(Server.Prefix + "/playground.html");
             Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support offline option")]
@@ -290,8 +290,8 @@ namespace Microsoft.Playwright.Tests
 
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => page.GotoAsync(Server.EmptyPage));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-1.spec.ts", "should support acceptDownloads option")]

--- a/src/Playwright.Tests/DefaultBrowsercontext2Tests.cs
+++ b/src/Playwright.Tests/DefaultBrowsercontext2Tests.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Playwright.Tests
             await page.GotoAsync(Server.Prefix + "/mobile.html");
             Assert.True(await page.EvaluateAsync<bool>("() => 'ontouchstart' in window"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should work in persistent context")]
@@ -66,8 +66,8 @@ namespace Microsoft.Playwright.Tests
             await page.GotoAsync(Server.EmptyPage);
             Assert.AreEqual(980, await page.EvaluateAsync<int>("() => window.innerWidth"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support colorScheme option")]
@@ -81,8 +81,8 @@ namespace Microsoft.Playwright.Tests
             Assert.False(await page.EvaluateAsync<bool?>("() => matchMedia('(prefers-color-scheme: light)').matches"));
             Assert.True(await page.EvaluateAsync<bool?>("() => matchMedia('(prefers-color-scheme: dark)').matches"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support reducedMotion option")]
@@ -96,8 +96,8 @@ namespace Microsoft.Playwright.Tests
             Assert.True(await page.EvaluateAsync<bool?>("() => matchMedia('(prefers-reduced-motion: reduce)').matches"));
             Assert.False(await page.EvaluateAsync<bool?>("() => matchMedia('(prefers-reduced-motion: no-preference)').matches"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support timezoneId option")]
@@ -110,8 +110,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual("Sat Nov 19 2016 13:12:34 GMT-0500 (Eastern Standard Time)", await page.EvaluateAsync<string>("() => new Date(1479579154987).toString()"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support locale option")]
@@ -124,8 +124,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual("fr-CH", await page.EvaluateAsync<string>("() => navigator.language"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support geolocation and permissions options")]
@@ -148,8 +148,8 @@ namespace Microsoft.Playwright.Tests
             Assert.AreEqual(10, geolocation.Latitude);
             Assert.AreEqual(10, geolocation.Longitude);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support ignoreHTTPSErrors option")]
@@ -163,8 +163,8 @@ namespace Microsoft.Playwright.Tests
             var response = await page.GotoAsync(HttpsServer.Prefix + "/empty.html");
             Assert.True(response.Ok);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should support extraHTTPHeaders option")]
@@ -186,8 +186,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.AreEqual("bar", fooHeader);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should accept userDataDir")]
@@ -227,16 +227,13 @@ namespace Microsoft.Playwright.Tests
                 await page.GotoAsync(Server.EmptyPage);
                 Assert.That("hello", Is.Not.EqualTo(await page.EvaluateAsync<string>("() => localStorage.hey")));
             }
-
-            userDataDir2.Dispose();
-            userDataDir.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should restore cookies from userDataDir")]
         [Skip(SkipAttribute.Targets.Chromium | SkipAttribute.Targets.Windows)]
         public async Task ShouldRestoreCookiesFromUserDataDir()
         {
-            var userDataDir = new TempDirectory();
+            using var userDataDir = new TempDirectory();
 
             await using (var browserContext = await BrowserType.LaunchPersistentContextAsync(userDataDir.Path))
             {
@@ -257,16 +254,13 @@ namespace Microsoft.Playwright.Tests
                 Assert.AreEqual("doSomethingOnlyOnce=true", await page.EvaluateAsync<string>("() => document.cookie"));
             }
 
-            var userDataDir2 = new TempDirectory();
+            using var userDataDir2 = new TempDirectory();
             await using (var browserContext2 = await BrowserType.LaunchPersistentContextAsync(userDataDir2.Path))
             {
                 var page = await browserContext2.NewPageAsync();
                 await page.GotoAsync(Server.EmptyPage);
                 Assert.That("doSomethingOnlyOnce=true", Is.Not.EqualTo(await page.EvaluateAsync<string>("() => document.cookie")));
             }
-
-            userDataDir2.Dispose();
-            userDataDir.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should have default URL when launching browser")]
@@ -277,19 +271,18 @@ namespace Microsoft.Playwright.Tests
             string[] urls = context.Pages.Select(p => p.Url).ToArray();
             Assert.AreEqual(new[] { "about:blank" }, urls);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should throw if page argument is passed")]
         [Skip(SkipAttribute.Targets.Firefox)]
         public async Task ShouldThrowIfPageArgumentIsPassed()
         {
-            var tmp = new TempDirectory();
+            using var tmp = new TempDirectory();
             var args = new[] { Server.EmptyPage };
             await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() =>
                 BrowserType.LaunchPersistentContextAsync(tmp.Path, new() { Args = args }));
-            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "should have passed URL when launching with ignoreDefaultArgs: true")]
@@ -320,8 +313,8 @@ namespace Microsoft.Playwright.Tests
 
             Assert.True(closed);
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         [PlaywrightTest("defaultbrowsercontext-2.spec.ts", "coverage should work")]
@@ -374,8 +367,8 @@ namespace Microsoft.Playwright.Tests
             Assert.AreEqual("hello", await page.InnerHTMLAsync("css=div"));
             Assert.AreEqual("hello", await page.InnerHTMLAsync("defaultContextCSS=div"));
 
-            tmp.Dispose();
             await context.DisposeAsync();
+            tmp.Dispose();
         }
 
         private async Task<(TempDirectory tmp, IBrowserContext context, IPage page)> LaunchAsync(BrowserTypeLaunchPersistentContextOptions options = null)

--- a/src/Playwright.Tests/DownloadTests.cs
+++ b/src/Playwright.Tests/DownloadTests.cs
@@ -412,8 +412,10 @@ namespace Microsoft.Playwright.Tests
             {
                 expected += $"a{i}";
             }
-            using var stream = await download.CreateReadStreamAsync();
-            Assert.AreEqual(expected, await new StreamReader(stream).ReadToEndAsync());
+            using (var stream = await download.CreateReadStreamAsync())
+            {
+                Assert.AreEqual(expected, await new StreamReader(stream).ReadToEndAsync());
+            }
 
             await page.CloseAsync();
         }

--- a/src/Playwright.Tests/DownloadsPathTests.cs
+++ b/src/Playwright.Tests/DownloadsPathTests.cs
@@ -170,10 +170,10 @@ namespace Microsoft.Playwright.Tests
         }
 
         [TearDown]
-        public Task DisposeAsync()
+        public async Task DisposeAsync()
         {
-            _tmp?.Dispose();
-            return _browser.CloseAsync();
+            await _browser.CloseAsync();
+            _tmp.Dispose();
         }
     }
 }

--- a/src/Playwright.Tests/Helpers/TempDirectory.cs
+++ b/src/Playwright.Tests/Helpers/TempDirectory.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Playwright.Tests
                     Directory.Delete(path, true);
                     return;
                 }
-                catch (IOException)
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
                 {
                     await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
                     if (retryDelay < maxDelayInMs)

--- a/src/Playwright.Tests/PageClickTimeout2Tests.cs
+++ b/src/Playwright.Tests/PageClickTimeout2Tests.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Playwright.Tests
         {
             await Page.GotoAsync(Server.Prefix + "/input/button.html");
             await Page.EvalOnSelectorAsync("button", "b => b.style.visibility = 'hidden'");
-            var clickTask = Page.ClickAsync("button", new() { Timeout = 5000 });
             var exception = await PlaywrightAssert.ThrowsAsync<TimeoutException>(()
                 => Page.ClickAsync("button", new() { Timeout = 5000 }));
 

--- a/src/Playwright.Tests/PageGotoTests.cs
+++ b/src/Playwright.Tests/PageGotoTests.cs
@@ -259,7 +259,8 @@ namespace Microsoft.Playwright.Tests
         public async Task ShouldNotCrashWhenNavigatingToBadSSLAfterACrossOriginNavigation()
         {
             await Page.GotoAsync(Server.CrossProcessPrefix + "/empty.html");
-            await Page.GotoAsync(HttpsServer.Prefix + "/empty.html").ContinueWith(_ => { });
+            var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.GotoAsync(HttpsServer.Prefix + "/empty.html"));
+            TestUtils.AssertSSLError(exception.Message);
         }
 
         [PlaywrightTest("page-goto.spec.ts", "should throw if networkidle0 is passed as an option")]

--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -275,8 +275,9 @@ namespace Microsoft.Playwright.Tests
 
             IRequest failedRequest = null;
             Page.RequestFailed += (_, e) => failedRequest = e;
-            await Page.GotoAsync(Server.EmptyPage).ContinueWith(_ => { });
+            var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.GotoAsync(Server.EmptyPage));
             Assert.NotNull(failedRequest);
+            StringAssert.StartsWith(failedRequest.Failure, exception.Message);
             if (TestConstants.IsWebKit)
             {
                 Assert.AreEqual("Request intercepted", failedRequest.Failure);

--- a/src/Playwright.Tests/TestUtils.cs
+++ b/src/Playwright.Tests/TestUtils.cs
@@ -66,6 +66,22 @@ namespace Microsoft.Playwright.Tests
             }
         }
 
+        internal static void AssertCSPError(string errorMessage)
+        {
+            if (TestConstants.IsWebKit)
+            {
+                StringAssert.StartsWith("Refused to execute a script because its hash, its nonce, or 'unsafe-inline' appears in neither the script-src directive nor the default-src directive of the Content Security Policy.", errorMessage);
+            }
+            else if (TestConstants.IsFirefox)
+            {
+                StringAssert.StartsWith("[JavaScript Error: \"Content Security Policy: The page’s settings blocked the loading of a resource at inline (“default-src”).\"", errorMessage);
+            }
+            else
+            {
+                StringAssert.StartsWith("Refused to execute inline script because it violates the following Content Security Policy directive: \"default-src 'self'\".", errorMessage);
+            }
+        }
+
         /// <summary>
         /// Removes as much whitespace as possible from a given string. Whitespace
         /// that separates letters and/or digits is collapsed to a space character.

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Playwright.Tests
         private static (IReadOnlyList<TraceEventEntry> Events, Dictionary<string, byte[]> Resources) ParseTrace(string path)
         {
             Dictionary<string, byte[]> resources = new();
-            var archive = ZipFile.OpenRead(path);
+            using var archive = ZipFile.OpenRead(path);
             foreach (var entry in archive.Entries)
             {
                 var memoryStream = new MemoryStream();

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -145,13 +145,7 @@ namespace Microsoft.Playwright.Core
 
             void ClosePipe()
             {
-                try
-                {
-                    pipe.CloseAsync().ConfigureAwait(false);
-                }
-                catch (Exception)
-                {
-                }
+                pipe.CloseAsync().IgnoreException();
             }
 #pragma warning disable CA2000 // Dispose objects before losing scope
             Connection connection = new Connection();

--- a/src/Playwright/Helpers/TaskHelper.cs
+++ b/src/Playwright/Helpers/TaskHelper.cs
@@ -190,11 +190,15 @@ namespace Microsoft.Playwright.Helpers
             }
 
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            using var cancellationToken = new CancellationTokenSource();
-            cancellationToken.CancelAfter(timeout);
+            using var cancellationToken = new CancellationTokenSource(timeout);
             using (cancellationToken.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
             {
-                return tcs.Task == await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+                if (tcs.Task == await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
+                {
+                    task.IgnoreException();
+                    return true;
+                }
+                return false;
             }
         }
 

--- a/src/Playwright/Helpers/TaskHelper.cs
+++ b/src/Playwright/Helpers/TaskHelper.cs
@@ -197,5 +197,10 @@ namespace Microsoft.Playwright.Helpers
                 return tcs.Task == await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
             }
         }
+
+        public static void IgnoreException(this Task task)
+        {
+            _ = task.ContinueWith(t => t.Exception.Handle(_ => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+        }
     }
 }


### PR DESCRIPTION
- Adds an `TaskScheduler.UnobservedTaskException` event handler for each test to check if there are any unobserved exceptions
- Sets `[LevelOfParallelism(1)]` to ensure that each test is run in sequence. This was already the case for CI where `NUnit.NumberOfTestWorkers=1` is used, which now could be removed. And now it also applies when run locally.
https://github.com/microsoft/playwright-dotnet/blob/c12b4fcd8061b396ef4d4587dafd9b876202f009/.github/workflows/tests.yml#L42
- Add `IgnoreException` utility which marks all exceptions as handled if a task faulted.
- Fixes dispose order for browser / browsercontext and tempdirectory to avoid unnecessary exceptions. Deleting the tempdirectory before disposing the browser throws a `UnauthorizedAccessException`.

Fixes #1963