### PR TITLE
don't suppress route exceptions when page is still open

### DIFF
--- a/src/Playwright.Tests/PageRequestContinueTests.cs
+++ b/src/Playwright.Tests/PageRequestContinueTests.cs
@@ -127,5 +127,26 @@ namespace Microsoft.Playwright.Tests
             await tsc.Task;
             await done;
         }
+
+        [PlaywrightTest("page-request-continue.spec.ts", "should not allow changing protocol when overriding url")]
+        public async Task ShouldNotAllowChangingProtocolWhenOverridingUrl()
+        {
+            PlaywrightException exception = null;
+            await Page.RouteAsync("**/empty.html", async (route) =>
+            {
+                try
+                {
+                    await route.ContinueAsync(new RouteContinueOptions { Url = "file:///tmp/foo" });
+                }
+                catch (PlaywrightException ex)
+                {
+                    exception = ex;
+                    await route.ContinueAsync();
+                }
+            });
+            await Page.GotoAsync(Server.EmptyPage);
+            Assert.NotNull(exception);
+            Assert.AreEqual("New URL must have same protocol as overridden URL", exception.Message);
+        }
     }
 }

--- a/src/Playwright/Core/Route.cs
+++ b/src/Playwright/Core/Route.cs
@@ -92,9 +92,13 @@ namespace Microsoft.Playwright.Core
             // When page closes or crashes, we catch any potential rejects from this Route.
             // Note that page could be missing when routing popup's initial request that
             // does not have a Page initialized just yet.
-            if (task != await Task.WhenAny(task.ContinueWith(t => t.Exception.Handle(_ => true), System.Threading.CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default), page.ClosedOrCrashedTcs.Task).ConfigureAwait(false))
+            if (task != await Task.WhenAny(task, page.ClosedOrCrashedTcs.Task).ConfigureAwait(false))
             {
                 task.IgnoreException();
+            }
+            else
+            {
+                await task.ConfigureAwait(false);
             }
         }
 

--- a/src/Playwright/Helpers/TaskHelper.cs
+++ b/src/Playwright/Helpers/TaskHelper.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Playwright.Helpers
             using var cancellationToken = new CancellationTokenSource(timeout);
             using (cancellationToken.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
             {
-                if (tcs.Task == await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
+                if (task != await Task.WhenAny(task, tcs.Task).ConfigureAwait(false))
                 {
                     task.IgnoreException();
                     return true;


### PR DESCRIPTION
follow up to https://github.com/microsoft/playwright-dotnet/pull/1973#discussion_r793594152

also added test from https://github.com/microsoft/playwright/blob/5ba7903ba098586a13745e0d7ac894f1d55d47aa/tests/page/page-request-continue.spec.ts#L65-L78