### PR TITLE
update Locator AllInnerText / AllTextContent

### DIFF
--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Playwright.Core
             => await EvaluateAllAsync<string[]>("ee => ee.map(e => e.innerText)").ConfigureAwait(false);
 
         public async Task<IReadOnlyList<string>> AllTextContentsAsync()
-            => await EvaluateAllAsync<string[]>("ee => ee.map(e => e.textContent || '')").ConfigureAwait(false); // we don't filter nulls, as per https://github.com/microsoft/playwright/blob/master/src/client/locator.ts#L205
+            => await EvaluateAllAsync<string[]>("ee => ee.map(e => e.textContent || '')").ConfigureAwait(false);
 
         public async Task<LocatorBoundingBoxResult> BoundingBoxAsync(LocatorBoundingBoxOptions options = null)
             => await WithElementAsync(


### PR DESCRIPTION
`Locator.AllInnerTextAsync` / `Locator.AllTextContentAsync` didn't dispose the intermediate `IElementHandle` objects which is what the first commit fixes.

The second commit changes these to use `Locator.EvaluateAllAsync` instead so there are no intermediate objects created in the first place which results in better performance and memory usage.
This is also what the JS version is using:
https://github.com/microsoft/playwright/blob/0606afb2e66737a352cf8627fa0260ea2fceb267/packages/playwright-core/src/client/locator.ts#L241
https://github.com/microsoft/playwright/blob/0606afb2e66737a352cf8627fa0260ea2fceb267/packages/playwright-core/src/client/locator.ts#L245

Please let me know which version is preferred.