### PR TITLE
treat non generic Task and VoidTaskResult as null in Binding

### DIFF
--- a/src/Playwright.Tests/PageExposeFunctionTests.cs
+++ b/src/Playwright.Tests/PageExposeFunctionTests.cs
@@ -241,6 +241,28 @@ namespace Microsoft.Playwright.Tests
         {
         }
 
+        [PlaywrightTest]
+        public async Task ShouldReturnNullForTask()
+        {
+            await Page.ExposeFunctionAsync("compute", () => Task.CompletedTask);
+            await Page.GotoAsync(Server.EmptyPage);
+            var result = await Page.EvaluateAsync(@"async function() {
+                return await compute();
+            }");
+            Assert.IsNull(result);
+        }
+
+        [PlaywrightTest]
+        public async Task ShouldReturnNullForTaskDelay()
+        {
+            await Page.ExposeFunctionAsync("compute", () => Task.Delay(100));
+            await Page.GotoAsync(Server.EmptyPage);
+            var result = await Page.EvaluateAsync(@"async function() {
+                return await compute();
+            }");
+            Assert.IsNull(result);
+        }
+
         internal class ComplexObject
         {
             public int x { get; set; }


### PR DESCRIPTION
Before non generic tasks and `VoidTaskResult`s were serialized as JSON objects which does not make much sense so lets treat them as `null` instead. E.g. `Task.CompletedTask` / `Task.Delay` or in general `Func<Task>`.

`Task.CompletedTask` is actually a [`Task<VoidTaskResult>`](https://github.com/dotnet/runtime/blob/6233735c37b1af9c182c28c9d74aeac0104785b8/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L1457-L1462). 
`Task.Delay` is a real [`Task`](https://github.com/dotnet/runtime/blob/6233735c37b1af9c182c28c9d74aeac0104785b8/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L5569-L5570).

A similar change was committed to a similar library: https://github.com/cefsharp/CefSharp/commit/cd225bc1697cc3001d4aa4c7e9ca4ac85a0cd810