### PR TITLE
chore: migrate tooling over to .NET 6

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -28,10 +28,17 @@ stages:
     steps:
 
     - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
+      displayName: 'Use .NET 5 SDK'
       inputs:
         packageType: sdk
         version: 5.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 6 SDK'
+      inputs:
+        packageType: sdk
+        version: 6.x
         installationPath: $(Agent.ToolsDirectory)/dotnet
 
     - task: MicroBuildSigningPlugin@3

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: |
+          5.0.x
+          6.0.x
     - name: Install dotnet-format
       run: dotnet tool install --global dotnet-format
     - name: Check formatting

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            5.0.x
+            6.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-net5:
-    name: Test Harness Tests .NET 5
+    name: Test Harness Tests .NET 6
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -20,7 +20,9 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            5.0.x
+            6.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: ./build.sh --download-driver

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-net5:
-    name: ${{ matrix.browser }}/${{ matrix.os }}/.NET 5
+    name: ${{ matrix.browser }}/${{ matrix.os }}/.NET 6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -25,12 +25,14 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            5.0.x
+            6.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: ./build.sh --download-driver
       - name: Building
-        run: dotnet build ./src
+        run: dotnet build -f net5.0 ./src
       - name: Installing Browsers and dependencies
         run: dotnet run --project ./src/Playwright/Playwright.csproj -f net5.0 -- install --with-deps ${{ matrix.browser }}
       - name: Running tests
@@ -49,14 +51,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET 5.0 # needed for our build steps
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: ./build.sh --download-driver

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -185,6 +185,7 @@ dotnet_diagnostic.SA1202.severity = none
 dotnet_diagnostic.SA1503.severity = none
 dotnet_diagnostic.RCS1075.severity = none
 dotnet_diagnostic.SA1402.severity = none
+dotnet_diagnostic.CA1844.severity = none
 
 [Playwright/Core/*.cs]
 dotnet_diagnostic.SA1118.severity = none # This should be removed when we finish

--- a/src/Common/Dependencies.props
+++ b/src/Common/Dependencies.props
@@ -10,11 +10,11 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.312">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.0.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Playwright/Core/Artifact.cs
+++ b/src/Playwright/Core/Artifact.cs
@@ -69,11 +69,13 @@ namespace Microsoft.Playwright.Core
                 return;
             }
             System.IO.Directory.CreateDirectory(Path.GetDirectoryName(path));
-            await using var stream = await _channel.SaveAsStreamAsync().ConfigureAwait(false);
-
-            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            var stream = await _channel.SaveAsStreamAsync().ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
             {
-                await stream.StreamImpl.CopyToAsync(fileStream).ConfigureAwait(false);
+                using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+                {
+                    await stream.StreamImpl.CopyToAsync(fileStream).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Macross.Json.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -78,7 +78,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="Roslynator.Analyzers" Version="3.1.0">
+    <PackageReference Update="Roslynator.Analyzers" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -143,7 +143,9 @@ namespace Microsoft.Playwright.Transport
                         object obj = propertyDescriptor.GetValue(args);
                         if (obj != null)
                         {
+#pragma warning disable CA1845 // Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring
                             string name = propertyDescriptor.Name.Substring(0, 1).ToLower() + propertyDescriptor.Name.Substring(1);
+#pragma warning restore CA2000 // Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring
                             sanitizedArgs.Add(name, obj);
                         }
                     }

--- a/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
+++ b/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Macross.Json.Extensions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
-        <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
+        <PackageReference Include="Roslynator.Analyzers" Version="4.0.2">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/1974
Relates https://github.com/microsoft/playwright-dotnet/pull/1884

Motivation: .NET 5 reaches EOL in May 8, 2022 since it was no LTS, LTS is .NET 6. There are no changes in the TFM so no user facing changes and only tooling.

