### PR TITLE
ChannelOwnerBase: move _objects.Clear() out of loop

### DIFF
--- a/src/Playwright/Transport/ChannelOwnerBase.cs
+++ b/src/Playwright/Transport/ChannelOwnerBase.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Playwright.Transport
             foreach (var item in _objects.Values)
             {
                 item.DisposeOwner();
-                _objects.Clear();
             }
+            _objects.Clear();
         }
     }
 }


### PR DESCRIPTION
Align with upstream: https://github.com/microsoft/playwright/blob/f82e09be044c78c04964162aeda3e03d82c1ed06/packages/playwright-core/src/client/channelOwner.ts#L68

`ConcurrentDictionary.Values` returns a new list which is why it didn't throw: 
https://github.com/dotnet/runtime/blob/ef817df491e87d1d5ffcd12e78d48c6520430be2/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs#L2142-L2174