### PR TITLE
fix: do not empty line on stderr on close

### DIFF
--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -45,7 +45,11 @@ namespace Microsoft.Playwright.Transport
             _process.StartInfo.Arguments = "run-driver";
             _process.Start();
             _process.Exited += (_, _) => Close("Process exited");
-            _process.ErrorDataReceived += (_, error) => LogReceived?.Invoke(this, error.Data);
+            _process.ErrorDataReceived += (_, error) =>
+            {
+                if (error.Data != null)
+                    LogReceived?.Invoke(this, error.Data);
+            };
             _process.BeginErrorReadLine();
 
             ScheduleTransportTask(GetResponseAsync, _readerCancellationSource.Token);


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/1998

(When the redirected stream is closed, a null line is sent to the event handler. see [here](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.datareceivedeventhandler?view=net-6.0#remarks)