### PR TITLE
chore: don't include PlaywrightCopyItems in pack

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -33,6 +33,7 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <PublishState>Included</PublishState>
         <Visible>false</Visible>
+        <Pack>false</Pack>
       </Content>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Fixes #2022 