### PR TITLE
chore: simplify ParseEvaluateResult for arrays

### DIFF
--- a/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
+++ b/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
@@ -317,16 +317,18 @@ namespace Microsoft.Playwright.Transport.Converters
 
             if (result.ValueKind == JsonValueKind.Array)
             {
+                var elementType = t.GetElementType();
                 var serializerOptions = JsonExtensions.GetNewDefaultSerializerOptions();
-                serializerOptions.Converters.Add(GetNewConverter(t.GetElementType()));
+                serializerOptions.Converters.Add(GetNewConverter(elementType));
 
-                var resultArray = new ArrayList();
+                var resultArray = Array.CreateInstance(elementType, result.GetArrayLength());
+                var i = 0;
                 foreach (var item in result.EnumerateArray())
                 {
-                    resultArray.Add(ParseEvaluateResult(item, t.GetElementType(), serializerOptions));
+                    resultArray.SetValue(ParseEvaluateResult(item, elementType, serializerOptions), i++);
                 }
 
-                return resultArray.ToArray(t.GetElementType());
+                return resultArray;
             }
 
             return result.ToObject(t);

--- a/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
+++ b/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
@@ -326,10 +326,7 @@ namespace Microsoft.Playwright.Transport.Converters
                     resultArray.Add(ParseEvaluateResult(item, t.GetElementType(), serializerOptions));
                 }
 
-                var destinationArray = Array.CreateInstance(t.GetElementType(), resultArray.Count);
-                Array.Copy(resultArray.ToArray(), destinationArray, resultArray.Count);
-
-                return destinationArray;
+                return resultArray.ToArray(t.GetElementType());
             }
 
             return result.ToObject(t);


### PR DESCRIPTION
which avoids creating intermediate arrays and coping between them.
The second commit uses `GetArrayLength` so the typed array can be directly created without going through an `ArrayList` first.