### PR TITLE
check namespace for null

### DIFF
--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -440,7 +440,11 @@ namespace Microsoft.Playwright.Transport
                 var sf = st.GetFrame(i);
                 string fileName = sf.GetFileName();
                 string cSharpNamespace = sf.GetMethod().ReflectedType.Namespace;
-                bool playwrightInternal = cSharpNamespace == "Microsoft.Playwright" || cSharpNamespace.StartsWith("Microsoft.Playwright.Core", StringComparison.InvariantCultureIgnoreCase) || cSharpNamespace.StartsWith("Microsoft.Playwright.Transport", StringComparison.InvariantCultureIgnoreCase) || cSharpNamespace.StartsWith("Microsoft.Playwright.Helpers", StringComparison.InvariantCultureIgnoreCase);
+                bool playwrightInternal = cSharpNamespace != null &&
+                                          (cSharpNamespace == "Microsoft.Playwright" ||
+                                          cSharpNamespace.StartsWith("Microsoft.Playwright.Core", StringComparison.InvariantCultureIgnoreCase) ||
+                                          cSharpNamespace.StartsWith("Microsoft.Playwright.Transport", StringComparison.InvariantCultureIgnoreCase) ||
+                                          cSharpNamespace.StartsWith("Microsoft.Playwright.Helpers", StringComparison.InvariantCultureIgnoreCase));
                 if (string.IsNullOrEmpty(fileName) && !playwrightInternal)
                 {
                     continue;


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.type.namespace?view=net-6.0

> Namespace: The namespace of the [Type](https://docs.microsoft.com/en-us/dotnet/api/system.type?view=net-6.0); null if the current instance has no namespace or represents a generic parameter.

```
System.NullReferenceException: Object reference not set to an instance of an object.

System.NullReferenceException
Object reference not set to an instance of an object.
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal) in /_/src/Playwright/Transport/Connection.cs:line 443
   at Microsoft.Playwright.Transport.Channels.Root.InitializeAsync() in /_/src/Playwright/Transport/Channels/Root.cs:line 47
   at Microsoft.Playwright.Playwright.CreateAsync() in /_/src/Playwright/Playwright.cs:line 52
   at PlaywrightFixture.InitializeAsync() in C:\Code\Verify.HeadlessBrowsers\src\Tests\PlaywrightFixture.cs:line 22
   at Xunit.Sdk.ExceptionAggregator.RunAsync(Func`1 code) in C:\Dev\xunit\xunit\src\xunit.core\Sdk\ExceptionAggregator.cs:line 90
```