### PR TITLE
chore: do not redirect stdout/stderr in CLI

### DIFF
--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -24,7 +24,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
 using Microsoft.Playwright.Helpers;
 
 namespace Microsoft.Playwright
@@ -53,7 +52,6 @@ namespace Microsoft.Playwright
             var playwrightStartInfo = new ProcessStartInfo(pwPath, allArgs)
             {
                 UseShellExecute = false,
-                CreateNoWindow = true,
             };
             foreach (var pair in Driver.GetEnvironmentVariables())
             {

--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -54,9 +54,6 @@ namespace Microsoft.Playwright
             {
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-                RedirectStandardOutput = true,
             };
             foreach (var pair in Driver.GetEnvironmentVariables())
             {
@@ -68,41 +65,8 @@ namespace Microsoft.Playwright
                 StartInfo = playwrightStartInfo,
             };
 
-            using var outputWaitHandle = new AutoResetEvent(false);
-            using var errorWaitHandle = new AutoResetEvent(false);
-
-            pwProcess.OutputDataReceived += (_, e) =>
-            {
-                if (e.Data == null)
-                {
-                    outputWaitHandle.Set();
-                }
-                else
-                {
-                    Console.WriteLine(e.Data);
-                }
-            };
-
-            pwProcess.ErrorDataReceived += (_, e) =>
-            {
-                if (e.Data == null)
-                {
-                    errorWaitHandle.Set();
-                }
-                else
-                {
-                    Console.Error.WriteLine(e.Data);
-                }
-            };
-
             pwProcess.Start();
-
-            pwProcess.BeginOutputReadLine();
-            pwProcess.BeginErrorReadLine();
-
             pwProcess.WaitForExit();
-            outputWaitHandle.WaitOne(5000);
-            errorWaitHandle.WaitOne(5000);
             return pwProcess.ExitCode;
         }
 


### PR DESCRIPTION
Current state/implementation (ToT) when invoking the CLI:

```
CreateNoWindow = true,
RedirectStandardError = true,
RedirectStandardInput = true,
RedirectStandardOutput = true,
```

(properties when calling the Playwright CLI via our ps1 script or Playwright CLI.

This ends up that the stdout/stderr stream does end up in `OutputDataReceived` and `ErrorDataReceived` which has the downside that `isTTY` on `Node.js` side is `false`. -> No progress bar when downloading browsers.

New implementation:

```
CreateNoWindow = false,
RedirectStandardError = false,
RedirectStandardInput = false,
RedirectStandardOutput = false,
```

(leaving defaults there so its easier understandable). When specifying these values to false, `they` get automatically written to `Process.StandardOutput` and friends. Thats what we want. On Windows this does only work when `CreateNoWindow=false`, after testing I saw no issue with it keeping it on false (tested on Windows).

See here for reference: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput?view=net-6.0