### PR TITLE
Use ItemGroup for copying playwright.ps1

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -35,25 +35,13 @@
         <Visible>false</Visible>
         <Pack>false</Pack>
       </Content>
+      <Content Include="$(MSBuildThisFileDirectory)playwright.ps1">
+        <Link>playwright.ps1</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <PublishState>Included</PublishState>
+        <Visible>false</Visible>
+        <Pack>false</Pack>
+      </Content>
     </ItemGroup>
-  </Target>
-  <Target Name="CopyRuntimeConfigToOutput" AfterTargets="CopyFilesToOutputDirectory">
-    <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Playwright.runtimeconfig.json')">
-      <_CopyRuntimeConfigItems Include="$(MSBuildThisFileDirectory)..\lib\$(TargetFramework)\Microsoft.Playwright.runtimeconfig.json" />
-    </ItemGroup>
-    <Message Text="[Playwright] Copying config from $(MSBuildThisFileDirectory)..\lib\$(TargetFramework) to $(OutDir)..." />
-    <Copy SourceFiles="@(_CopyRuntimeConfigItems)" DestinationFiles="@(_CopyRuntimeConfigItems->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
-  </Target>
-  <Target Name="CopyPlaywrightShellToOutput" AfterTargets="CopyFilesToOutputDirectory">
-    <ItemGroup>
-      <_CopyItemsShell Include="$(MSBuildThisFileDirectory)playwright.ps1" />
-    </ItemGroup>
-    <Message Text="[Playwright] Copying shell script from $(MSBuildThisFileDirectory) to $(OutputPath)..." />
-    <Copy SourceFiles="@(_CopyItemsShell)" DestinationFiles="@(_CopyItemsShell->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true"/>
-  </Target>
-  <Target Name="PlaywrightBuildCleanup" AfterTargets="Clean">
-    <Message Text="[Playwright] Cleaning up .playwright folder and artifacts..."/>
-    <RemoveDir Directories="$(OutDir)\.playwright" Condition="Exists('$(OutDir)\.playwright')"/>
-    <Delete Files="$(OutDir)\playwright.ps1" Condition="Exists('$(OutDir)\playwright.ps1')" />
   </Target>
 </Project>


### PR DESCRIPTION
which copies files correctly when using `publish`.

- `CopyRuntimeConfigToOutput` is no longer needed as there is no runtime config for `netstandard2.0`. (It was needed for NET 3.1/5/6 etc.)
- `PlaywrightBuildCleanup` is no longer needed because `Content` files are automatically part of the `clean` target.
- `PlaywrightPlatform` does not affect `playwright.ps1`.

Fixes #2098