### PR TITLE
fix: fix progress bar reporting on Windows

### DIFF
--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading;
 using Microsoft.Playwright.Helpers;
 
@@ -57,6 +58,8 @@ namespace Microsoft.Playwright
                 RedirectStandardError = true,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             };
             foreach (var pair in Driver.GetEnvironmentVariables())
             {


### PR DESCRIPTION
Before this change the progress bar was broken on Windows, due the default encoding did not process the progress bar character correctly. It looked like this:

![image](https://user-images.githubusercontent.com/17984549/170659254-141d3e92-a103-4221-a67b-de007466b5c4.png)

This change fixes it.