### PR TITLE
test: fix flaky tests with concurrent file reads on test server

### DIFF
--- a/src/Playwright.Tests.TestServer/SimpleServer.cs
+++ b/src/Playwright.Tests.TestServer/SimpleServer.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Playwright.Tests.TestServer
                 return;
             }
             context.Response.StatusCode = StatusCodes.Status200OK;
-            using (var file = File.Open(filePath, mode: FileMode.Open))
+            using (var file = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 context.Response.ContentType = GetContentType(filePath);
 


### PR DESCRIPTION
Before this change some tests were failing where concurrent file reads were involved on the same file see the following picture:

![image](https://user-images.githubusercontent.com/17984549/170665315-b5af9c15-6b5a-415f-bd03-1db8c0d03970.png)


This fixes it.