### PR TITLE
Include publishing ARM64 in docker manifest

### DIFF
--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -111,4 +111,5 @@ publish_docker_manifest () {
 }
 
 publish_docker_images_with_arch_suffix focal amd64
-publish_docker_manifest focal amd64
+publish_docker_images_with_arch_suffix focal arm64
+publish_docker_manifest focal amd64 arm64


### PR DESCRIPTION
This should also include arm64 in the docker manifest when published, allowing it to be used on systems with that architecture.  Should help with the later comments on https://github.com/microsoft/playwright-dotnet/issues/1611
