### PR TITLE
devops: use .NET 6 for publishing

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -34,10 +34,10 @@ stages:
         version: 3.1.x
 
     - task: UseDotNet@2
-      displayName: 'Use .NET 5 SDK'
+      displayName: 'Use .NET 6 SDK'
       inputs:
         packageType: sdk
-        version: 5.x
+        version: 6.x
 
     - task: MicroBuildSigningPlugin@3
       inputs:

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,7 +10,7 @@ assignees: ''
 **Context:**
 - Playwright Version: [what Playwright version do you use?]
 - Operating System: [e.g. Windows, Linux or Mac]
-- .NET version: [e.g. .NET 5]
+- .NET version: [e.g. .NET 6]
 - Browser: [e.g. All, Chromium, Firefox, WebKit]
 - Extra: [any specific details about your environment]
 


### PR DESCRIPTION
I made a dry run which was working fine.

This was our last remainder for the .NET 6 tooling migration.