### PR TITLE
chore(mstest): make page/context/browser non-nullable

### DIFF
--- a/src/Playwright.MSTest/BrowserTest.cs
+++ b/src/Playwright.MSTest/BrowserTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class BrowserTest : PlaywrightTest
     {
-        public IBrowser Browser { get; private set; }
+        public IBrowser Browser { get; private set; } = null!;
         private readonly List<IBrowserContext> _contexts = new();
 
         public async Task<IBrowserContext> NewContextAsync(BrowserNewContextOptions? options)
@@ -59,7 +59,7 @@ namespace Microsoft.Playwright.MSTest
                 }
             }
             _contexts.Clear();
-            Browser = null;
+            Browser = null!;
         }
     }
 }

--- a/src/Playwright.MSTest/BrowserTest.cs
+++ b/src/Playwright.MSTest/BrowserTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class BrowserTest : PlaywrightTest
     {
-        public IBrowser? Browser { get; private set; }
+        public IBrowser Browser { get; private set; }
         private readonly List<IBrowserContext> _contexts = new();
 
         public async Task<IBrowserContext> NewContextAsync(BrowserNewContextOptions? options)

--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class ContextTest : BrowserTest
     {
-        public IBrowserContext Context { get; private set; }
+        public IBrowserContext Context { get; private set; } = null!;
 
         [TestInitialize]
         public async Task ContextSetup()

--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class ContextTest : BrowserTest
     {
-        public IBrowserContext? Context { get; private set; }
+        public IBrowserContext Context { get; private set; }
 
         [TestInitialize]
         public async Task ContextSetup()

--- a/src/Playwright.MSTest/PageTest.cs
+++ b/src/Playwright.MSTest/PageTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class PageTest : ContextTest
     {
-        public IPage Page { get; private set; }
+        public IPage Page { get; private set; } = null!;
 
         [TestInitialize]
         public async Task PageSetup()

--- a/src/Playwright.MSTest/PageTest.cs
+++ b/src/Playwright.MSTest/PageTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Playwright.MSTest
     [TestClass]
     public class PageTest : ContextTest
     {
-        public IPage? Page { get; private set; }
+        public IPage Page { get; private set; }
 
         [TestInitialize]
         public async Task PageSetup()

--- a/src/Playwright.MSTest/Services/BrowserService.cs
+++ b/src/Playwright.MSTest/Services/BrowserService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.MSTest.Services
 {
     public class BrowserService : IWorkerService
     {
-        public IBrowser? Browser { get; internal set; }
+        public IBrowser Browser { get; internal set; }
 
         public Task ResetAsync() => Task.CompletedTask;
 

--- a/src/Playwright.MSTest/Services/BrowserService.cs
+++ b/src/Playwright.MSTest/Services/BrowserService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.MSTest.Services
 {
     public class BrowserService : IWorkerService
     {
-        public IBrowser Browser { get; internal set; }
+        public IBrowser Browser { get; internal set; } = null!;
 
         public Task ResetAsync() => Task.CompletedTask;
 

--- a/src/Playwright.NUnit/BrowserService.cs
+++ b/src/Playwright.NUnit/BrowserService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.NUnit
 {
     public class BrowserService : IWorkerService
     {
-        public IBrowser Browser { get; internal set; }
+        public IBrowser Browser { get; internal set; } = null!;
 
         public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType)
         {

--- a/src/Playwright.NUnit/BrowserTest.cs
+++ b/src/Playwright.NUnit/BrowserTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Playwright.NUnit
 {
     public class BrowserTest : PlaywrightTest
     {
-        public IBrowser Browser { get; internal set; }
+        public IBrowser Browser { get; internal set; } = null!;
         private readonly List<IBrowserContext> _contexts = new();
 
         public async Task<IBrowserContext> NewContext(BrowserNewContextOptions options)
@@ -58,7 +58,7 @@ namespace Microsoft.Playwright.NUnit
                 }
             }
             _contexts.Clear();
-            Browser = null;
+            Browser = null!;
         }
     }
 }

--- a/src/Playwright.NUnit/ContextTest.cs
+++ b/src/Playwright.NUnit/ContextTest.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Playwright.NUnit
 {
     public class ContextTest : BrowserTest
     {
-        public IBrowserContext Context { get; private set; }
+        public IBrowserContext Context { get; private set; } = null!;
 
         public virtual BrowserNewContextOptions ContextOptions()
         {
-            return null;
+            return null!;
         }
 
         [SetUp]

--- a/src/Playwright.NUnit/PageTest.cs
+++ b/src/Playwright.NUnit/PageTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.NUnit
 {
     public class PageTest : ContextTest
     {
-        public IPage Page { get; private set; }
+        public IPage Page { get; private set; } = null!;
 
         [SetUp]
         public async Task PageSetup()

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -19,6 +19,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="../Common/Version.props" />

--- a/src/Playwright.NUnit/PlaywrightTest.cs
+++ b/src/Playwright.NUnit/PlaywrightTest.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Playwright.NUnit
 
         private static readonly Task<IPlaywright> _playwrightTask = Microsoft.Playwright.Playwright.CreateAsync();
 
-        public IPlaywright Playwright { get; private set; }
-        public IBrowserType BrowserType { get; private set; }
+        public IPlaywright Playwright { get; private set; } = null!;
+        public IBrowserType BrowserType { get; private set; } = null!;
 
         [SetUp]
         public async Task PlaywrightSetup()

--- a/src/Playwright.NUnit/WorkerAwareTest.cs
+++ b/src/Playwright.NUnit/WorkerAwareTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Playwright.NUnit
         }
 
         private static readonly ConcurrentStack<Worker> _allWorkers = new();
-        private Worker _currentWorker;
+        private Worker _currentWorker = null!;
 
         public int WorkerIndex { get; internal set; }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Playwright.NUnit
                 _currentWorker.Services[name] = await factory().ConfigureAwait(false);
             }
 
-            return _currentWorker.Services[name] as T;
+            return (_currentWorker.Services[name] as T)!;
         }
 
         [SetUp]


### PR DESCRIPTION
This aligns it with our NUnit harness. When users used it before, it always yelled with "hey Page can be null" warning.