### PR TITLE
fix: HEADED env was not respected inside testing harness

### DIFF
--- a/src/Playwright.TestingHarnessTest/tests/mstest.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/mstest.spec.ts
@@ -124,6 +124,37 @@ test('should prioritize browser from env over the runsettings file', async ({ ru
   expect(/User-Agent: .*Firefox.*/.test(result.stdout)).toBeTruthy()
 });
 
+test('should be able to make the browser headed via the env', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.MSTest;
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]  
+      public class <class-name> : PageTest
+      {
+          [TestMethod]
+          public async Task Test()
+          {
+              await Page.GotoAsync("about:blank");
+              Console.WriteLine("BrowserName: " + BrowserName);
+              Console.WriteLine("User-Agent: " + await Page.EvaluateAsync<string>("() => navigator.userAgent"));
+          }
+      }`,
+  }, 'dotnet test', {
+    HEADED: '1'
+  });
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  expect(result.stdout).toContain("BrowserName: chromium")
+  expect(result.stdout).not.toContain("Headless")
+});
+
 test('should be able to override context options', async ({ runTest }) => {
   const result = await runTest({
     'ExampleTests.cs': `

--- a/src/Playwright.TestingHarnessTest/tests/nunit.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/nunit.spec.ts
@@ -124,6 +124,36 @@ test('should prioritize browser from env over the runsettings file', async ({ ru
   expect(/User-Agent: .*Firefox.*/.test(result.stdout)).toBeTruthy()
 });
 
+test('should be able to make the browser headed via the env', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.NUnit;
+      using NUnit.Framework;
+
+      namespace Playwright.TestingHarnessTest.NUnit;
+
+      public class <class-name> : PageTest
+      {
+          [Test]
+          public async Task Test()
+          {
+              await Page.GotoAsync("about:blank");
+              Console.WriteLine("BrowserName: " + BrowserName);
+              Console.WriteLine("User-Agent: " + await Page.EvaluateAsync<string>("() => navigator.userAgent"));
+          }
+      }`,
+  }, 'dotnet test', {
+    HEADED: '1'
+  });
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  expect(result.stdout).toContain("BrowserName: chromium")
+  expect(result.stdout).not.toContain("Headless")
+});
+
 test('should be able to override context options', async ({ runTest }) => {
   const result = await runTest({
     'ExampleTests.cs': `

--- a/src/Playwright/Core/Shared/RunSettingsParser.cs
+++ b/src/Playwright/Core/Shared/RunSettingsParser.cs
@@ -45,8 +45,18 @@ namespace Microsoft.Playwright.Core.Shared
         internal RunSettingsParser(IDictionary<string, string> settings)
         {
             _settings = settings;
-            LaunchOptions = ParseTestParameters<BrowserTypeLaunchOptions>(settings);
+            LaunchOptions = DetermineLaunchOptions(settings);
             BrowserName = DetermineBrowserType();
+        }
+
+        private static BrowserTypeLaunchOptions DetermineLaunchOptions(IDictionary<string, string> settings)
+        {
+            var launchOptions = ParseTestParameters<BrowserTypeLaunchOptions>(settings);
+            if (Environment.GetEnvironmentVariable("HEADED") == "1")
+            {
+                launchOptions.Headless = false;
+            }
+            return launchOptions;
         }
 
         private static T ParseTestParameters<T>(IDictionary<string, string> parameters)


### PR DESCRIPTION
This regressed in https://github.com/microsoft/playwright-dotnet/pull/2212.