### PR TITLE
fix: make sure it works with packages.config (.NET 4.8)

### DIFF
--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -32,8 +32,13 @@ namespace Microsoft.Playwright.Helpers
 {
     internal static class Driver
     {
-        internal static string GetExecutablePath()
+        internal static string GetExecutablePath(string driversPath = null)
         {
+            if (driversPath != null)
+            {
+                return GetPath(driversPath);
+            }
+
             DirectoryInfo assemblyDirectory = new(AppContext.BaseDirectory);
             if (!assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
             {

--- a/src/Playwright/Playwright.cs
+++ b/src/Playwright/Playwright.cs
@@ -37,11 +37,12 @@ namespace Microsoft.Playwright
         /// <summary>
         /// Launches Playwright.
         /// </summary>
+        /// <param name="driversPath">Playwright driver path.</param>
         /// <returns>A <see cref="Task"/> that completes when the playwright driver is ready to be used.</returns>
-        public static async Task<IPlaywright> CreateAsync()
+        public static async Task<IPlaywright> CreateAsync(string driversPath = null)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            var transport = new StdIOTransport();
+            var transport = new StdIOTransport(driversPath);
 #pragma warning restore CA2000
             var connection = new Connection();
             transport.MessageReceived += (_, message) => connection.Dispatch(JsonSerializer.Deserialize<PlaywrightServerMessage>(message, JsonExtensions.DefaultJsonSerializerOptions));

--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Playwright.Transport
         private readonly List<byte> _data = new();
         private int? _currentMessageSize;
 
-        internal StdIOTransport()
+        internal StdIOTransport(string driversPath = null)
         {
-            _process = GetProcess();
+            _process = GetProcess(driversPath);
             _process.StartInfo.Arguments = "run-driver";
             _process.Start();
             _process.Exited += (_, _) => Close("Process exited");
@@ -114,9 +114,9 @@ namespace Microsoft.Playwright.Transport
             }
         }
 
-        private static Process GetProcess()
+        private static Process GetProcess(string driversPath = null)
         {
-            var startInfo = new ProcessStartInfo(Driver.GetExecutablePath())
+            var startInfo = new ProcessStartInfo(Driver.GetExecutablePath(driversPath))
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,


### PR DESCRIPTION
Extended Playwright.CreateAsync() with optional driversPath param.

Fixes #1842, fixes #2240, fixes #2004

`Playwright.CreateAsync()` fails in .NET 4.8 with "PlaywrightException: Driver not found" and there's currently no workaround.

This change allows to specify the driversPath, to a path where the runtime can pick the .playwright-folder:
```c#
Playwright.CreateAsync(driversPath: "path/.playwright")
```

The implementation is inspired by [PlaywrightSharp](https://github.com/hardkoded/playwright-sharp). If driversPath is specified, it uses that path, otherwise it tries to find the .playwright-folder automatically (as before).

A working example with ASP.Net 4.8 can be found at https://github.com/BeniFreitag/Playwright-AspNet-4.8/tree/develop