### PR TITLE
chore: fix dotnet build did not pack the same results as dotnet pack

### DIFF
--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -24,7 +24,6 @@
   <Import Project="../Common/Version.props" />
   <Import Project="../Common/Dependencies.props" />
   <Import Project="../Common/SignAssembly.props" />
-  <Import Project="build/Microsoft.Playwright.targets" />
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
`dotnet build` did not produce the same results as `dotnet pack` this ended up that the `nupkg` files were kinda broken. This fixes it.