### PR TITLE
chore: align connection close with upstream impl

### DIFF
--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Playwright.Core
                     context.OnClose();
                 }
                 browser?.DidClose();
-                connection.DoClose(closeError != null ? closeError : DriverMessages.BrowserClosedExceptionMessage);
+                connection.DoClose(closeError ?? DriverMessages.BrowserClosedExceptionMessage);
             }
             pipe.Closed += (_, _) => OnPipeClosed();
             connection.OnMessage = async (object message) =>
@@ -219,7 +219,6 @@ namespace Microsoft.Playwright.Core
             async Task<IBrowser> CreateBrowserAsync()
             {
                 var playwright = await connection.InitializePlaywrightAsync().ConfigureAwait(false);
-                playwright.Connection = connection;
                 if (playwright.PreLaunchedBrowser == null)
                 {
                     ClosePipe();

--- a/src/Playwright/Core/PlaywrightImpl.cs
+++ b/src/Playwright/Core/PlaywrightImpl.cs
@@ -76,8 +76,6 @@ namespace Microsoft.Playwright.Core
 
         public IReadOnlyDictionary<string, BrowserNewContextOptions> Devices => _devices;
 
-        internal Connection Connection { get; set; }
-
         internal Browser PreLaunchedBrowser => _initializer.PreLaunchedBrowser;
 
         public IAPIRequest APIRequest { get; }
@@ -111,7 +109,7 @@ namespace Microsoft.Playwright.Core
                 return;
             }
 
-            Connection?.Dispose();
+            _connection?.Dispose();
         }
     }
 }

--- a/src/Playwright/Playwright.cs
+++ b/src/Playwright/Playwright.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Playwright
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var transport = new StdIOTransport();
-#pragma warning restore CA2000
             var connection = new Connection();
+#pragma warning restore CA2000
             transport.MessageReceived += (_, message) => connection.Dispatch(JsonSerializer.Deserialize<PlaywrightServerMessage>(message, JsonExtensions.DefaultJsonSerializerOptions));
             transport.LogReceived += (_, log) =>
             {
@@ -55,7 +55,6 @@ namespace Microsoft.Playwright
             connection.OnMessage = (message) => transport.SendAsync(JsonSerializer.SerializeToUtf8Bytes(message, connection.DefaultJsonSerializerOptions));
             connection.Close += (_, reason) => transport.Close(reason);
             var playwright = await connection.InitializePlaywrightAsync().ConfigureAwait(false);
-            playwright.Connection = connection;
             return playwright;
         }
     }


### PR DESCRIPTION
Apply the upstream https://github.com/microsoft/playwright/pull/9524 patch.

Drive-by fix specific connect waiter.cs tests. For the actual fox of them see the comment related to `callback.Value.TaskCompletionSource.Task.IgnoreException();`.