### PR TITLE
chore: verify for status code 200 when downloading driver

### DIFF
--- a/src/tools/Playwright.Tooling/DriverDownloader.cs
+++ b/src/tools/Playwright.Tooling/DriverDownloader.cs
@@ -118,6 +118,12 @@ internal class DriverDownloader
         {
             var response = await client.GetAsync(url).ConfigureAwait(false);
 
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new Exception($"Failed to download driver from {url} with status {response.StatusCode} and content {content}.");
+            }
+
             var directory = new DirectoryInfo(Path.Combine(destinationDirectory.FullName, platform));
 
             if (directory.Exists)


### PR DESCRIPTION
This should help us to understand [this](https://github.com/microsoft/playwright-dotnet/actions/runs/3039803653/jobs/4895150780). It's not user-facing, only we on our CI workflows and dev workflows download the driver, for users we ship it inside the nupkg file.