### PR TITLE
chore: make retries work with custom timeouts

### DIFF
--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -36,7 +36,7 @@ public class ContextTest : BrowserTest
     public async Task ContextInitialize()
     {
         Context = await NewContextAsync(ContextOptions()).ConfigureAwait(false);
-        PlaywrightTimeoutAttribute.ContextCloseHookOnTimeout = ContextCleanup;
+        PlaywrightTimeoutAttribute.ContextCloseHookOnTimeoutAsync = ContextCleanup;
     }
 
     [TestCleanup]

--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -42,12 +42,7 @@ public class ContextTest : BrowserTest
     [TestCleanup]
     public async Task ContextCleanup()
     {
-        // Inside PlaywrightTimeoutAttribute we already call the Cleanup methods
-        if (Context != null)
-        {
-            await Context.CloseAsync().ConfigureAwait(false);
-            Context = null!;
-        }
+        await Context.CloseAsync().ConfigureAwait(false);
     }
 
     public virtual BrowserNewContextOptions ContextOptions()

--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -33,9 +33,21 @@ public class ContextTest : BrowserTest
     public IBrowserContext Context { get; private set; } = null!;
 
     [TestInitialize]
-    public async Task ContextSetup()
+    public async Task ContextInitialize()
     {
         Context = await NewContextAsync(ContextOptions()).ConfigureAwait(false);
+        PlaywrightTimeoutAttribute.ContextCloseHookOnTimeout = ContextCleanup;
+    }
+
+    [TestCleanup]
+    public async Task ContextCleanup()
+    {
+        // Inside PlaywrightTimeoutAttribute we already call the Cleanup methods
+        if (Context != null)
+        {
+            await Context.CloseAsync().ConfigureAwait(false);
+            Context = null!;
+        }
     }
 
     public virtual BrowserNewContextOptions ContextOptions()

--- a/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
+++ b/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
@@ -1,0 +1,115 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Playwright.TestAdapter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Playwright.MSTest;
+
+internal class PlaywrightTimeoutAttribute : TestMethodAttribute
+{
+    static internal Func<Task>? ContextCloseHookOnTimeout { get; set; } = null;
+
+    public override TestResult[] Execute(ITestMethod testMethod)
+    {
+        var timeout = PlaywrightSettingsProvider.TestTimeout;
+        if (timeout == null || Debugger.IsAttached)
+        {
+            return base.Execute(testMethod);
+        }
+        if (CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(testMethod, timeout.Value) is var result && result != null)
+        {
+            return result;
+        }
+
+        return ExecuteWithTimeoutAsync(testMethod, timeout.Value).GetAwaiter().GetResult();
+    }
+
+    private async Task<TestResult[]> ExecuteWithTimeoutAsync(ITestMethod testMethod, int timeout)
+    {
+        // 1. Race Test execution against the specified timeout.
+        // In MSTest base.Execute will internally run the TestInitialize and TestCleanup. In case of a timeout, we don't
+        // run TestCleanup, only TestInitialize. To get good error messages, we close the browser context inside ContextCloseHookOnTimeout.
+        var testExecutionTask = Task.Run(() => base.Execute(testMethod));
+        var timeoutTask = Task.Delay(timeout);
+        await Task.WhenAny(testExecutionTask, timeoutTask);
+
+        // 2. Close the BrowserContext
+        if (ContextCloseHookOnTimeout != null)
+        {
+            await ContextCloseHookOnTimeout().ConfigureAwait(false);
+        }
+
+        // 3. If timeout was reached, we need to wait for the test execution to finish, since Page.Click could hang.
+        if (timeoutTask.IsCompleted)
+        {
+            // 3.1 Wait for the test execution to complete (let e.g. Page.ClickAsync throw)
+            // and give the test 5 seconds to finish.
+            await Task.WhenAny(testExecutionTask, Task.Delay(5000));
+        }
+
+        // 4. If the test execution is still running, we know it was a timeout.
+        if (!testExecutionTask.IsCompleted)
+        {
+            return new TestResult[]
+            {
+                new TestResult()
+                {
+                    Outcome = UnitTestOutcome.Timeout,
+                    TestFailureException = new Exception($"Test timed out after {timeout}ms.")
+                },
+            };
+        }
+
+        return await testExecutionTask;
+    }
+
+    private TestResult[]? CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(ITestMethod testMethod, int playwrightTestTimeout)
+    {
+        var timeout = MSTestProvider.TestTimeout;
+        var timeoutAttribute = testMethod.MethodInfo.GetCustomAttributes(typeof(TimeoutAttribute), false).FirstOrDefault();
+        if (timeoutAttribute != null)
+        {
+            timeout = ((TimeoutAttribute)timeoutAttribute).Timeout;
+        }
+
+        if (timeout != null && timeout != 0 && playwrightTestTimeout > timeout)
+        {
+            return new TestResult[]
+            {
+                new TestResult()
+                {
+                    Outcome = UnitTestOutcome.Failed,
+                    TestFailureException = new Exception($"Playwright test timeout ({playwrightTestTimeout}ms) is larger than MSTest timeout ({timeout}ms).")
+                },
+            };
+        }
+        return null;
+    }
+}

--- a/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
+++ b/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
@@ -106,7 +106,7 @@ internal class PlaywrightTimeoutAttribute : TestMethodAttribute
                 new TestResult()
                 {
                     Outcome = UnitTestOutcome.Failed,
-                    TestFailureException = new InvalidOperationException($"Playwright test timeout ({playwrightTestTimeout}ms) is larger than MSTest timeout ({timeout}ms).")
+                    TestFailureException = new InvalidOperationException($"Playwright test timeout ({playwrightTestTimeout}ms) is larger than MSTest timeout ({timeout}ms). Set the Playwright test timeout to a lower value or disable the MSTest timeout.")
                 },
             };
         }

--- a/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
+++ b/src/Playwright.MSTest/PlaywrightTimeoutAttribute.cs
@@ -23,7 +23,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -43,7 +42,7 @@ internal class PlaywrightTimeoutAttribute : TestMethodAttribute
         {
             return base.Execute(testMethod);
         }
-        if (CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(testMethod, timeout.Value) is TestResult[] result)
+        if (EnsureThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(testMethod, timeout.Value) is TestResult[] result)
         {
             return result;
         }
@@ -90,7 +89,7 @@ internal class PlaywrightTimeoutAttribute : TestMethodAttribute
         return await testExecutionTask;
     }
 
-    private TestResult[]? CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(ITestMethod testMethod, int playwrightTestTimeout)
+    private TestResult[]? EnsureThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(ITestMethod testMethod, int playwrightTestTimeout)
     {
         var timeout = MSTestProvider.TestTimeout;
         var timeoutAttribute = testMethod.MethodInfo.GetCustomAttributes(typeof(TimeoutAttribute), false).FirstOrDefault();

--- a/src/Playwright.NUnit/ContextTest.cs
+++ b/src/Playwright.NUnit/ContextTest.cs
@@ -46,6 +46,5 @@ public class ContextTest : BrowserTest
     public async Task ContextTearDown()
     {
         await Context.CloseAsync().ConfigureAwait(false);
-        Context = null!;
     }
 }

--- a/src/Playwright.NUnit/ContextTest.cs
+++ b/src/Playwright.NUnit/ContextTest.cs
@@ -41,4 +41,11 @@ public class ContextTest : BrowserTest
     {
         Context = await NewContext(ContextOptions()).ConfigureAwait(false);
     }
+
+    [TearDown]
+    public async Task ContextTearDown()
+    {
+        await Context.CloseAsync().ConfigureAwait(false);
+        Context = null!;
+    }
 }

--- a/src/Playwright.NUnit/PlaywrightTestAttribute.cs
+++ b/src/Playwright.NUnit/PlaywrightTestAttribute.cs
@@ -252,7 +252,7 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
             if (timeout != 0 && playwrightTestTimeout > timeout)
             {
                 var result = context.CurrentTest.MakeTestResult();
-                result.RecordException(new InvalidOperationException($"The Playwright test timeout of {playwrightTestTimeout}ms is higher than the NUnit test timeout of {timeout}ms. Set the Playwright test timeout to a lower value."));
+                result.RecordException(new InvalidOperationException($"The Playwright test timeout of {playwrightTestTimeout}ms is higher than the NUnit test timeout of {timeout}ms. Set the Playwright test timeout to a lower value or disable the NUnit timeout."));
                 return result;
             }
             return null;

--- a/src/Playwright.NUnit/PlaywrightTestAttribute.cs
+++ b/src/Playwright.NUnit/PlaywrightTestAttribute.cs
@@ -24,9 +24,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.Playwright.TestAdapter;
+using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
@@ -46,21 +49,26 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
 
     public TestCommand Wrap(TestCommand command) => new RetryTestCommand(command);
 
-    internal class RetryTestCommand : DelegatingTestCommand
+    internal class RetryTestCommand : BeforeTestCommand
     {
-        public RetryTestCommand(TestCommand innerCommand) : base(innerCommand)
-        {
-        }
+
+        public RetryTestCommand(TestCommand innerCommand) : base(innerCommand) { }
 
         public override TestResult Execute(TestExecutionContext context)
         {
             List<SlimTestResult> failedResults = new List<SlimTestResult>();
+            bool tearDownRan = false;
             context.CurrentTest.Properties.Set("RetryCount", 0);
             while (true)
             {
+                // NUnit takes care about running SetUp for the first iteration. If we run Execute more than once, we need to manually run SetUp.
+                if (Test2RetryCount(context.CurrentTest) > 0)
+                {
+                    Task.WaitAll(RunSetUpOrTearDownMethod(context, isSetUp: true));
+                }
                 try
                 {
-                    context.CurrentResult = innerCommand.Execute(context);
+                    (context.CurrentResult, tearDownRan) = ExecuteWithTimeout(context);
                 }
                 catch (Exception ex)
                 {
@@ -75,6 +83,12 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
                 if (Test2RetryCount(context.CurrentTest) == PlaywrightSettingsProvider.Retries)
                 {
                     break;
+                }
+                // NUnit takes care about running TearDown for the last iteration. PlaywrightTestAttribute inherits from
+                // the TimeoutCommand which runs TearDown for us in a case of a timeout.
+                if (!tearDownRan)
+                {
+                    Task.WaitAll(RunSetUpOrTearDownMethod(context, isTearDown: true));
                 }
                 context.CurrentTest.Properties.Set("RetryCount", Test2RetryCount(context.CurrentTest) + 1);
             }
@@ -102,14 +116,14 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
             if (failedResults.Count > 0)
             {
                 output += $"\nFailing test runs:\n";
-                foreach (var result in failedResults)
+                foreach (var (result, retry) in failedResults.Select((run, i) => (run, i)))
                 {
                     if (result == null)
                     {
                         continue;
                     }
                     output += new String('-', 40) + "\n";
-                    output += $"  Test: {result.FullName}\n";
+                    output += $"  Test: {result.FullName} (retry #{retry})\n";
                     output += $"  Outcome: {result.ResultState}\n";
                     if (!string.IsNullOrEmpty(result.Output))
                     {
@@ -129,6 +143,117 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
         private static string Indent(string text, int indent)
         {
             return text.Split(new[] { "\n" }, StringSplitOptions.None).Select(line => new String(' ', indent) + line).Aggregate((a, b) => a + "\n" + b);
+        }
+
+        private (TestResult, bool) ExecuteWithTimeout(TestExecutionContext context)
+        {
+            var timeout = PlaywrightSettingsProvider.TestTimeout;
+            if (timeout == null || Debugger.IsAttached)
+            {
+                return (innerCommand.Execute(context), false);
+            }
+
+            if (CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(context, timeout.Value) is var result && result != null)
+            {
+                return (result, false);
+            };
+
+            return ExecuteWithTimeoutInnerAsync(context, timeout.Value).GetAwaiter().GetResult();
+        }
+
+        private async Task<(TestResult, bool)> ExecuteWithTimeoutInnerAsync(TestExecutionContext context, int timeout)
+        {
+            bool tearDownRan = false;
+            string timeoutExceptionMessage = $"Test exceeded Timeout value of {timeout}ms";
+            // 1. Race Test execution against the specified timeout.
+            var testExecutionTask = Task.Run(() => innerCommand.Execute(context));
+            var timeoutTask = Task.Delay(timeout);
+            await Task.WhenAny(testExecutionTask, timeoutTask);
+
+            // 2. If timeout was reached, call the tearDownHandlers and
+            // cancel by that the underlying BrowserContext calls.
+            if (timeoutTask.IsCompleted)
+            {
+                // 2.1 Call the test teardown handlers.
+                await RunSetUpOrTearDownMethod(context, isTearDown: true);
+                tearDownRan = true;
+
+                // 2.2 Wait for the test execution to complete (let e.g. Page.ClickAsync throw)
+                // and give the test 5 seconds to finish.
+                await Task.WhenAny(testExecutionTask, Task.Delay(5000));
+            }
+            TestResult result;
+            if (!testExecutionTask.IsCompleted)
+            {
+                result = context.CurrentTest.MakeTestResult();
+                result.RecordException(new TimeoutException(timeoutExceptionMessage));
+                return (result, tearDownRan);
+            }
+            try
+            {
+                return (await testExecutionTask, tearDownRan);
+            }
+            catch (System.Exception exception)
+            {
+                result = context.CurrentTest.MakeTestResult();
+                result.RecordException(new AggregateException(new Exception[] { new TimeoutException(timeoutExceptionMessage), exception }), FailureSite.Test);
+                return (result, tearDownRan);
+            }
+        }
+
+        protected async Task RunSetUpOrTearDownMethod(TestExecutionContext context, bool isSetUp = false, bool isTearDown = false)
+        {
+            if (isSetUp == isTearDown)
+            {
+                throw new ArgumentException("isSetUp and isTearDown cannot be both true or both false");
+            }
+            // https://github.com/nunit/nunit/blob/f77ac94d69daf985653763f073e651304d9e31f8/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs#L94
+            // Try to locate the parent fixture. In current implementations, the test method
+            // is either one or two levels below the TestFixture - if this changes,
+            // so should the following code.
+            TestFixture? parentFixture = Test.Parent as TestFixture ?? Test.Parent?.Parent as TestFixture;
+
+            // In normal operation we should always get the methods from the parent fixture.
+            // However, some of NUnit's own tests can create a TestMethod without a parent
+            // fixture. Most likely, we should stop doing this, but it affects 100s of cases.
+            IMethodInfo[] methods;
+            if (isSetUp)
+            {
+                methods = parentFixture?.SetUpMethods ?? Test.TypeInfo!.GetMethodsWithAttribute<SetUpAttribute>(true);
+            }
+            else
+            {
+                methods = parentFixture?.TearDownMethods ?? Test.TypeInfo!.GetMethodsWithAttribute<TearDownAttribute>(true);
+            }
+
+            foreach (var method in methods)
+            {
+                // https://github.com/nunit/nunit/blob/f77ac94d69daf985653763f073e651304d9e31f8/src/NUnitFramework/framework/Internal/Commands/SetUpTearDownItem.cs#L103
+                var result = method.Invoke(method.IsStatic ? null : context.TestObject, null);
+                if (result is Task task)
+                {
+                    await task;
+                }
+            }
+        }
+
+        private TestResult? CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(TestExecutionContext context, int playwrightTestTimeout)
+        {
+            // See https://github.com/nunit/nunit/blob/f77ac94d69daf985653763f073e651304d9e31f8/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs#L142-L148
+            // If a timeout is specified, create a TimeoutCommand
+            // Timeout set at a higher level
+            int timeout = context.TestCaseTimeout;
+            // Timeout set on this test
+            if (Test.Properties.ContainsKey(PropertyNames.Timeout))
+                timeout = (int)Test.Properties.Get(PropertyNames.Timeout)!;
+
+            if (timeout != 0 && playwrightTestTimeout > timeout)
+            {
+                var result = context.CurrentTest.MakeTestResult();
+                result.RecordException(new TimeoutException($"The Playwright test timeout of {playwrightTestTimeout}ms is higher than the NUnit test timeout of {timeout}ms. Set the Playwright test timeout to a lower value."));
+                return result;
+            }
+            return null;
         }
     }
 

--- a/src/Playwright.NUnit/PlaywrightTestAttribute.cs
+++ b/src/Playwright.NUnit/PlaywrightTestAttribute.cs
@@ -155,7 +155,7 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
                 return (innerCommand.Execute(context), false);
             }
 
-            if (CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(context, timeout.Value) is TestResult result)
+            if (EnsureThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(context, timeout.Value) is TestResult result)
             {
                 return (result, false);
             };
@@ -239,7 +239,7 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
             }
         }
 
-        private TestResult? CheckThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(TestExecutionContext context, int playwrightTestTimeout)
+        private TestResult? EnsureThatPlaywrightTimeoutIsSmallerThanNUnitTimeout(TestExecutionContext context, int playwrightTestTimeout)
         {
             // See https://github.com/nunit/nunit/blob/f77ac94d69daf985653763f073e651304d9e31f8/src/NUnitFramework/framework/Internal/Execution/SimpleWorkItem.cs#L142-L148
             // If a timeout is specified, create a TimeoutCommand

--- a/src/Playwright.NUnit/PlaywrightTestAttribute.cs
+++ b/src/Playwright.NUnit/PlaywrightTestAttribute.cs
@@ -182,7 +182,7 @@ internal class PlaywrightTestAttribute : NUnitFrameworkBase.TestAttribute, IWrap
 
                 // 2.2 Wait for the test execution to complete (let e.g. Page.ClickAsync throw)
                 // and give the test 5 seconds to finish.
-                await Task.WhenAny(testExecutionTask, Task.Delay(5000));
+                // await Task.WhenAny(testExecutionTask, Task.Delay(5000));
             }
             TestResult result;
             if (!testExecutionTask.IsCompleted)

--- a/src/Playwright.TestAdapter/MSTestProvider.cs
+++ b/src/Playwright.TestAdapter/MSTestProvider.cs
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Xml;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.Playwright.TestAdapter;
+
+/// <summary>
+/// MSTest does not provide a way to get the global timeout value during a test execution.
+/// This class is a workaround to get the timeout value from the runsettings file / CLI options.
+/// </summary>
+[ExtensionUri("settings://playwright-mstest")]
+[SettingsName("MSTest")]
+public class MSTestProvider : ISettingsProvider
+{
+    public static int? TestTimeout = null;
+    public void Load(XmlReader reader)
+    {
+        reader.Read();
+        // Read the <MSTest> element
+        if (reader.IsEmptyElement)
+        {
+            return;
+        }
+        while (reader.Read())
+        // https://github.com/microsoft/testfx/blob/9d520357fde04064f9964fa42c9434b844587ce7/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs#L429
+        {
+            if (reader.NodeType != XmlNodeType.Element)
+            {
+                continue;
+            }
+            switch (reader.Name.ToUpperInvariant())
+            {
+                case "TESTTIMEOUT":
+                    {
+                        if (int.TryParse(reader.ReadInnerXml(), out int testTimeout) && testTimeout > 0)
+                        {
+                            TestTimeout = testTimeout;
+                        }
+                        break;
+                    }
+            }
+        }
+    }
+}

--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -71,6 +71,11 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         }
     }
 
+    public static int? TestTimeout
+    {
+        get => _settings?.TestTimeout ?? 30_000;
+    }
+
     public static int Retries
     {
         get => _settings?.Retries ?? 0;

--- a/src/Playwright.TestAdapter/PlaywrightSettingsXml.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsXml.cs
@@ -58,6 +58,10 @@ public class PlaywrightSettingsXml
                     reader.Read();
                     ExpectTimeout = float.Parse(reader.Value, CultureInfo.InvariantCulture);
                     break;
+                case "TestTimeout":
+                    reader.Read();
+                    TestTimeout = int.Parse(reader.Value, CultureInfo.InvariantCulture);
+                    break;
                 case "Retries":
                     reader.Read();
                     Retries = int.Parse(reader.Value, CultureInfo.InvariantCulture);
@@ -152,6 +156,7 @@ public class PlaywrightSettingsXml
     public string? BrowserName { get; private set; }
     public bool? Headless { get; private set; }
     public float? ExpectTimeout { get; private set; }
+    public int? TestTimeout { get; private set; }
     public int? Retries { get; private set; }
 }
 

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -6,21 +6,19 @@
   "packages": {
     "": {
       "name": "playwright.testingharnesstest",
-      "version": "1.0.0",
-      "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.23.4",
-        "fast-xml-parser": "^4.0.9"
+        "@playwright/test": "^1.26.0",
+        "fast-xml-parser": "^4.0.10"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.4.tgz",
-      "integrity": "sha512-iIsoMJDS/lyuhw82FtcV/B3PXikgVD3hNe5hyvOpRM0uRr1OIpN3LgPeRbBjhzBWmyf6RgRg5fqK5sVcpA03yA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.23.4"
+        "playwright-core": "1.26.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -36,9 +34,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.10.tgz",
+      "integrity": "sha512-mYMMIk7Ho1QOiedyvafdyPamn1Vlda+5n95lcn0g79UiCQoLQ2xfPQ8m3pcxBMpVaftYXtoIE2wrNTjmLQnnkg==",
       "dev": true,
       "dependencies": {
         "strnum": "^1.0.5"
@@ -52,9 +50,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.4.tgz",
-      "integrity": "sha512-h5V2yw7d8xIwotjyNrkLF13nV9RiiZLHdXeHo+nVJIYGVlZ8U2qV0pMxNJKNTvfQVT0N8/A4CW6/4EW2cOcTiA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -72,13 +70,13 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.4.tgz",
-      "integrity": "sha512-iIsoMJDS/lyuhw82FtcV/B3PXikgVD3hNe5hyvOpRM0uRr1OIpN3LgPeRbBjhzBWmyf6RgRg5fqK5sVcpA03yA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.23.4"
+        "playwright-core": "1.26.0"
       }
     },
     "@types/node": {
@@ -88,18 +86,18 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz",
-      "integrity": "sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.10.tgz",
+      "integrity": "sha512-mYMMIk7Ho1QOiedyvafdyPamn1Vlda+5n95lcn0g79UiCQoLQ2xfPQ8m3pcxBMpVaftYXtoIE2wrNTjmLQnnkg==",
       "dev": true,
       "requires": {
         "strnum": "^1.0.5"
       }
     },
     "playwright-core": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.4.tgz",
-      "integrity": "sha512-h5V2yw7d8xIwotjyNrkLF13nV9RiiZLHdXeHo+nVJIYGVlZ8U2qV0pMxNJKNTvfQVT0N8/A4CW6/4EW2cOcTiA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "^1.23.4",
-    "fast-xml-parser": "^4.0.9"
+    "@playwright/test": "^1.26.0",
+    "fast-xml-parser": "^4.0.10"
   }
 }

--- a/src/Playwright.TestingHarnessTest/tests/baseTest.ts
+++ b/src/Playwright.TestingHarnessTest/tests/baseTest.ts
@@ -22,7 +22,7 @@ export const test = base.extend<{
     const testResults: RunResult[] = [];
     await use(async (files, command, env) => {
       const testDir = testInfo.outputPath();
-      const testClassName = testInfo.titlePath.join(' ').replace(/[^\w]/g, '');
+      const testClassName = testInfo.titlePath.join(' ').replace(/[^\w]/g, '') + testInfo.repeatEachIndex + 'Test';
       for (const [fileName, fileContent] of Object.entries(files)) {
         await fs.promises.writeFile(path.join(testDir, fileName), unintentFile(fileContent).replace('<class-name>', testClassName));
       }

--- a/src/Playwright.TestingHarnessTest/tests/mstest/retry.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/mstest/retry.spec.ts
@@ -186,3 +186,172 @@ test('should retry a failed test and stop once it passed', async ({ runTest }) =
   expect(result.stdout).toContain('Test was retried 4 times.');
   expect(result.rawStdout).toMatch(/Passed MyTest \[/);
 });
+
+test('should retry on timeout and print the click api call which was pending', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.MSTest;
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+      
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]
+      public class <class-name> : PageTest
+      {
+          static int retries = 0;
+
+          [PlaywrightTestMethod]
+          public async Task MyTest()
+          {
+              Console.WriteLine("@marker-running-spec");
+              retries++;
+              if (retries < 3)
+                await Page.ClickAsync("button");
+          }
+
+          [TestInitialize]
+          public void TestInitialize()
+          {
+            Console.WriteLine("@marker-initialize");
+          }
+
+          [TestCleanup]
+          public void TestCleanup()
+          {
+            Console.WriteLine("@marker-cleanup");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>5000</TestTimeout>
+          <Retries>5</Retries>
+        </Playwright>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  const markers = result.stdout.split("\n").map(line => line.trim()).filter(line => line.startsWith('@marker'));
+  expect(markers).toEqual([
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-cleanup",
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-cleanup",
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-cleanup",
+  ]);
+  expect(result.stdout.match(/waiting for "Locator\("button"\)"/g).length).toBe(4);
+  expect(result.stdout).toContain('Test was retried 2 times.');
+  expect(result.rawStdout).toMatch(/Passed MyTest \[/);
+});
+
+test('should retry on timeout if the method is not aborting on timeout', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.MSTest;
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+      
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]
+      public class <class-name> : PageTest
+      {
+          static int retries = 0;
+
+          [PlaywrightTestMethod]
+          public async Task MyTest()
+          {
+              Console.WriteLine("@marker-running-spec");
+              retries++;
+              if (retries < 3)
+                await Task.Delay(-1);
+          }
+
+          [TestInitialize]
+          public void TestInitialize()
+          {
+            Console.WriteLine("@marker-initialize");
+          }
+
+          [TestCleanup]
+          public void TestCleanup()
+          {
+            Console.WriteLine("@marker-cleanup");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>5000</TestTimeout>
+          <Retries>5</Retries>
+        </Playwright>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  const markers = result.stdout.split("\n").map(line => line.trim()).filter(line => line.startsWith('@marker'));
+  expect(markers).toEqual([
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-initialize",
+    "@marker-running-spec",
+    "@marker-cleanup",
+  ]);
+  expect(result.stdout).toContain('Test was retried 2 times.');
+  expect(result.stdout.match(/Test timed out after 5000ms./g)).toHaveLength(2);
+  expect(result.rawStdout).toMatch(/Passed MyTest \[/);
+});
+
+test('should throw if the MSTest timeout < Playwright TestTimeout', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.MSTest;
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+      
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]
+      public class <class-name> : PageTest
+      {
+          [PlaywrightTestMethod]
+          public void MyTest()
+          {
+              Console.Error.WriteLine("@marker-running-spec");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>10000</TestTimeout>
+          <Retries>1</Retries>
+        </Playwright>
+        <MSTest>
+          <TestTimeout>5000</TestTimeout>
+        </MSTest>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.total).toBe(1);
+  expect(result.rawStdout).toMatch(/Playwright test timeout \(10000ms\) is larger than MSTest timeout \(5000ms\)\./);
+  expect(result.rawStdout).not.toContain('@marker-running-spec');
+});

--- a/src/Playwright.TestingHarnessTest/tests/nunit/retry.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/nunit/retry.spec.ts
@@ -190,3 +190,174 @@ test('should retry a failed test and stop once it passed', async ({ runTest }) =
   expect(result.stdout).toContain('Test was retried 4 times.');
   expect(result.rawStdout).toMatch(/Passed MyTest \[/);
 });
+
+test('should retry on timeout and print the click api call which was pending', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.NUnit;
+      using NUnit.Framework;
+      
+      namespace Playwright.TestingHarnessTest.NUnit;
+
+      [TestFixture]
+      public class <class-name> : PageTest
+      {
+          static int retries = 0;
+
+          [PlaywrightTest]
+          public async Task MyTest()
+          {
+              Console.Error.WriteLine("@marker-running-spec");
+              retries++;
+              if (retries < 3)
+                await Page.ClickAsync("button");
+          }
+
+          [SetUp]
+          public void Setup()
+          {
+            Console.Error.WriteLine("@marker-setup");
+          }
+
+          [TearDown]
+          public void Teardown()
+          {
+            Console.Error.WriteLine("@marker-teardown");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>5000</TestTimeout>
+          <Retries>5</Retries>
+        </Playwright>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  const markers = result.stderr.split("\n").map(line => line.trim());
+  expect(markers).toEqual([
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+  ]);
+  expect(result.stdout.match(/waiting for "Locator\("button"\)"/g).length).toBe(4);
+  expect(result.stdout).toContain('Test was retried 2 times.');
+  expect(result.rawStdout).toMatch(/Passed MyTest \[/);
+});
+
+test('should retry on timeout if the method is not aborting on timeout', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.NUnit;
+      using NUnit.Framework;
+      
+      namespace Playwright.TestingHarnessTest.NUnit;
+
+      [TestFixture]
+      public class <class-name> : PageTest
+      {
+          static int retries = 0;
+
+          [PlaywrightTest]
+          public async Task MyTest()
+          {
+              Console.Error.WriteLine("@marker-running-spec");
+              retries++;
+              if (retries < 3)
+                await Task.Delay(-1);
+          }
+
+          [SetUp]
+          public void Setup()
+          {
+            Console.Error.WriteLine("@marker-setup");
+          }
+
+          [TearDown]
+          public void Teardown()
+          {
+            Console.Error.WriteLine("@marker-teardown");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>5000</TestTimeout>
+          <Retries>5</Retries>
+        </Playwright>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+  const markers = result.stderr.split("\n").map(line => line.trim());
+  expect(markers).toEqual([
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+    "@marker-setup",
+    "@marker-running-spec",
+    "@marker-teardown",
+  ]);
+  expect(result.stdout).toContain('Test was retried 2 times.');
+  expect(result.stdout.match(/Test exceeded Timeout value of/g)).toHaveLength(2);
+  expect(result.rawStdout).toMatch(/Passed MyTest \[/);
+});
+
+test('should throw if the NUnit timeout < Playwright TestTimeout', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System;
+      using System.Threading.Tasks;
+      using Microsoft.Playwright.NUnit;
+      using NUnit.Framework;
+      
+      namespace Playwright.TestingHarnessTest.NUnit;
+
+      [TestFixture]
+      public class <class-name> : PageTest
+      {
+          [PlaywrightTest]
+          public void MyTest()
+          {
+              Console.Error.WriteLine("@marker-running-spec");
+          }
+      }`,
+      '.runsettings': `
+      <?xml version="1.0" encoding="utf-8"?>
+      <RunSettings>
+        <Playwright>
+          <TestTimeout>10000</TestTimeout>
+          <Retries>1</Retries>
+        </Playwright>
+        <NUnit>
+          <DefaultTimeout>5000</DefaultTimeout>
+        </NUnit>
+      </RunSettings>`,
+  }, 'dotnet test --settings=.runsettings');
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.total).toBe(1);
+  expect(result.rawStdout).toMatch(/The Playwright test timeout of \d+ms is higher than the NUnit test timeout of \d+ms./);
+  expect(result.rawStdout).not.toContain('@marker-running-spec');
+});


### PR DESCRIPTION
Differences between NUnit and MSTest:

- NUnit will call the `afterEach` when a timeout is reached, this is not possible in MSTest since the `base.Execute()` takes care of calling `beforeEach/afterEach`.

Both implementations will:
- throw if test framework timeout < Playwright test timeout
- gracefully close the BrowserContext when the test timeout has reached
- making reached timeouts compatible with retries

Relates https://github.com/microsoft/playwright-dotnet/issues/2316