### PR TITLE
chore: use ResolveAssemblyReferences instead of BeforeBuild

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="BeforeBuild">
+  <Target Name="CopyPlaywrightFilesToOutput" AfterTargets="ResolveAssemblyReferences">
     <PropertyGroup>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == ''">%(RuntimePack.RuntimeIdentifier)</PlaywrightPlatform>
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == ''">$(RuntimeIdentifier)</PlaywrightPlatform>


### PR DESCRIPTION
Which will run the `CopyPlaywrightFilesToOutput` target also on `publish --no-build`.

Fixes #2354