### PR TITLE
chore: roll to 1.28.0-beta-1668538774000

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.27.1</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.28.0-alpha-nov-11-2022</DriverVersion>
+    <DriverVersion>1.28.0-beta-1668538774000</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright.MSTest/PlaywrightTest.cs
+++ b/src/Playwright.MSTest/PlaywrightTest.cs
@@ -73,6 +73,7 @@ public class PlaywrightTest
         {
             _currentWorker = new();
         }
+        Playwright.Selectors.SetTestIdAttribute("data-testid");
     }
 
     [ClassInitialize(InheritanceBehavior.BeforeEachDerivedClass)]

--- a/src/Playwright.NUnit/PlaywrightTest.cs
+++ b/src/Playwright.NUnit/PlaywrightTest.cs
@@ -43,6 +43,7 @@ public class PlaywrightTest : WorkerAwareTest
         Playwright = await _playwrightTask.ConfigureAwait(false);
         BrowserName = PlaywrightSettingsProvider.BrowserName;
         BrowserType = Playwright[BrowserName];
+        Playwright.Selectors.SetTestIdAttribute("data-testid");
     }
 
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);

--- a/src/Playwright.Tests/BaseTests/PlaywrightTestEx.cs
+++ b/src/Playwright.Tests/BaseTests/PlaywrightTestEx.cs
@@ -38,5 +38,6 @@ public class PlaywrightTestEx : PlaywrightTest
         Server = http.Server;
         HttpsServer = http.HttpsServer;
         TestConstants.BrowserName = BrowserName;
+        Playwright.Selectors.SetTestIdAttribute("data-testid");
     }
 }

--- a/src/Playwright.Tests/Locator/LocatorFrameTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorFrameTests.cs
@@ -126,7 +126,7 @@ public class LocatorFrameTests : PageTestEx
     {
         await Page.GotoAsync(Server.EmptyPage);
         var error = await Page.FrameLocator("iframe").Locator("span").ClickAsync(new() { Timeout = 1000 }).ContinueWith(t => t.Exception.InnerException);
-        StringAssert.Contains("waiting for frameLocator('iframe')", error.Message);
+        StringAssert.Contains("waiting for FrameLocator('iframe')", error.Message);
     }
 
     [PlaywrightTest("locator-frame.spec.ts", "should wait for frame 2")]

--- a/src/Playwright.Tests/Locator/LocatorFrameTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorFrameTests.cs
@@ -126,7 +126,7 @@ public class LocatorFrameTests : PageTestEx
     {
         await Page.GotoAsync(Server.EmptyPage);
         var error = await Page.FrameLocator("iframe").Locator("span").ClickAsync(new() { Timeout = 1000 }).ContinueWith(t => t.Exception.InnerException);
-        StringAssert.Contains("waiting for FrameLocator('iframe')", error.Message);
+        StringAssert.Contains("waiting for FrameLocator(\"iframe\")", error.Message);
     }
 
     [PlaywrightTest("locator-frame.spec.ts", "should wait for frame 2")]

--- a/src/Playwright.Tests/SelectorGeneratorTests.cs
+++ b/src/Playwright.Tests/SelectorGeneratorTests.cs
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace Microsoft.Playwright.Tests;
+
+public class SelectorGeneratorTests : PageTestEx
+{
+    [PlaywrightTest("selector-generator.spec.ts", "should use data-testid in strict errors")]
+    public async Task ShouldUseDataTestIdInStrictErrors()
+    {
+        Playwright.Selectors.SetTestIdAttribute("data-custom-id");
+        await Page.SetContentAsync(@"
+      <div>
+        <div></div>
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <div>
+        <div class='foo bar:0' data-custom-id='One'>
+        </div>
+        <div class='foo bar:1' data-custom-id='Two'>
+        </div>
+      </div>
+    ");
+        var error = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.Locator(".foo").HoverAsync());
+        StringAssert.Contains("strict mode violation", error.Message);
+        StringAssert.Contains("<div class=\"foo bar:0", error.Message);
+        StringAssert.Contains("<div class=\"foo bar:1", error.Message);
+        StringAssert.Contains("aka GetByTestId(\"One\")", error.Message);
+        StringAssert.Contains("aka GetByTestId(\"Two\")", error.Message);
+    }
+}

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -227,6 +227,7 @@ internal class BrowserType : ChannelOwnerBase, IChannelOwner<BrowserType>, IBrow
                 ClosePipe();
                 throw new ArgumentException("Malformed endpoint. Did you use launchServer method?");
             }
+            playwright.SetSelectors(this.Playwright._selectors);
             browser = playwright.PreLaunchedBrowser;
             browser.ShouldCloseConnectionOnClose = true;
             browser.Disconnected += (_, _) => ClosePipe();

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -688,7 +688,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         => Locator(Core.Locator.GetByRoleSelector(role, new(options)));
 
     public ILocator GetByTestId(string testId)
-        => Locator(Core.Locator.GetByTestIdSelector(testId));
+        => Locator(Core.Locator.GetByTestIdSelector(Core.Locator.TestIdAttributeName(), testId));
 
     public ILocator GetByText(string text, FrameGetByTextOptions options = null)
         => Locator(Core.Locator.GetByTextSelector(text, options?.Exact));

--- a/src/Playwright/Core/FrameLocator.cs
+++ b/src/Playwright/Core/FrameLocator.cs
@@ -65,7 +65,7 @@ internal class FrameLocator : IFrameLocator
         => Locator(Core.Locator.GetByRoleSelector(role, new(options)));
 
     public ILocator GetByTestId(string testId)
-        => Locator(Core.Locator.GetByTestIdSelector(testId));
+        => Locator(Core.Locator.GetByTestIdSelector(Core.Locator.TestIdAttributeName(), testId));
 
     public ILocator GetByText(string text, FrameLocatorGetByTextOptions options = null)
         => Locator(Core.Locator.GetByTextSelector(text, options?.Exact));

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -374,7 +374,7 @@ internal class Locator : ILocator
         => ((ILocator)this).Locator(GetByRoleSelector(role, new(options)));
 
     public ILocator GetByTestId(string testId)
-        => ((ILocator)this).Locator(GetByTestIdSelector(testId));
+        => ((ILocator)this).Locator(GetByTestIdSelector(TestIdAttributeName(), testId));
 
     public ILocator GetByText(string text, LocatorGetByTextOptions options = null)
         => ((ILocator)this).Locator(GetByTextSelector(text, options?.Exact));
@@ -388,11 +388,13 @@ internal class Locator : ILocator
     public ILocator GetByTitle(Regex text, LocatorGetByTitleOptions options = null)
         => ((ILocator)this).Locator(GetByTitleSelector(text, options?.Exact));
 
+    internal static string TestIdAttributeName() => _testIdAttributeName;
+
     internal static void SetTestIdAttribute(string attributeName)
         => _testIdAttributeName = attributeName;
 
-    internal static string GetByTestIdSelector(string testId)
-        => GetByAttributeTextSelector(_testIdAttributeName, testId, exact: true);
+    internal static string GetByTestIdSelector(string testIdAttributeName, string testId)
+        => $"internal:testid=[{testIdAttributeName}={EscapeForAttributeSelector(testId, true)}]";
 
     internal static string GetByAttributeTextSelector(string attrName, string text, bool? exact)
         => $"internal:attr=[{attrName}={EscapeForAttributeSelector(text, exact ?? false)}]";
@@ -459,11 +461,11 @@ internal class Locator : ILocator
         }
         if (options.Name != null)
         {
-            props.Add(new List<string> { "name", EscapeForAttributeSelector(options.Name, false) });
+            props.Add(new List<string> { "name", EscapeForAttributeSelector(options.Name, options?.Exact ?? false) });
         }
         else if (options.NameString != null)
         {
-            props.Add(new List<string> { "name", EscapeForAttributeSelector(options.NameString, false) });
+            props.Add(new List<string> { "name", EscapeForAttributeSelector(options.NameString, options?.Exact ?? false) });
         }
         else if (options.NameRegex != null)
         {
@@ -529,6 +531,7 @@ internal class ByRoleOptions
         NameRegex = clone.NameRegex;
         Pressed = clone.Pressed;
         Selected = clone.Selected;
+        Exact = clone.Exact;
     }
 
     public ByRoleOptions(FrameLocatorGetByRoleOptions clone)
@@ -547,6 +550,7 @@ internal class ByRoleOptions
         NameRegex = clone.NameRegex;
         Pressed = clone.Pressed;
         Selected = clone.Selected;
+        Exact = clone.Exact;
     }
 
     public ByRoleOptions(PageGetByRoleOptions clone)
@@ -565,6 +569,7 @@ internal class ByRoleOptions
         NameRegex = clone.NameRegex;
         Pressed = clone.Pressed;
         Selected = clone.Selected;
+        Exact = clone.Exact;
     }
 
     public ByRoleOptions(LocatorGetByRoleOptions clone)
@@ -583,6 +588,7 @@ internal class ByRoleOptions
         NameRegex = clone.NameRegex;
         Pressed = clone.Pressed;
         Selected = clone.Selected;
+        Exact = clone.Exact;
     }
 
     public bool? Checked { get; set; }
@@ -604,4 +610,6 @@ internal class ByRoleOptions
     public bool? Pressed { get; set; }
 
     public bool? Selected { get; set; }
+
+    public bool? Exact { get; set; }
 }

--- a/src/Playwright/Transport/Channels/SelectorsChannel.cs
+++ b/src/Playwright/Transport/Channels/SelectorsChannel.cs
@@ -22,6 +22,7 @@
 * SOFTWARE.
 */
 
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Core;
@@ -34,18 +35,31 @@ internal class SelectorsChannel : Channel<Selectors>
     {
     }
 
-    internal async Task RegisterAsync(
-        string name,
-        string source,
-        bool? contentScript)
+    internal async Task RegisterAsync(SelectorsRegisterParams @params)
         => await Connection.SendMessageToServerAsync<JsonElement>(
             Guid,
             "register",
             new
             {
-                name = name,
-                source = source,
-                contentScript = contentScript,
+                name = @params.Name,
+                source = @params.Source,
+                contentScript = @params.ContentScript,
             })
             .ConfigureAwait(false);
+
+    internal Task SetTestIdAttributeAsync(string name)
+        => Connection.SendMessageToServerAsync<JsonElement>(
+            Guid,
+            "setTestIdAttributeName",
+            new Dictionary<string, object>
+            {
+                ["testIdAttributeName"] = name,
+            });
+}
+
+internal record SelectorsRegisterParams
+{
+    internal string Name;
+    internal string Source;
+    internal bool? ContentScript;
 }


### PR DESCRIPTION
- Add GetByRole Exact
- align selectors handling with upstream
- remove legacy namespace declaration in some of the channels (the rest is good already) moved out into https://github.com/microsoft/playwright-dotnet/pull/2391.