### PR TITLE
Use .Net 7 SDK as base image

### DIFF
--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
@@ -33,8 +33,8 @@ RUN mkdir /ms-playwright && \
     echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><add key="local" value="/tmp/"/></packageSources></configuration>' > nuget.config && \
     dotnet add package Microsoft.Playwright --prerelease && \
     dotnet build && \
-    ./bin/Debug/net6.0/playwright.ps1 install --with-deps && \
-    ./bin/Debug/net6.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    ./bin/Debug/net7.0/playwright.ps1 install --with-deps && \
+    ./bin/Debug/net7.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
     rm -rf /ms-playwright-agent && \


### PR DESCRIPTION
As a followup for both #2411 and #2410 

Context:
I am using this image as part of a bitbucket pipeline where Is execute "xUnit driven playwright test" as follows:
```
image: nwwz/playwright-dotnet:v1.28.0-net7-jammy
       caches:
        - dotnetcore
       script:
        - dotnet dev-certs https --clean
        - dotnet dev-certs https --trust
        - export TESTCONTAINERS_RYUK_DISABLED=true
        - dotnet restore
        - cd tests/End2EndTests
        - dotnet test
       services:
        - docker
```

I had to replace the official playwright image (_mcr.microsoft.com/playwright/dotnet:v1.27.0-focal_) with my own (_nwwz/playwright-dotnet:v1.28.0-net7-jammy_) as part of migrating my app to .NET 7.

_nwwz/playwright-dotnet:v1.28.0-net7-jammy_ was built using the same change as made in this PR.