### PR TITLE
Added .NET 6 as target platform

### DIFF
--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -499,7 +499,7 @@ internal class Locator : ILocator
         {
             return $"\"{text.Replace("\"", "\\\"")}\"";
         }
-        if (text.Contains("\"") || text.Contains(">>") || text[0] == '/')
+        if (text.Contains('"') || text.Contains(">>") || text[0] == '/')
         {
             return $"/{new Regex(@"\s+").Replace(EscapeForRegex(text), "\\s+")}/i";
         }

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -7,7 +7,7 @@
     <Summary>The .NET port of Playwright, used to automate Chromium, Firefox and WebKit with a single API.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DocumentationFile>Microsoft.Playwright.xml</DocumentationFile>
     <RunWithWarnings>true</RunWithWarnings>
@@ -17,7 +17,7 @@
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <BuildFromSource>True</BuildFromSource>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <NoWarn>1701;1702;CS0067;1734;NU5110;NU5111</NoWarn>
+    <NoWarn>1701;1702;CS0067;1734;NU5110;NU5111;CA1835</NoWarn>
     <AssemblyName>Microsoft.Playwright</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -29,9 +29,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'" >
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
What was changed:
-  .NET 6 was added as target platform

Motivation:
- no dependencies for .NET 6+. App will use built-in types. No changes for .NET Standard 2.0
- It allow to enable nullable reference types and provide additional information for parameters\results in future