### PR TITLE
chore: simplify Playwright CLI

### DIFF
--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -24,8 +24,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
-using System.Threading;
 using Microsoft.Playwright.Helpers;
 
 namespace Microsoft.Playwright;
@@ -54,12 +52,6 @@ public class Program
         var playwrightStartInfo = new ProcessStartInfo(pwPath, allArgs)
         {
             UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardError = true,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            StandardOutputEncoding = Encoding.UTF8,
-            StandardErrorEncoding = Encoding.UTF8,
         };
         foreach (var pair in Driver.GetEnvironmentVariables())
         {
@@ -71,41 +63,9 @@ public class Program
             StartInfo = playwrightStartInfo,
         };
 
-        using var outputWaitHandle = new AutoResetEvent(false);
-        using var errorWaitHandle = new AutoResetEvent(false);
-
-        pwProcess.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data == null)
-            {
-                outputWaitHandle.Set();
-            }
-            else
-            {
-                Console.WriteLine(e.Data);
-            }
-        };
-
-        pwProcess.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data == null)
-            {
-                errorWaitHandle.Set();
-            }
-            else
-            {
-                Console.Error.WriteLine(e.Data);
-            }
-        };
-
         pwProcess.Start();
 
-        pwProcess.BeginOutputReadLine();
-        pwProcess.BeginErrorReadLine();
-
         pwProcess.WaitForExit();
-        outputWaitHandle.WaitOne(5000);
-        errorWaitHandle.WaitOne(5000);
         return pwProcess.ExitCode;
     }
 


### PR DESCRIPTION
We only had it because we had CreateNoWindow=true and it was added in https://github.com/microsoft/playwright-dotnet/pull/1426. Let's not add it to actually forward the stderr/stdout how it should be.

I tested it that it does not produce any console window etc.