### PR TITLE
fix: Handle case when AppContext.BaseDirectory is empty

### DIFF
--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -34,8 +34,12 @@ internal static class Driver
 {
     internal static string GetExecutablePath()
     {
-        DirectoryInfo assemblyDirectory = new(AppContext.BaseDirectory);
-        if (!assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
+        DirectoryInfo assemblyDirectory = null;
+        if (!string.IsNullOrEmpty(AppContext.BaseDirectory))
+        {
+            assemblyDirectory = new(AppContext.BaseDirectory);
+        }
+        if (assemblyDirectory is null || !assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
         {
             string assemblyLocation;
             var assembly = typeof(Playwright).Assembly;

--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -39,7 +39,7 @@ internal static class Driver
         {
             assemblyDirectory = new(AppContext.BaseDirectory);
         }
-        if (assemblyDirectory is null || !assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
+        if (assemblyDirectory == null || !assemblyDirectory.Exists || !File.Exists(Path.Combine(assemblyDirectory.FullName, "Microsoft.Playwright.dll")))
         {
             string assemblyLocation;
             var assembly = typeof(Playwright).Assembly;


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2479 

Was unable to create an automated test as unsure how to alter `AppContext.BaseDirectory` without taking a complex dependency on my loading scenario. Was manually tested by loading the built `Microsoft.Playwright.dll` into a script. The fix is straightforward.