### PR TITLE
fix: Start install with no new window

### DIFF
--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -52,6 +52,7 @@ public class Program
         var playwrightStartInfo = new ProcessStartInfo(pwPath, allArgs)
         {
             UseShellExecute = false,
+            CreateNoWindow = true,
         };
         foreach (var pair in Driver.GetEnvironmentVariables())
         {


### PR DESCRIPTION
Running Playwright.Main(new [] { "install" }) shows console window in WPF app, which does not show in normal test. In normal test we are already running under existing conhost which is started as hidden so we don't show extra window. In WPF app that uses WinExe and has no existing conhost a new console is shown for playwright.cmd. This PR makes sure that the window is hidden.

Fixes #2462