### PR TITLE
fix: be able to call Route.FetchAsync() without args

### DIFF
--- a/src/Playwright.Tests/PageRequestInterceptTests.cs
+++ b/src/Playwright.Tests/PageRequestInterceptTests.cs
@@ -266,4 +266,15 @@ public class PageRequestInterceptTests : PageTestEx
         var requestBody = await requestBodyPromise;
         Assert.AreEqual(requestBody, JsonSerializer.Serialize(new Dictionary<string, object>() { { "foo", "bar" } }));
     }
+
+    [PlaywrightTest("page-request-intercept.spec.ts", "")]
+    public async Task ShouldBeAbleToCallRouteFetchWithoutParameters()
+    {
+        await Page.RouteAsync("**/*", async (route) =>
+        {
+            var response = await route.FetchAsync();
+            await route.FulfillAsync(new() { Response = response });
+        });
+        await Page.GotoAsync($"{Server.Prefix}/empty.html");
+    }
 }

--- a/src/Playwright/Core/Route.cs
+++ b/src/Playwright/Core/Route.cs
@@ -258,12 +258,12 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
             () =>
             {
                 var context = _request._context;
-                return ((APIRequestContext)context.APIRequest).InnerFetchAsync(_request, options.Url, new()
+                return ((APIRequestContext)context.APIRequest).InnerFetchAsync(_request, options?.Url, new()
                 {
-                    Headers = options.Headers,
-                    Method = options.Method,
-                    DataByte = options.PostData,
-                    MaxRedirects = options.MaxRedirects,
+                    Headers = options?.Headers,
+                    Method = options?.Method,
+                    DataByte = options?.PostData,
+                    MaxRedirects = options?.MaxRedirects,
                 });
             });
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2506