### PR TITLE
chore: swallow OperationCanceledException in transport

### DIFF
--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -167,6 +167,10 @@ internal class StdIOTransport : IDisposable
                 }
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Ignore
+        }
         catch (Exception ex)
         {
             Close(ex);


### PR DESCRIPTION
This fixes the following which was shown when debugging a .NET program using Playwright and a playwright.close was happening.:

```log
System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Threading.CancellationToken.ThrowIfCancellationRequested()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.IO.Pipes.PipeStream.ReadAsyncCore(Memory`1 destination, CancellationToken cancellationToken)
   at Microsoft.Playwright.Transport.StdIOTransport.GetResponseAsync(CancellationToken token) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Transport/StdIOTransport.cs:line 161
```

when the driver was gracefully closed.