### PR TITLE
chore: use darwin folder on osx and replace contains with identity check

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -12,25 +12,23 @@
       <PlaywrightPlatform Condition="'$(PlaywrightPlatform)' == '' AND $([MSBuild]::IsOSPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">osx-arm64</PlaywrightPlatform>
     </PropertyGroup>
     <ItemGroup Condition="'$(PlaywrightPlatform)' != 'none'">
+      <_PlaywrightPlatforms Include="$(PlaywrightPlatform)" />
        <!-- 'linux' to stay backwards compatible -->
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux-x64\**" Condition="$(PlaywrightPlatform.Contains('linux')) OR $(PlaywrightPlatform.Contains('linux-x64'))">
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux-x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'linux' OR '%(_PlaywrightPlatforms.Identity)' == 'linux-x64'">
         <PlaywrightFolder>node\linux-x64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux-arm64\**" Condition="$(PlaywrightPlatform.Contains('linux-arm64'))">
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\linux-arm64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'linux-arm64'">
         <PlaywrightFolder>node\linux-arm64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
       <!-- 'osx' to stay backwards compatible -->
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\mac-x64\**" Condition="$(PlaywrightPlatform.Contains('osx')) OR $(PlaywrightPlatform.Contains('osx-x64'))">
-        <PlaywrightFolder>node\mac-x64\</PlaywrightFolder>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\darwin-x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'osx' OR '%(_PlaywrightPlatforms.Identity)' == 'osx-x64'">
+        <PlaywrightFolder>node\darwin-x64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\mac-arm64\**" Condition="$(PlaywrightPlatform.Contains('osx-arm64'))">
-        <PlaywrightFolder>node\mac-arm64\</PlaywrightFolder>
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\darwin-arm64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'osx-arm64'">
+        <PlaywrightFolder>node\darwin-arm64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="$(PlaywrightPlatform.Contains('win'))">
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'win'">
         <PlaywrightFolder>node\win32_x64\</PlaywrightFolder>
-      </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\mac\**" Condition="$(PlaywrightPlatform.Contains('osx'))">
-        <PlaywrightFolder>node\mac\</PlaywrightFolder>
       </_PlaywrightCopyItems>
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\**" Condition="'@(_PlaywrightCopyItems->Count())' == '0'">
         <PlaywrightFolder>node\</PlaywrightFolder>


### PR DESCRIPTION
The item `<_PlaywrightPlatforms Include="$(PlaywrightPlatform)" />` will split the `PlaywrightPlatform` property by `;` and so each entry can be checked individually with `%(_PlaywrightPlatforms.Identity)` which is better than using `Contains`.

Fixes #2525

@mxschmitt It looks like with version 1.32.0 the `mac` package was renamed to `darwin` in the nuget and the changes done in #2500 look wrong to me for the `Microsoft.Playwright.targets` file.
Maybe this needs a 1.32.1 release?