### PR TITLE
test: enable tests that use screenshots as they work.

### DIFF
--- a/src/Playwright.Tests/PageRequestFulfillTests.cs
+++ b/src/Playwright.Tests/PageRequestFulfillTests.cs
@@ -72,7 +72,6 @@ public class RequestFulfillTests : PageTestEx
     }
 
     [PlaywrightTest("page-request-fulfill.spec.ts", "should allow mocking binary responses")]
-    [Ignore("We need screenshots for this")]
     public async Task ShouldAllowMockingBinaryResponses()
     {
         await Page.RouteAsync("**/*", (route) =>
@@ -101,7 +100,6 @@ public class RequestFulfillTests : PageTestEx
     }
 
     [PlaywrightTest("page-request-fulfill.spec.ts", "should work with file path")]
-    [Ignore("We need screenshots for this")]
     public async Task ShouldWorkWithFilePath()
     {
         await Page.RouteAsync("**/*", (route) =>

--- a/src/Playwright/Helpers/TaskHelper.cs
+++ b/src/Playwright/Helpers/TaskHelper.cs
@@ -204,6 +204,6 @@ internal static class TaskHelper
 
     public static void IgnoreException(this Task task)
     {
-        _ = task.ContinueWith(t => t.Exception.Handle(_ => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+        _ = task.ContinueWith(t => t.Exception!.Handle(_ => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
     }
 }

--- a/src/Playwright/Helpers/TaskHelper.cs
+++ b/src/Playwright/Helpers/TaskHelper.cs
@@ -204,6 +204,6 @@ internal static class TaskHelper
 
     public static void IgnoreException(this Task task)
     {
-        _ = task.ContinueWith(t => t.Exception!.Handle(_ => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+        _ = task.ContinueWith(t => t.Exception.Handle(_ => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
     }
 }


### PR DESCRIPTION
Enable tests that use screenshots as they work.
Removing a warning.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2541