### PR TITLE
chore(locator): Optimize Locator's constructor

### DIFF
--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -46,12 +46,6 @@ internal class Locator : ILocator
     {
         _frame = parent;
         _selector = selector;
-
-        var serializerOptions = new JsonSerializerOptions
-        {
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
-
         if (options?.HasTextRegex != null)
         {
             _selector += $" >> internal:has-text={EscapeForTextSelector(options.HasTextRegex, false)}";
@@ -72,6 +66,11 @@ internal class Locator : ILocator
             {
                 throw new ArgumentException("Inner \"Has\" locator must belong to the same frame.");
             }
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
             _selector += " >> internal:has=" + JsonSerializer.Serialize(locator._selector, serializerOptions);
         }
     }


### PR DESCRIPTION
JsonSerializerOptions is a deceptively heavy type, with [official guidance](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options?pivots=dotnet-7-0) recommending re-use, etc.

This patch only initializes a JsonSerializerOptions when it is necessary in Locator's constructor.