### PR TITLE
fix: fix ElementHandle.GetAttributeAsync when attribute does not exist

### DIFF
--- a/src/Playwright.Tests/Locator/LocatorConvenienceTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorConvenienceTests.cs
@@ -52,6 +52,15 @@ public class LocatorConvenienceTests : PageTestEx
         Assert.IsNull(await locator.GetAttributeAsync("foo"));
         Assert.AreEqual("value", await Page.GetAttributeAsync("#outer", "name"));
         Assert.IsNull(await Page.GetAttributeAsync("#outer", "foo"));
+        Assert.IsNull(await Page.GetAttributeAsync("#outer", "foo"));
+    }
+
+    [PlaywrightTest("locator-convenience.spec.ts", "getAttribute should work when attribute does not exist")]
+    public async Task GetAttributeShouldWorkWhenAttributeDoesNotExist()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.SetContentAsync("<div></div>");
+        Assert.IsNull(await (await Page.QuerySelectorAsync("div")).GetAttributeAsync("foo"));
     }
 
     [PlaywrightTest("locator-convenience.spec.ts", "inputValue should work")]

--- a/src/Playwright/Transport/Channels/ElementHandleChannel.cs
+++ b/src/Playwright/Transport/Channels/ElementHandleChannel.cs
@@ -303,7 +303,11 @@ internal class ElementHandleChannel : JSHandleChannel, IChannel<ElementHandle>
             ["name"] = name,
         };
 
-        return (await Connection.SendMessageToServerAsync(Guid, "getAttribute", args).ConfigureAwait(false))?.GetProperty("value").ToString();
+        if ((await Connection.SendMessageToServerAsync(Guid, "getAttribute", args).ConfigureAwait(false))?.TryGetProperty("value", out var value) ?? false)
+        {
+            return value.ToString();
+        }
+        return null;
     }
 
     internal async Task<string> InnerHTMLAsync()


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2566