### PR TITLE
Switching RequestFinished event handling to use IReponse object 

### DIFF
--- a/src/Playwright.Tests/BrowserContextNetworkEventTests.cs
+++ b/src/Playwright.Tests/BrowserContextNetworkEventTests.cs
@@ -106,14 +106,15 @@ public class BrowserContextNetworkEventTests : BrowserTestEx
         await using var context = await Browser.NewContextAsync();
         var page = await context.NewPageAsync();
 
-        var request = await page.RunAndWaitForRequestFinishedAsync(() => page.GotoAsync(Server.EmptyPage));
-        Assert.AreEqual(Server.EmptyPage, request.Url);
+        var response = await page.RunAndWaitForRequestFinishedAsync(() => page.GotoAsync(Server.EmptyPage));
+        Assert.AreEqual(Server.EmptyPage, response.Url);
 
-        var response = await request.ResponseAsync();
         Assert.NotNull(response);
-        Assert.NotNull(request.Frame);
-        Assert.AreEqual(Server.EmptyPage, request.Frame.Url);
-        Assert.IsNull(request.Failure);
+        Assert.NotNull(response.Frame);
+        Assert.NotNull(response.Request.Frame);
+        Assert.AreEqual(Server.EmptyPage, response.Frame.Url);
+        Assert.AreEqual(Server.EmptyPage, response.Request.Frame.Url);
+        Assert.IsNull(response.Request.Failure);
     }
 
     /// <playwright-file>browsercontext-network-event.spec.ts</playwright-file>

--- a/src/Playwright.Tests/ResourceTimingTests.cs
+++ b/src/Playwright.Tests/ResourceTimingTests.cs
@@ -48,11 +48,11 @@ public class ResourceTimingTests : ContextTestEx
     {
         await using var context = await NewContext();
         var page = await context.NewPageAsync();
-        var (request, _) = await TaskUtils.WhenAll(
+        var (response, _) = await TaskUtils.WhenAll(
             page.WaitForRequestFinishedAsync(),
             page.GotoAsync(Server.EmptyPage));
 
-        var timing = request.Timing;
+        var timing = response.Request.Timing;
 
         VerifyConnectionTimingConsistency(timing);
         Assert.GreaterOrEqual(timing.RequestStart, timing.ConnectEnd);
@@ -67,14 +67,14 @@ public class ResourceTimingTests : ContextTestEx
     {
         await using var context = await NewContext();
         var page = await context.NewPageAsync();
-        var requests = new List<IRequest>();
+        var responses = new List<IResponse>();
 
-        page.RequestFinished += (_, e) => requests.Add(e);
+        page.RequestFinished += (_, e) => responses.Add(e);
         await page.GotoAsync(Server.Prefix + "/one-style.html");
 
-        Assert.AreEqual(2, requests.Count);
+        Assert.AreEqual(2, responses.Count);
 
-        var timing = requests[1].Timing;
+        var timing = responses[1].Request.Timing;
 
         VerifyConnectionTimingConsistency(timing);
 
@@ -90,11 +90,11 @@ public class ResourceTimingTests : ContextTestEx
     {
         await using var context = await NewContext(new() { IgnoreHTTPSErrors = true });
         var page = await context.NewPageAsync();
-        var (request, _) = await TaskUtils.WhenAll(
+        var (response, _) = await TaskUtils.WhenAll(
             page.WaitForRequestFinishedAsync(),
             page.GotoAsync(HttpsServer.Prefix + "/empty.html"));
 
-        var timing = request.Timing;
+        var timing = response.Request.Timing;
         VerifyConnectionTimingConsistency(timing);
         Assert.GreaterOrEqual(timing.RequestStart, timing.ConnectEnd);
         Assert.GreaterOrEqual(timing.ResponseStart, timing.RequestStart);

--- a/src/Playwright/API/Generated/IBrowserContext.cs
+++ b/src/Playwright/API/Generated/IBrowserContext.cs
@@ -132,7 +132,7 @@ public partial interface IBrowserContext
     /// page, use <see cref="IPage.RequestFinished"/>.
     /// </para>
     /// </summary>
-    event EventHandler<IRequest> RequestFinished;
+    event EventHandler<IResponse> RequestFinished;
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -254,7 +254,7 @@ public partial interface IPage
     /// and <c>requestfinished</c>.
     /// </para>
     /// </summary>
-    event EventHandler<IRequest> RequestFinished;
+    event EventHandler<IResponse> RequestFinished;
 
     /// <summary>
     /// <para>
@@ -3002,20 +3002,20 @@ public partial interface IPage
 
     /// <summary>
     /// <para>
-    /// Performs action and waits for a <see cref="IRequest"/> to finish loading. If predicate
-    /// is provided, it passes <see cref="IRequest"/> value into the <c>predicate</c> function
+    /// Waits for a <see cref="IRequest"/> to finish loading. If predicate
+    /// is provided, it passes <see cref="IResponse"/> value into the <c>predicate</c> function
     /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
     /// error if the page is closed before the <see cref="IPage.RequestFinished"/> event
     /// is fired.
     /// </para>
     /// </summary>
     /// <param name="options">Call options</param>
-    Task<IRequest> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions? options = default);
+    Task<IResponse> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions? options = default);
 
     /// <summary>
     /// <para>
     /// Performs action and waits for a <see cref="IRequest"/> to finish loading. If predicate
-    /// is provided, it passes <see cref="IRequest"/> value into the <c>predicate</c> function
+    /// is provided, it passes <see cref="IResponse"/> value into the <c>predicate</c> function
     /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
     /// error if the page is closed before the <see cref="IPage.RequestFinished"/> event
     /// is fired.
@@ -3023,7 +3023,7 @@ public partial interface IPage
     /// </summary>
     /// <param name="action">Action that triggers the event.</param>
     /// <param name="options">Call options</param>
-    Task<IRequest> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions? options = default);
+    Task<IResponse> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions? options = default);
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageRunAndWaitForRequestFinishedOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageRunAndWaitForRequestFinishedOptions.cs
@@ -46,12 +46,12 @@ public class PageRunAndWaitForRequestFinishedOptions
 
     /// <summary>
     /// <para>
-    /// Receives the <see cref="IRequest"/> object and resolves to truthy value when the
+    /// Receives the <see cref="IResponse"/> object and resolves to truthy value when the
     /// waiting should resolve.
     /// </para>
     /// </summary>
     [JsonPropertyName("predicate")]
-    public Func<IRequest, bool>? Predicate { get; set; }
+    public Func<IResponse, bool>? Predicate { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageWaitForRequestFinishedOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageWaitForRequestFinishedOptions.cs
@@ -46,12 +46,12 @@ public class PageWaitForRequestFinishedOptions
 
     /// <summary>
     /// <para>
-    /// Receives the <see cref="IRequest"/> object and resolves to truthy value when the
+    /// Receives the <see cref="IResponse"/> object and resolves to truthy value when the
     /// waiting should resolve.
     /// </para>
     /// </summary>
     [JsonPropertyName("predicate")]
-    public Func<IRequest, bool>? Predicate { get; set; }
+    public Func<IResponse, bool>? Predicate { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -79,8 +79,8 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         {
             e.Request.SetResponseEndTiming(e.ResponseEndTiming);
             e.Request.Sizes = e.RequestSizes;
-            _requestFinishedImpl?.Invoke(this, e.Request);
-            e.Page?.FireRequestFinished(e.Request);
+            _requestFinishedImpl?.Invoke(this, e.Response);
+            e.Page?.FireRequestFinished(e.Response);
             e.Response?.ReportFinished();
         };
         Channel.Response += (_, e) =>
@@ -105,7 +105,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
 
     private event EventHandler<IResponse> _responseImpl;
 
-    private event EventHandler<IRequest> _requestFinishedImpl;
+    private event EventHandler<IResponse> _requestFinishedImpl;
 
     private event EventHandler<IRequest> _requestFailedImpl;
 
@@ -125,7 +125,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         remove => this._responseImpl = UpdateEventHandler("response", this._responseImpl, value, false);
     }
 
-    public event EventHandler<IRequest> RequestFinished
+    public event EventHandler<IResponse> RequestFinished
     {
         add => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, true);
         remove => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, false);

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -133,7 +133,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     private event EventHandler<IResponse> _responseImpl;
 
-    private event EventHandler<IRequest> _requestFinishedImpl;
+    private event EventHandler<IResponse> _requestFinishedImpl;
 
     private event EventHandler<IRequest> _requestFailedImpl;
 
@@ -157,7 +157,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         remove => this._responseImpl = UpdateEventHandler("response", this._responseImpl, value, false);
     }
 
-    public event EventHandler<IRequest> RequestFinished
+    public event EventHandler<IResponse> RequestFinished
     {
         add => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, true);
         remove => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, false);
@@ -354,7 +354,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
     public Task<IRequest> WaitForRequestAsync(Func<IRequest, bool> urlOrPredicate, PageWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, null, e => urlOrPredicate(e), options?.Timeout);
 
-    public Task<IRequest> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions options = default)
+    public Task<IResponse> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, null, options?.Predicate, options?.Timeout);
 
     public Task<IResponse> WaitForResponseAsync(string urlOrPredicate, PageWaitForResponseOptions options = default)
@@ -381,7 +381,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
     public Task<IPage> RunAndWaitForPopupAsync(Func<Task> action, PageRunAndWaitForPopupOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Popup, action, options?.Predicate, options?.Timeout);
 
-    public Task<IRequest> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions options = default)
+    public Task<IResponse> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, action, options?.Predicate, options?.Timeout);
 
     public Task<IWebSocket> RunAndWaitForWebSocketAsync(Func<Task> action, PageRunAndWaitForWebSocketOptions options = default)
@@ -984,7 +984,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     internal void FireRequestFailed(IRequest request) => _requestFailedImpl?.Invoke(this, request);
 
-    internal void FireRequestFinished(IRequest request) => _requestFinishedImpl?.Invoke(this, request);
+    internal void FireRequestFinished(IResponse response) => _requestFinishedImpl?.Invoke(this, response);
 
     internal void FireResponse(IResponse response) => _responseImpl?.Invoke(this, response);
 

--- a/src/Playwright/Core/PageEvent.cs
+++ b/src/Playwright/Core/PageEvent.cs
@@ -34,7 +34,7 @@ internal static class PageEvent
     /// <summary>
     /// <see cref="PlaywrightEvent{T}"/> representing a <see cref="IPage.RequestFinished"/>.
     /// </summary>
-    public static PlaywrightEvent<IRequest> RequestFinished { get; } = new() { Name = "RequestFinished" };
+    public static PlaywrightEvent<IResponse> RequestFinished { get; } = new() { Name = "RequestFinished" };
 
     /// <summary>
     /// <see cref="PlaywrightEvent{T}"/> representing a <see cref="IPage.Crash"/>.


### PR DESCRIPTION
Switching RequestFinished event handling to use IReponse object that is already there - it is more useful in this context.