### PR TITLE
Add an artificial ResponseFinished to pass IResponse alongside IRequest

### DIFF
--- a/src/Playwright.Tests/PageEventNetworkTests.cs
+++ b/src/Playwright.Tests/PageEventNetworkTests.cs
@@ -128,6 +128,7 @@ public class PageEventNetworkTests : PageTestEx
         Page.Request += (_, e) => events[e.Url].Add(e.Method);
         Page.Response += (_, e) => events[e.Url].Add(e.Status.ToString(CultureInfo.InvariantCulture));
         Page.RequestFinished += (_, e) => events[e.Url].Add("DONE");
+        Page.ResponseFinished += (_, e) => events[e.Response.Url].Add("DONE_2");
         Page.RequestFailed += (_, e) => events[e.Url].Add("FAIL");
         Server.SetRedirect("/foo.html", "/empty.html");
         var response = await Page.GotoAsync(FOO_URL);
@@ -135,8 +136,8 @@ public class PageEventNetworkTests : PageTestEx
 
         var expected = new Dictionary<string, List<string>>
         {
-            [FOO_URL] = new() { "GET", "302", "DONE" },
-            [EMPTY_URL] = new() { "GET", "200", "DONE" }
+            [FOO_URL] = new() { "GET", "302", "DONE", "DONE_2" },
+            [EMPTY_URL] = new() { "GET", "200", "DONE", "DONE_2" }
         };
 
         Assert.AreEqual(expected, events);

--- a/src/Playwright.Tests/PageGotoTests.cs
+++ b/src/Playwright.Tests/PageGotoTests.cs
@@ -235,6 +235,11 @@ public class PageGotoTests : PageTestEx
     {
         Page.Request += (_, e) => Assert.NotNull(e);
         Page.RequestFinished += (_, e) => Assert.NotNull(e);
+        Page.ResponseFinished += (_, e) =>
+        {
+            Assert.NotNull(e.Request);
+            Assert.NotNull(e.Response);
+        };
         Page.RequestFailed += (_, e) => Assert.NotNull(e);
 
         var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.GotoAsync(HttpsServer.Prefix + "/empty.html"));

--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -153,7 +153,7 @@ public class PageNetworkResponseTests : PageTestEx
         bool requestFinished = false;
         Page.RequestFinished += (_, e) => requestFinished = requestFinished || e.Url.Contains("/get");
         bool responseFinished = false;
-        Page.ResponseFinished+= (_, e) => responseFinished = responseFinished || e.Response.Url.Contains("/get");
+        Page.ResponseFinished += (_, e) => responseFinished = responseFinished || e.Response.Url.Contains("/get");
         // send request and wait for server response
         var (pageResponse, _) = await TaskUtils.WhenAll(
             Page.WaitForResponseAsync("**/*"),

--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -152,6 +152,8 @@ public class PageNetworkResponseTests : PageTestEx
         // Setup page to trap response.
         bool requestFinished = false;
         Page.RequestFinished += (_, e) => requestFinished = requestFinished || e.Url.Contains("/get");
+        bool responseFinished = false;
+        Page.ResponseFinished+= (_, e) => responseFinished = responseFinished || e.Response.Url.Contains("/get");
         // send request and wait for server response
         var (pageResponse, _) = await TaskUtils.WhenAll(
             Page.WaitForResponseAsync("**/*"),
@@ -163,6 +165,7 @@ public class PageNetworkResponseTests : PageTestEx
         Assert.NotNull(pageResponse);
         Assert.AreEqual((int)HttpStatusCode.OK, pageResponse.Status);
         Assert.False(requestFinished);
+        Assert.False(responseFinished);
 
         var responseText = pageResponse.TextAsync();
         // Write part of the response and wait for it to be flushed.

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -3011,7 +3011,7 @@ public partial interface IPage
 
     /// <summary>
     /// <para>
-    /// Performs action and waits for a <see cref="IRequest"/> to finish loading. If predicate
+    /// Waits for a <see cref="IRequest"/> to finish loading. If predicate
     /// is provided, it passes <see cref="IRequest"/> value into the <c>predicate</c> function
     /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
     /// error if the page is closed before the <see cref="IPage.RequestFinished"/> event
@@ -3038,8 +3038,8 @@ public partial interface IPage
     /// <para>
     /// Waits for a <see cref="IRequest"/> to finish loading. If predicate
     /// is provided, it passes <see cref="IRequest"/> and <see cref="IResponse"/> value into the <c>predicate</c> function
-    /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
-    /// error if the page is closed before the <see cref="IPage.ResponseFinished"/> event
+    /// and waits for <c>predicate(request, response)</c> to return a truthy value. Will throw an
+    /// error if the page is closed before the <see cref="IPage.RequestFinished"/> event
     /// is fired.
     /// </para>
     /// </summary>
@@ -3050,8 +3050,8 @@ public partial interface IPage
     /// <para>
     /// Performs action and waits for a <see cref="IRequest"/> to finish loading. If predicate
     /// is provided, it passes <see cref="IRequest"/> and <see cref="IResponse"/> value into the <c>predicate</c> function
-    /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
-    /// error if the page is closed before the <see cref="IPage.ResponseFinished"/> event
+    /// and waits for <c>predicate(request, response)</c> to return a truthy value. Will throw an
+    /// error if the page is closed before the <see cref="IPage.RequestFinished"/> event
     /// is fired.
     /// </para>
     /// </summary>

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -258,6 +258,15 @@ public partial interface IPage
 
     /// <summary>
     /// <para>
+    /// Emitted after request finishes successfully after downloading the response body to filter by response.
+    /// For a successful response, the sequence of events is <c>request</c>, <c>response</c>
+    /// and <c>requestfinished</c>.
+    /// </para>
+    /// </summary>
+    event EventHandler<(IRequest Request, IResponse? Response)> ResponseFinished;
+
+    /// <summary>
+    /// <para>
     /// Emitted when <see cref="response"/> status and headers are received for a request.
     /// For a successful response, the sequence of events is <c>request</c>, <c>response</c>
     /// and <c>requestfinished</c>.
@@ -3024,6 +3033,31 @@ public partial interface IPage
     /// <param name="action">Action that triggers the event.</param>
     /// <param name="options">Call options</param>
     Task<IRequest> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions? options = default);
+
+    /// <summary>
+    /// <para>
+    /// Waits for a <see cref="IRequest"/> to finish loading. If predicate
+    /// is provided, it passes <see cref="IRequest"/> and <see cref="IResponse"/> value into the <c>predicate</c> function
+    /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
+    /// error if the page is closed before the <see cref="IPage.ResponseFinished"/> event
+    /// is fired.
+    /// </para>
+    /// </summary>
+    /// <param name="options">Call options</param>
+    Task<(IRequest Request, IResponse Response)> WaitForResponseFinishedAsync(PageWaitForRequestFinishedOptions? options = default);
+
+    /// <summary>
+    /// <para>
+    /// Performs action and waits for a <see cref="IRequest"/> to finish loading. If predicate
+    /// is provided, it passes <see cref="IRequest"/> and <see cref="IResponse"/> value into the <c>predicate</c> function
+    /// and waits for <c>predicate(request)</c> to return a truthy value. Will throw an
+    /// error if the page is closed before the <see cref="IPage.ResponseFinished"/> event
+    /// is fired.
+    /// </para>
+    /// </summary>
+    /// <param name="action">Action that triggers the event.</param>
+    /// <param name="options">Call options</param>
+    Task<(IRequest Request, IResponse Response)> RunAndWaitForResponseFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions? options = default);
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -3044,7 +3044,7 @@ public partial interface IPage
     /// </para>
     /// </summary>
     /// <param name="options">Call options</param>
-    Task<(IRequest Request, IResponse Response)> WaitForResponseFinishedAsync(PageWaitForRequestFinishedOptions? options = default);
+    Task<(IRequest Request, IResponse Response)> WaitForResponseFinishedAsync(PageWaitForResponseFinishedOptions? options = default);
 
     /// <summary>
     /// <para>
@@ -3057,7 +3057,7 @@ public partial interface IPage
     /// </summary>
     /// <param name="action">Action that triggers the event.</param>
     /// <param name="options">Call options</param>
-    Task<(IRequest Request, IResponse Response)> RunAndWaitForResponseFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions? options = default);
+    Task<(IRequest Request, IResponse Response)> RunAndWaitForResponseFinishedAsync(Func<Task> action, PageRunAndWaitForResponseFinishedOptions? options = default);
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageRunAndWaitForResponseFinishedOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageRunAndWaitForResponseFinishedOptions.cs
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Microsoft.Playwright;
+
+public class PageRunAndWaitForResponseFinishedOptions
+{
+    public PageRunAndWaitForResponseFinishedOptions() { }
+
+    public PageRunAndWaitForResponseFinishedOptions(PageRunAndWaitForResponseFinishedOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
+
+        Predicate = clone.Predicate;
+        Timeout = clone.Timeout;
+    }
+
+    /// <summary>
+    /// <para>
+    /// Receives the <see cref="IRequest"/> and <see cref="IResponse"/> object and resolves to truthy value when the
+    /// waiting should resolve.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("predicate")]
+    public Func<(IRequest Request, IResponse? Response), bool>? Predicate { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Maximum time to wait for in milliseconds. Defaults to <c>30000</c> (30 seconds).
+    /// Pass <c>0</c> to disable timeout. The default value can be changed by using the
+    /// <see cref="IBrowserContext.SetDefaultTimeout"/>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("timeout")]
+    public float? Timeout { get; set; }
+}
+
+#nullable disable

--- a/src/Playwright/API/Generated/Options/PageWaitForResponseFinishedOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageWaitForResponseFinishedOptions.cs
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Microsoft.Playwright;
+
+public class PageWaitForResponseFinishedOptions
+{
+    public PageWaitForResponseFinishedOptions() { }
+
+    public PageWaitForResponseFinishedOptions(PageWaitForResponseFinishedOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
+
+        Predicate = clone.Predicate;
+        Timeout = clone.Timeout;
+    }
+
+    /// <summary>
+    /// <para>
+    /// Receives the <see cref="IRequest"/> and <see cref="IResponse"/> object and resolves to truthy value when the
+    /// waiting should resolve.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("predicate")]
+    public Func<(IRequest Request, IResponse? Response), bool>? Predicate { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Maximum time to wait for in milliseconds. Defaults to <c>30000</c> (30 seconds).
+    /// Pass <c>0</c> to disable timeout. The default value can be changed by using the
+    /// <see cref="IBrowserContext.SetDefaultTimeout"/>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("timeout")]
+    public float? Timeout { get; set; }
+}
+
+#nullable disable

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -82,6 +82,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
             _requestFinishedImpl?.Invoke(this, e.Request);
             e.Page?.FireRequestFinished(e.Request);
             e.Response?.ReportFinished();
+            e.Page?.FireResponseFinished(e.Request, e.Response);
         };
         Channel.Response += (_, e) =>
         {

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -135,6 +135,8 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     private event EventHandler<IRequest> _requestFinishedImpl;
 
+    private event EventHandler<(IRequest Request, IResponse Response)> _responseFinishedImpl;
+
     private event EventHandler<IRequest> _requestFailedImpl;
 
     private event EventHandler<IFileChooser> _fileChooserImpl;
@@ -161,6 +163,13 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
     {
         add => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, true);
         remove => this._requestFinishedImpl = UpdateEventHandler("requestFinished", this._requestFinishedImpl, value, false);
+    }
+
+    // Response finished is an artificial event - actual is the requestFinished
+    public event EventHandler<(IRequest Request, IResponse Response)> ResponseFinished
+    {
+        add => this._responseFinishedImpl = UpdateEventHandler("requestFinished", this._responseFinishedImpl, value, true);
+        remove => this._responseFinishedImpl = UpdateEventHandler("requestFinished", this._responseFinishedImpl, value, false);
     }
 
     public event EventHandler<IRequest> RequestFailed
@@ -357,6 +366,9 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
     public Task<IRequest> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, null, options?.Predicate, options?.Timeout);
 
+    public Task<(IRequest Request, IResponse Response)> WaitForResponseFinishedAsync(PageWaitForResponseFinishedOptions options = default)
+        => InnerWaitForEventAsync(PageEvent.ResponseFinished, null, options?.Predicate, options?.Timeout);
+
     public Task<IResponse> WaitForResponseAsync(string urlOrPredicate, PageWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, null, e => Context.UrlMatches(e.Url, urlOrPredicate), options?.Timeout);
 
@@ -383,6 +395,9 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     public Task<IRequest> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, action, options?.Predicate, options?.Timeout);
+
+    public Task<(IRequest Request, IResponse Response)> RunAndWaitForResponseFinishedAsync(Func<Task> action, PageRunAndWaitForResponseFinishedOptions options = default)
+        => InnerWaitForEventAsync(PageEvent.ResponseFinished, action, options?.Predicate, options?.Timeout);
 
     public Task<IWebSocket> RunAndWaitForWebSocketAsync(Func<Task> action, PageRunAndWaitForWebSocketOptions options = default)
         => InnerWaitForEventAsync(PageEvent.WebSocket, action, options?.Predicate, options?.Timeout);
@@ -985,6 +1000,8 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
     internal void FireRequestFailed(IRequest request) => _requestFailedImpl?.Invoke(this, request);
 
     internal void FireRequestFinished(IRequest request) => _requestFinishedImpl?.Invoke(this, request);
+
+    internal void FireResponseFinished(IRequest request, IResponse response) => _responseFinishedImpl?.Invoke(this, (request, response));
 
     internal void FireResponse(IResponse response) => _responseImpl?.Invoke(this, response);
 

--- a/src/Playwright/Core/PageEvent.cs
+++ b/src/Playwright/Core/PageEvent.cs
@@ -37,6 +37,11 @@ internal static class PageEvent
     public static PlaywrightEvent<IRequest> RequestFinished { get; } = new() { Name = "RequestFinished" };
 
     /// <summary>
+    /// <see cref="PlaywrightEvent{T}"/> representing an artificial ResponseFinished event to pass <see cref="IResponse"/> in addition of <see cref="IRequest"/>.
+    /// </summary>
+    public static PlaywrightEvent<(IRequest Request, IResponse Response)> ResponseFinished { get; } = new() { Name = "ResponseFinished" };
+
+    /// <summary>
     /// <see cref="PlaywrightEvent{T}"/> representing a <see cref="IPage.Crash"/>.
     /// </summary>
     public static PlaywrightEvent<IPage> Crash { get; } = new() { Name = "Crash" };


### PR DESCRIPTION
Add an artificial ResponseFinished to pass IResponse alongside IRequest for predicates - the most compatible way I thought of

https://github.com/microsoft/playwright-dotnet/issues/2576