### PR TITLE
chore: small refinements string constants extraction and use more readable String.Equals implementation

### DIFF
--- a/src/Playwright.Tests.TestServer/SimpleServer.cs
+++ b/src/Playwright.Tests.TestServer/SimpleServer.cs
@@ -46,7 +46,11 @@ namespace Microsoft.Playwright.Tests.TestServer;
 
 public class SimpleServer
 {
-    const int MaxMessageSize = 256 * 1024;
+    private const string AuthorizationHeader = "Authorization";
+    private const string BasicAuthorizationWithSpace = "Basic ";
+
+
+    private const int MaxMessageSize = 256 * 1024;
 
     private readonly IDictionary<string, Action<HttpContext>> _requestWaits;
     private readonly IList<Action<HttpContext>> _waitForWebSocketConnectionRequestsWaits;
@@ -297,10 +301,10 @@ public class SimpleServer
 
     private static bool Authenticate(string username, string password, HttpContext context)
     {
-        string authHeader = context.Request.Headers["Authorization"];
-        if (authHeader != null && authHeader.StartsWith("Basic", StringComparison.Ordinal))
+        string authHeader = context.Request.Headers[AuthorizationHeader];
+        if (authHeader != null && authHeader.StartsWith(BasicAuthorizationWithSpace, StringComparison.Ordinal))
         {
-            string encodedUsernamePassword = authHeader.Substring("Basic ".Length).Trim();
+            string encodedUsernamePassword = authHeader[BasicAuthorizationWithSpace.Length..].Trim();
             var encoding = Encoding.GetEncoding("iso-8859-1");
             string auth = encoding.GetString(Convert.FromBase64String(encodedUsernamePassword));
 

--- a/src/Playwright/Core/RawHeaders.cs
+++ b/src/Playwright/Core/RawHeaders.cs
@@ -61,7 +61,7 @@ internal class RawHeaders
             return null;
         }
 
-        return string.Join("set-cookie".Equals(name, StringComparison.OrdinalIgnoreCase) ? "\n" : ", ", values);
+        return string.Join(string.Equals("set-cookie", name, StringComparison.OrdinalIgnoreCase) ? "\n" : ", ", values);
     }
 
     public string[] GetAll(string name)


### PR DESCRIPTION
chore: string constants extraction and use more readable String.Equals implementation)
- extracted some strings to constants on top of classes and methods
- use more readable Equals with regard to comparing constant strings with input

fixes https://github.com/microsoft/playwright-dotnet/issues/2595