### PR TITLE
Prevent TieredPGO inlining from breaking stack trace walking logic

### DIFF
--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Playwright.Tests;
+
+public class ConventionTests
+{
+    // To ensure that public method are not inlined by the nwe PGO guided tiered JIT,
+    // we need to mark them with [MethodImpl(MethodImplOptions.NoInlining)]
+    [Test]
+    public void EnsurePublicMethodsAreNotInlined()
+    {
+        var assembly = typeof(Playwright).Assembly;
+
+        var types = assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract)
+            .Where(t => t.BaseType != null && t.BaseType.Name == "ChannelOwnerBase");
+
+        foreach (var type in types)
+        {
+            var methods = type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => !m.IsSpecialName)
+                .Where(m => m.Name != "Dispose" && m.Name != "DisposeAsync" && m.Name != "ToString");
+
+            foreach (var method in methods)
+            {
+                Assert.True(method.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining), $"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
+            }
+        }
+    }
+}

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -30,7 +30,9 @@ public class ConventionTests
             {
                 if (!method.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining))
                 {
-                    failedAssertions.AppendLine(CultureInfo.InvariantCulture, $"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
+#pragma warning disable CA1305
+                    failedAssertions.AppendLine($"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
+#pragma warning restore CA1305
                 }
             }
         }

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -30,9 +30,11 @@ public class ConventionTests
             {
                 if (!method.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining))
                 {
-#pragma warning disable CA1305
-                    failedAssertions.AppendLine($"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
-#pragma warning restore CA1305
+                    failedAssertions.AppendLine(
+                        ((FormattableString)
+                            $"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]")
+                        .ToString(CultureInfo.InvariantCulture)
+                    );
                 }
             }
         }

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -8,6 +8,7 @@ public class ConventionTests
 {
     // To ensure that public method are not inlined by the new tiered PGO JIT mode,
     // we need to mark them with [MethodImpl(MethodImplOptions.NoInlining)]
+    // See https://github.com/microsoft/playwright-dotnet/issues/2617
     [Test]
     public void EnsurePublicMethodsAreNotInlined()
     {

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -24,7 +24,7 @@ public class ConventionTests
             var methods = type
                 .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                 .Where(m => !m.IsSpecialName)
-                .Where(m => m.Name != "Dispose" && m.Name != "DisposeAsync" && m.Name != "ToString");
+                .Where(m => m.Name != "Dispose" && m.Name != "ToString");
 
             foreach (var method in methods)
             {

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -1,5 +1,6 @@
+using System.Globalization;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Microsoft.Playwright.Tests;
 
@@ -16,6 +17,8 @@ public class ConventionTests
             .Where(t => t.IsClass && !t.IsAbstract)
             .Where(t => t.BaseType != null && t.BaseType.Name == "ChannelOwnerBase");
 
+        var failedAssertions = new StringBuilder();
+
         foreach (var type in types)
         {
             var methods = type
@@ -25,8 +28,16 @@ public class ConventionTests
 
             foreach (var method in methods)
             {
-                Assert.True(method.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining), $"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
+                if (!method.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining))
+                {
+                    failedAssertions.AppendLine(CultureInfo.InvariantCulture, $"{type.Name}.{method.Name} is not marked with [MethodImpl(MethodImplOptions.NoInlining)]");
+                }
             }
+        }
+
+        if (failedAssertions.Length > 0)
+        {
+            throw new AssertionException(failedAssertions.ToString());
         }
     }
 }

--- a/src/Playwright.Tests/ConventionTests.cs
+++ b/src/Playwright.Tests/ConventionTests.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Playwright.Tests;
 
 public class ConventionTests
 {
-    // To ensure that public method are not inlined by the nwe PGO guided tiered JIT,
+    // To ensure that public method are not inlined by the new tiered PGO JIT mode,
     // we need to mark them with [MethodImpl(MethodImplOptions.NoInlining)]
     [Test]
     public void EnsurePublicMethodsAreNotInlined()

--- a/src/Playwright/Core/APIRequestContext.cs
+++ b/src/Playwright/Core/APIRequestContext.cs
@@ -53,6 +53,7 @@ internal class APIRequestContext : ChannelOwnerBase, IChannelOwner<APIRequestCon
 
     IChannel<APIRequestContext> IChannelOwner<APIRequestContext>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ValueTask DisposeAsync() => new(_channel.DisposeAsync());
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Playwright/Core/APIRequestContext.cs
+++ b/src/Playwright/Core/APIRequestContext.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
@@ -54,6 +55,7 @@ internal class APIRequestContext : ChannelOwnerBase, IChannelOwner<APIRequestCon
 
     public ValueTask DisposeAsync() => new(_channel.DisposeAsync());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> FetchAsync(IRequest request, APIRequestContextOptions options = null)
         => InnerFetchAsync(request, null, options);
 
@@ -76,6 +78,7 @@ internal class APIRequestContext : ChannelOwnerBase, IChannelOwner<APIRequestCon
         return await FetchAsync(urlOverride ?? request.Url, options).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IAPIResponse> FetchAsync(string url, APIRequestContextOptions options = null)
     {
         options ??= new APIRequestContextOptions();
@@ -146,16 +149,22 @@ internal class APIRequestContext : ChannelOwnerBase, IChannelOwner<APIRequestCon
         return contentType.Value.Contains("application/json");
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> DeleteAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "DELETE"));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> GetAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "GET"));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> HeadAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "HEAD"));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> PatchAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "PATCH"));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> PostAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "POST"));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> PutAsync(string url, APIRequestContextOptions options = null) => FetchAsync(url, WithMethod(options, "PUT"));
 
     private APIRequestContextOptions WithMethod(APIRequestContextOptions options, string method)
@@ -165,6 +174,7 @@ internal class APIRequestContext : ChannelOwnerBase, IChannelOwner<APIRequestCon
         return options;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> StorageStateAsync(APIRequestContextStorageStateOptions options = null)
     {
         string state = JsonSerializer.Serialize(

--- a/src/Playwright/Core/Artifact.cs
+++ b/src/Playwright/Core/Artifact.cs
@@ -23,6 +23,7 @@
  */
 
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
 using Microsoft.Playwright.Transport.Channels;
@@ -50,6 +51,7 @@ internal class Artifact : ChannelOwnerBase, IChannelOwner<Artifact>
 
     internal string AbsolutePath { get; }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> PathAfterFinishedAsync()
     {
         if (_connection.IsRemote)
@@ -59,6 +61,7 @@ internal class Artifact : ChannelOwnerBase, IChannelOwner<Artifact>
         return await _channel.PathAfterFinishedAsync().ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task SaveAsAsync(string path)
     {
         if (!_connection.IsRemote)
@@ -77,6 +80,7 @@ internal class Artifact : ChannelOwnerBase, IChannelOwner<Artifact>
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<System.IO.Stream> CreateReadStreamAsync()
     {
         var stream = await _channel.StreamAsync().ConfigureAwait(false);

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -185,6 +185,7 @@ internal class Browser : ChannelOwnerBase, IChannelOwner<Browser>, IBrowser
         }).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
 
     internal static Dictionary<string, object> GetVideoArgs(string recordVideoDir, RecordVideoSize recordVideoSize)

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
 using Microsoft.Playwright.Transport.Channels;
@@ -64,6 +65,7 @@ internal class Browser : ChannelOwnerBase, IChannelOwner<Browser>, IBrowser
 
     public IBrowserType BrowserType => _browserType;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task CloseAsync()
     {
         try
@@ -84,6 +86,7 @@ internal class Browser : ChannelOwnerBase, IChannelOwner<Browser>, IBrowser
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IBrowserContext> NewContextAsync(BrowserNewContextOptions options = default)
     {
         options ??= new();
@@ -126,6 +129,7 @@ internal class Browser : ChannelOwnerBase, IChannelOwner<Browser>, IBrowser
         return context;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IPage> NewPageAsync(BrowserNewPageOptions options = default)
     {
         options ??= new();
@@ -215,6 +219,7 @@ internal class Browser : ChannelOwnerBase, IChannelOwner<Browser>, IBrowser
         _closedTcs.TrySetResult(true);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<ICDPSession> NewBrowserCDPSessionAsync()
         => (await Channel.NewBrowserCDPSessionAsync().ConfigureAwait(false)).Object;
 }

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -213,8 +214,10 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
 
     public IReadOnlyList<IWorker> ServiceWorkers => _serviceWorkers;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task AddCookiesAsync(IEnumerable<Cookie> cookies) => Channel.AddCookiesAsync(cookies);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task AddInitScriptAsync(string script = null, string scriptPath = null)
     {
         if (string.IsNullOrEmpty(script))
@@ -225,10 +228,13 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         return Channel.AddInitScriptAsync(script);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ClearCookiesAsync() => Channel.ClearCookiesAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ClearPermissionsAsync() => Channel.ClearPermissionsAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task CloseAsync()
     {
         if (_closeWasCalled)
@@ -272,65 +278,86 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         _tracing._tracesDir = tracesDir;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<BrowserContextCookiesResult>> CookiesAsync(IEnumerable<string> urls = null) => Channel.CookiesAsync(urls);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync(string name, Action callback, BrowserContextExposeBindingOptions options = default)
         => ExposeBindingAsync(name, callback, handle: options?.Handle ?? false);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync(string name, Action<BindingSource> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T>(string name, Action<BindingSource, T> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback)
         => ExposeBindingAsync(name, callback, true);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, TResult>(string name, Func<BindingSource, T1, T2, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, T3, TResult>(string name, Func<BindingSource, T1, T2, T3, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, T3, T4, TResult>(string name, Func<BindingSource, T1, T2, T3, T4, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync(string name, Action callback)
         => ExposeBindingAsync(name, (BindingSource _) => callback());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T>(string name, Action<T> callback)
         => ExposeBindingAsync(name, (BindingSource _, T t) => callback(t));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<TResult>(string name, Func<TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _) => callback());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T, TResult>(string name, Func<T, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T t) => callback(t));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, TResult>(string name, Func<T1, T2, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2) => callback(t1, t2));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, T3, TResult>(string name, Func<T1, T2, T3, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2, T3 t3) => callback(t1, t2, t3));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, T3, T4, TResult>(string name, Func<T1, T2, T3, T4, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2, T3 t3, T4 t4) => callback(t1, t2, t3, t4));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task GrantPermissionsAsync(IEnumerable<string> permissions, BrowserContextGrantPermissionsOptions options = default)
         => Channel.GrantPermissionsAsync(permissions, options?.Origin);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<ICDPSession> NewCDPSessionAsync(IPage page)
         => (await Channel.NewCDPSessionAsync(page as Page).ConfigureAwait(false)).Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<ICDPSession> NewCDPSessionAsync(IFrame frame)
         => (await Channel.NewCDPSessionAsync(frame as Frame).ConfigureAwait(false)).Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IPage> NewPageAsync()
     {
         if (OwnerPage != null)
@@ -341,31 +368,41 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         return (await Channel.NewPageAsync().ConfigureAwait(false)).Object;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(string url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
         => RouteAsync(new Regex(CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(string url, Func<IRoute, Task> handler, BrowserContextRouteOptions options = null)
         => RouteAsync(new Regex(CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Regex url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
         => RouteAsync(url, null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Regex url, Func<IRoute, Task> handler, BrowserContextRouteOptions options = default)
         => RouteAsync(url, null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Func<string, bool> url, Action<IRoute> handler, BrowserContextRouteOptions options = default)
         => RouteAsync(null, url, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Func<string, bool> url, Func<IRoute, Task> handler, BrowserContextRouteOptions options = default)
         => RouteAsync(null, url, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetExtraHTTPHeadersAsync(IEnumerable<KeyValuePair<string, string>> headers)
         => Channel.SetExtraHTTPHeadersAsync(headers);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetGeolocationAsync(Geolocation geolocation) => Channel.SetGeolocationAsync(geolocation);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetOfflineAsync(bool offline) => Channel.SetOfflineAsync(offline);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> StorageStateAsync(BrowserContextStorageStateOptions options = default)
     {
         string state = JsonSerializer.Serialize(
@@ -380,24 +417,31 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         return state;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(string urlString, Action<IRoute> handler = default)
         => UnrouteAsync(new Regex(CombineUrlWithBase(urlString).GlobToRegex()), null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(string urlString, Func<IRoute, Task> handler = null)
         => UnrouteAsync(new Regex(CombineUrlWithBase(urlString).GlobToRegex()), null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Regex urlRegex, Action<IRoute> handler = default)
         => UnrouteAsync(urlRegex, null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Regex urlRegex, Func<IRoute, Task> handler = default)
         => UnrouteAsync(urlRegex, null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Func<string, bool> urlFunc, Action<IRoute> handler = default)
         => UnrouteAsync(null, urlFunc, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Func<string, bool> urlFunc, Func<IRoute, Task> handler = default)
         => UnrouteAsync(null, urlFunc, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> InnerWaitForEventAsync<T>(PlaywrightEvent<T> playwrightEvent, Func<Task> action = default, Func<T, bool> predicate = default, float? timeout = default)
     {
         if (playwrightEvent == null)
@@ -423,20 +467,25 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         return await result.ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IPage> WaitForPageAsync(BrowserContextWaitForPageOptions options = default)
         => InnerWaitForEventAsync(BrowserContextEvent.Page, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IPage> RunAndWaitForPageAsync(Func<Task> action, BrowserContextRunAndWaitForPageOptions options = default)
         => InnerWaitForEventAsync(BrowserContextEvent.Page, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IConsoleMessage> WaitForConsoleMessageAsync(BrowserContextWaitForConsoleMessageOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Console, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IConsoleMessage> RunAndWaitForConsoleMessageAsync(Func<Task> action, BrowserContextRunAndWaitForConsoleMessageOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Console, action, options?.Predicate, options?.Timeout);
 
     public ValueTask DisposeAsync() => new(CloseAsync());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void SetDefaultNavigationTimeout(float timeout) => SetDefaultNavigationTimeoutImpl(timeout);
 
     internal void SetDefaultNavigationTimeoutImpl(float? timeout)
@@ -445,6 +494,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         WrapApiCallAsync(() => Channel.SetDefaultNavigationTimeoutNoReplyAsync(timeout), true).IgnoreException();
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void SetDefaultTimeout(float timeout) => SetDefaultTimeoutImpl(timeout);
 
     internal void SetDefaultTimeoutImpl(float? timeout)
@@ -625,6 +675,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
         _harRecorders.Add(harId, new() { Path = har, Content = contentPolicy ?? HarContentPolicy.Attach });
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task RouteFromHARAsync(string har, BrowserContextRouteFromHAROptions options = null)
     {
         if (options?.Update == true)

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -483,6 +483,7 @@ internal class BrowserContext : ChannelOwnerBase, IChannelOwner<BrowserContext>,
     public Task<IConsoleMessage> RunAndWaitForConsoleMessageAsync(Func<Task> action, BrowserContextRunAndWaitForConsoleMessageOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Console, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ValueTask DisposeAsync() => new(CloseAsync());
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
@@ -55,6 +56,7 @@ internal class BrowserType : ChannelOwnerBase, IChannelOwner<BrowserType>, IBrow
 
     public string Name => _initializer.Name;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IBrowser> LaunchAsync(BrowserTypeLaunchOptions options = default)
     {
         options ??= new BrowserTypeLaunchOptions();
@@ -81,6 +83,7 @@ internal class BrowserType : ChannelOwnerBase, IChannelOwner<BrowserType>, IBrow
         return browser;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IBrowserContext> LaunchPersistentContextAsync(string userDataDir, BrowserTypeLaunchPersistentContextOptions options = default)
     {
         options ??= new BrowserTypeLaunchPersistentContextOptions();
@@ -154,6 +157,7 @@ internal class BrowserType : ChannelOwnerBase, IChannelOwner<BrowserType>, IBrow
         return context;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IBrowser> ConnectAsync(string wsEndpoint, BrowserTypeConnectOptions options = null)
     {
         options ??= new BrowserTypeConnectOptions();
@@ -241,6 +245,7 @@ internal class BrowserType : ChannelOwnerBase, IChannelOwner<BrowserType>, IBrow
         return await task.WithTimeout(timeout, _ => throw new TimeoutException($"BrowserType.ConnectAsync: Timeout {options.Timeout}ms exceeded")).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IBrowser> ConnectOverCDPAsync(string endpointURL, BrowserTypeConnectOverCDPOptions options = null)
     {
         if (Name != "chromium")

--- a/src/Playwright/Core/CDPSession.cs
+++ b/src/Playwright/Core/CDPSession.cs
@@ -79,6 +79,7 @@ internal class CDPSession : ChannelOwnerBase, ICDPSession, IChannelOwner<CDPSess
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async ValueTask DisposeAsync()
     {
         await DetachAsync().ConfigureAwait(false);

--- a/src/Playwright/Core/CDPSession.cs
+++ b/src/Playwright/Core/CDPSession.cs
@@ -23,6 +23,7 @@
  */
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
@@ -48,8 +49,10 @@ internal class CDPSession : ChannelOwnerBase, ICDPSession, IChannelOwner<CDPSess
 
     IChannel<CDPSession> IChannelOwner<CDPSession>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DetachAsync() => _channel.DetachAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<JsonElement?> SendAsync(string method, Dictionary<string, object>? args = null)
         => _channel.SendAsync(method, args);
 
@@ -61,6 +64,7 @@ internal class CDPSession : ChannelOwnerBase, ICDPSession, IChannelOwner<CDPSess
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ICDPSessionEvent Event(string eventName)
     {
         if (_cdpSessionEvents.TryGetValue(eventName, out var cdpNamedEvent))

--- a/src/Playwright/Core/Dialog.cs
+++ b/src/Playwright/Core/Dialog.cs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
 using Microsoft.Playwright.Transport.Channels;
@@ -54,7 +55,9 @@ internal class Dialog : ChannelOwnerBase, IChannelOwner<Dialog>, IDialog
 
     IChannel<Dialog> IChannelOwner<Dialog>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task AcceptAsync(string promptText) => _channel.AcceptAsync(promptText ?? string.Empty);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DismissAsync() => _channel.DismissAsync();
 }

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -115,26 +116,34 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
 
     public bool IsDetached { get; internal set; }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> FrameElementAsync()
         => (await _channel.FrameElementAsync().ConfigureAwait(false)).Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IFrameLocator FrameLocator(string selector)
         => new FrameLocator(this, selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> TitleAsync() => _channel.TitleAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForTimeoutAsync(float timeout)
         => _channel.WaitForTimeoutAsync(timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, string values, FrameSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<string> values, FrameSelectOptionOptions options = default)
         => SelectOptionAsync(selector, values.Select(valueOrLabel => new SelectOptionValueProtocol() { ValueOrLabel = valueOrLabel }), options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IElementHandle values, FrameSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<IElementHandle> values, FrameSelectOptionOptions options = default)
         => (await _channel.SelectOptionAsync(
             selector,
@@ -144,9 +153,11 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             force: options?.Force,
             timeout: options?.Timeout).ConfigureAwait(false)).ToList().AsReadOnly();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, SelectOptionValue values, FrameSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<SelectOptionValue> values, FrameSelectOptionOptions options = default)
         => SelectOptionAsync(selector, values.Select(value => SelectOptionValueProtocol.From(value)), options);
 
@@ -159,6 +170,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             force: options?.Force,
             timeout: options?.Timeout).ConfigureAwait(false)).ToList().AsReadOnly();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task WaitForLoadStateAsync(LoadState? state = default, FrameWaitForLoadStateOptions options = default)
     {
         Waiter waiter = null;
@@ -198,6 +210,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> WaitForNavigationAsync(FrameWaitForNavigationOptions options = default)
     {
         return RunAndWaitForNavigationAsync(null, new()
@@ -211,6 +224,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         });
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> RunAndWaitForNavigationAsync(Func<Task> action, FrameRunAndWaitForNavigationOptions options = default)
     {
         using var waiter = SetupNavigationWaiter("frame.WaitForNavigationAsync", options?.Timeout);
@@ -282,6 +296,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         return response;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TapAsync(string selector, FrameTapOptions options = default)
         => _channel.TapAsync(
             selector,
@@ -296,11 +311,14 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
     internal Task<int> QueryCountAsync(string selector)
         => _channel.QueryCountAsync(selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> ContentAsync() => _channel.ContentAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FocusAsync(string selector, FrameFocusOptions options = default)
         => _channel.FocusAsync(selector, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TypeAsync(string selector, string text, FrameTypeOptions options = default)
         => _channel.TypeAsync(
             selector,
@@ -310,18 +328,23 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             noWaitAfter: options?.NoWaitAfter,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> GetAttributeAsync(string selector, string name, FrameGetAttributeOptions options = default)
         => _channel.GetAttributeAsync(selector, name, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InnerHTMLAsync(string selector, FrameInnerHTMLOptions options = default)
         => _channel.InnerHTMLAsync(selector, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InnerTextAsync(string selector, FrameInnerTextOptions options = default)
         => _channel.InnerTextAsync(selector, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> TextContentAsync(string selector, FrameTextContentOptions options = default)
         => _channel.TextContentAsync(selector, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task HoverAsync(string selector, FrameHoverOptions options = default)
         => _channel.HoverAsync(
             selector,
@@ -333,6 +356,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task PressAsync(string selector, string key, FramePressOptions options = default)
         => _channel.PressAsync(
             selector,
@@ -342,6 +366,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             noWaitAfter: options?.NoWaitAfter,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DispatchEventAsync(string selector, string type, object eventInit = default, FrameDispatchEventOptions options = default)
         => _channel.DispatchEventAsync(
                 selector,
@@ -350,9 +375,11 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
                 options?.Timeout,
                 options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FillAsync(string selector, string value, FrameFillOptions options = default)
         => _channel.FillAsync(selector, value, force: options?.Force, timeout: options?.Timeout, noWaitAfter: options?.NoWaitAfter, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> AddScriptTagAsync(FrameAddScriptTagOptions options = default)
     {
         var content = options?.Content;
@@ -365,6 +392,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         return (await _channel.AddScriptTagAsync(options?.Url, options?.Path, content, options?.Type).ConfigureAwait(false)).Object;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> AddStyleTagAsync(FrameAddStyleTagOptions options = default)
     {
         var content = options?.Content;
@@ -377,9 +405,11 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         return (await _channel.AddStyleTagAsync(options?.Url, options?.Path, content).ConfigureAwait(false)).Object;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, string files, FrameSetInputFilesOptions options = default)
         => SetInputFilesAsync(selector, new[] { files }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task SetInputFilesAsync(string selector, IEnumerable<string> files, FrameSetInputFilesOptions options = default)
     {
         var converted = await SetInputFilesHelpers.ConvertInputFilesAsync(files, (BrowserContext)Page.Context).ConfigureAwait(false);
@@ -393,15 +423,18 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, FilePayload files, FrameSetInputFilesOptions options = default)
         => SetInputFilesAsync(selector, new[] { files }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task SetInputFilesAsync(string selector, IEnumerable<FilePayload> files, FrameSetInputFilesOptions options = default)
     {
         var converted = SetInputFilesHelpers.ConvertInputFiles(files);
         await _channel.SetInputFilesAsync(selector, converted.Files, noWaitAfter: options?.NoWaitAfter, timeout: options?.Timeout, options?.Strict).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ClickAsync(string selector, FrameClickOptions options = default)
         => _channel.ClickAsync(
             selector,
@@ -416,6 +449,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DblClickAsync(string selector, FrameDblClickOptions options = default)
         => _channel.DblClickAsync(
             selector,
@@ -429,6 +463,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CheckAsync(string selector, FrameCheckOptions options = default)
         => _channel.CheckAsync(
             selector,
@@ -439,6 +474,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UncheckAsync(string selector, FrameUncheckOptions options = default)
         => _channel.UncheckAsync(
             selector,
@@ -449,6 +485,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetCheckedAsync(string selector, bool checkedState, FrameSetCheckedOptions options = null)
         => checkedState ?
         _channel.CheckAsync(
@@ -468,18 +505,23 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             trial: options?.Trial,
             strict: options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetContentAsync(string html, FrameSetContentOptions options = default)
         => _channel.SetContentAsync(html, timeout: options?.Timeout, waitUntil: options?.WaitUntil);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InputValueAsync(string selector, FrameInputValueOptions options = null)
         => _channel.InputValueAsync(selector, options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> QuerySelectorAsync(string selector)
         => (await _channel.QuerySelectorAsync(selector).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<IElementHandle>> QuerySelectorAllAsync(string selector)
         => (await _channel.QuerySelectorAllAsync(selector).ConfigureAwait(false)).Select(c => ((ElementHandleChannel)c).Object).ToList().AsReadOnly();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> WaitForFunctionAsync(string expression, object arg = default, FrameWaitForFunctionOptions options = default)
          => (await _channel.WaitForFunctionAsync(
             expression: expression,
@@ -487,6 +529,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             timeout: options?.Timeout,
             polling: options?.PollingInterval).ConfigureAwait(false)).Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> WaitForSelectorAsync(string selector, FrameWaitForSelectorOptions options = default)
         => (await _channel.WaitForSelectorAsync(
             selector: selector,
@@ -495,21 +538,25 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             strict: options?.Strict,
             omitReturnValue: false).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> EvaluateHandleAsync(string script, object args = null)
         => (await _channel.EvaluateExpressionHandleAsync(
             script,
             arg: ScriptsHelper.SerializedArgument(args)).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<JsonElement?> EvaluateAsync(string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<JsonElement?>(await _channel.EvaluateExpressionAsync(
             script,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvaluateAsync<T>(string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvaluateExpressionAsync(
             script,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<JsonElement?> EvalOnSelectorAsync(string selector, string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<JsonElement?>(await _channel.EvalOnSelectorAsync(
             selector: selector,
@@ -517,6 +564,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             arg: ScriptsHelper.SerializedArgument(arg),
             strict: null).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvalOnSelectorAsync<T>(string selector, string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvalOnSelectorAsync(
             selector: selector,
@@ -524,6 +572,7 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             arg: ScriptsHelper.SerializedArgument(arg),
             strict: null).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvalOnSelectorAsync<T>(string selector, string expression, object arg = null, FrameEvalOnSelectorOptions options = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvalOnSelectorAsync(
             selector: selector,
@@ -531,18 +580,21 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             arg: ScriptsHelper.SerializedArgument(arg),
             strict: options?.Strict).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<JsonElement?> EvalOnSelectorAllAsync(string selector, string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<JsonElement?>(await _channel.EvalOnSelectorAllAsync(
             selector: selector,
             script,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvalOnSelectorAllAsync<T>(string selector, string script, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvalOnSelectorAllAsync(
             selector: selector,
             script,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator Locator(string selector, FrameLocatorOptions options = null) =>
         new Locator(this, selector, new()
         {
@@ -556,9 +608,11 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             HasNotTextRegex = options?.HasNotTextRegex,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> QuerySelectorAsync(string selector, FrameQuerySelectorOptions options = null)
         => (await _channel.QuerySelectorAsync(selector, options?.Strict).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> GotoAsync(string url, FrameGotoOptions options = default)
         => (await _channel.GotoAsync(
             url,
@@ -566,35 +620,45 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
             waitUntil: options?.WaitUntil,
             referer: options?.Referer).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsCheckedAsync(string selector, FrameIsCheckedOptions options = default)
         => _channel.IsCheckedAsync(selector, timeout: options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsDisabledAsync(string selector, FrameIsDisabledOptions options = default)
         => _channel.IsDisabledAsync(selector, timeout: options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsEditableAsync(string selector, FrameIsEditableOptions options = default)
         => _channel.IsEditableAsync(selector, timeout: options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsEnabledAsync(string selector, FrameIsEnabledOptions options = default)
         => _channel.IsEnabledAsync(selector, timeout: options?.Timeout, options?.Strict);
 
 #pragma warning disable CS0612 // Type or member is obsolete
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsHiddenAsync(string selector, FrameIsHiddenOptions options = default)
         => _channel.IsHiddenAsync(selector, timeout: options?.Timeout, options?.Strict);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsVisibleAsync(string selector, FrameIsVisibleOptions options = default)
         => _channel.IsVisibleAsync(selector, timeout: options?.Timeout, options?.Strict);
 #pragma warning restore CS0612 // Type or member is obsolete
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(string url, FrameWaitForURLOptions options = default)
         => WaitForURLAsync(url, null, null, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(Regex url, FrameWaitForURLOptions options = default)
         => WaitForURLAsync(null, url, null, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(Func<string, bool> url, FrameWaitForURLOptions options = default)
         => WaitForURLAsync(null, null, url, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DragAndDropAsync(string source, string target, FrameDragAndDropOptions options = null)
         => _channel.DragAndDropAsync(source, target, options?.Force, options?.NoWaitAfter, options?.Timeout, options?.Trial, options?.Strict, options?.SourcePosition, options?.TargetPosition);
 
@@ -685,42 +749,55 @@ internal class Frame : ChannelOwnerBase, IChannelOwner<Frame>, IFrame
     internal Task HighlightAsync(string selector)
         => _channel.HighlightAsync(selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByAltText(string text, FrameGetByAltTextOptions options = null)
         => Locator(Core.Locator.GetByAltTextSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByAltText(Regex text, FrameGetByAltTextOptions options = null)
         => Locator(Core.Locator.GetByAltTextSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByLabel(string text, FrameGetByLabelOptions options = null)
         => Locator(Core.Locator.GetByLabelSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByLabel(Regex text, FrameGetByLabelOptions options = null)
         => Locator(Core.Locator.GetByLabelSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByPlaceholder(string text, FrameGetByPlaceholderOptions options = null)
         => Locator(Core.Locator.GetByPlaceholderSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByPlaceholder(Regex text, FrameGetByPlaceholderOptions options = null)
         => Locator(Core.Locator.GetByPlaceholderSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByRole(AriaRole role, FrameGetByRoleOptions options = null)
         => Locator(Core.Locator.GetByRoleSelector(role, new(options)));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTestId(string testId)
         => Locator(Core.Locator.GetByTestIdSelector(Core.Locator.TestIdAttributeName(), testId));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTestId(Regex testId)
         => Locator(Core.Locator.GetByTestIdSelector(Core.Locator.TestIdAttributeName(), testId));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByText(string text, FrameGetByTextOptions options = null)
         => Locator(Core.Locator.GetByTextSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByText(Regex text, FrameGetByTextOptions options = null)
         => Locator(Core.Locator.GetByTextSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTitle(string text, FrameGetByTitleOptions options = null)
         => Locator(Core.Locator.GetByTitleSelector(text, options?.Exact));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTitle(Regex text, FrameGetByTitleOptions options = null)
         => Locator(Core.Locator.GetByTitleSelector(text, options?.Exact));
 }

--- a/src/Playwright/Core/JSHandle.cs
+++ b/src/Playwright/Core/JSHandle.cs
@@ -89,6 +89,7 @@ internal class JSHandle : ChannelOwnerBase, IChannelOwner<JSHandle>, IJSHandle
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async ValueTask DisposeAsync() => await _channel.DisposeAsync().ConfigureAwait(false);
 
     public override string ToString() => Preview;

--- a/src/Playwright/Core/JSHandle.cs
+++ b/src/Playwright/Core/JSHandle.cs
@@ -23,6 +23,7 @@
  */
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
@@ -47,27 +48,34 @@ internal class JSHandle : ChannelOwnerBase, IChannelOwner<JSHandle>, IJSHandle
 
     internal string Preview { get; set; }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IElementHandle AsElement() => this as IElementHandle;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<JsonElement?> EvaluateAsync(string expression, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<JsonElement?>(await _channel.EvaluateExpressionAsync(
             script: expression,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> EvaluateHandleAsync(string expression, object arg = null)
         => (await _channel.EvaluateExpressionHandleAsync(
             script: expression,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvaluateAsync<T>(string expression, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvaluateExpressionAsync(
             script: expression,
             arg: ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> JsonValueAsync<T>() => ScriptsHelper.ParseEvaluateResult<T>(await _channel.JsonValueAsync().ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> GetPropertyAsync(string propertyName) => (await _channel.GetPropertyAsync(propertyName).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<Dictionary<string, IJSHandle>> GetPropertiesAsync()
     {
         var result = new Dictionary<string, IJSHandle>();

--- a/src/Playwright/Core/JsonPipe.cs
+++ b/src/Playwright/Core/JsonPipe.cs
@@ -23,6 +23,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
 using Microsoft.Playwright.Transport.Channels;
@@ -51,7 +52,9 @@ internal class JsonPipe : ChannelOwnerBase, IChannelOwner<JsonPipe>
 
     IChannel<JsonPipe> IChannelOwner<JsonPipe>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CloseAsync() => _channel.CloseAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SendAsync(object message) => _channel.SendAsync(message);
 }

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -260,23 +261,31 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     public IAPIRequestContext APIRequest { get; }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IFrame Frame(string name)
         => Frames.FirstOrDefault(f => f.Name == name);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IFrame FrameByUrl(string urlString) => Frames.FirstOrDefault(f => Context.UrlMatches(urlString, f.Url));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IFrame FrameByUrl(Regex urlRegex) => Frames.FirstOrDefault(f => urlRegex.IsMatch(f.Url));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public IFrame FrameByUrl(Func<string, bool> urlFunc) => Frames.FirstOrDefault(f => urlFunc(f.Url));
 
     IFrameLocator IPage.FrameLocator(string selector) => MainFrame.FrameLocator(selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> TitleAsync() => MainFrame.TitleAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task BringToFrontAsync() => _channel.BringToFrontAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IPage> OpenerAsync() => Task.FromResult<IPage>(Opener?.IsClosed == false ? Opener : null);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task EmulateMediaAsync(PageEmulateMediaOptions options = default)
     {
         var args = new Dictionary<string, object>
@@ -289,33 +298,43 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         return _channel.EmulateMediaAsync(args);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> GotoAsync(string url, PageGotoOptions options = default)
         => MainFrame.GotoAsync(url, new() { WaitUntil = options?.WaitUntil, Timeout = options?.Timeout, Referer = options?.Referer });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(string url, PageWaitForURLOptions options = default)
         => MainFrame.WaitForURLAsync(url, new() { WaitUntil = options?.WaitUntil, Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(Regex url, PageWaitForURLOptions options = default)
         => MainFrame.WaitForURLAsync(url, new() { WaitUntil = options?.WaitUntil, Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForURLAsync(Func<string, bool> url, PageWaitForURLOptions options = default)
         => MainFrame.WaitForURLAsync(url, new() { WaitUntil = options?.WaitUntil, Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IConsoleMessage> WaitForConsoleMessageAsync(PageWaitForConsoleMessageOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Console, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IFileChooser> WaitForFileChooserAsync(PageWaitForFileChooserOptions options = default)
         => InnerWaitForEventAsync(PageEvent.FileChooser, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IPage> WaitForPopupAsync(PageWaitForPopupOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Popup, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IWebSocket> WaitForWebSocketAsync(PageWaitForWebSocketOptions options = default)
         => InnerWaitForEventAsync(PageEvent.WebSocket, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IWorker> WaitForWorkerAsync(PageWaitForWorkerOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Worker, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> WaitForNavigationAsync(PageWaitForNavigationOptions options = default)
         => MainFrame.WaitForNavigationAsync(new()
         {
@@ -327,6 +346,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Timeout = options?.Timeout,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> RunAndWaitForNavigationAsync(Func<Task> action, PageRunAndWaitForNavigationOptions options = default)
         => MainFrame.RunAndWaitForNavigationAsync(action, new()
         {
@@ -338,72 +358,95 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Timeout = options?.Timeout,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> WaitForRequestAsync(string urlOrPredicate, PageWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, null, e => Context.UrlMatches(e.Url, urlOrPredicate), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> WaitForRequestAsync(Regex urlOrPredicate, PageWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, null, e => urlOrPredicate.IsMatch(e.Url), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> WaitForRequestAsync(Func<IRequest, bool> urlOrPredicate, PageWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, null, e => urlOrPredicate(e), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> WaitForRequestFinishedAsync(PageWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> WaitForResponseAsync(string urlOrPredicate, PageWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, null, e => Context.UrlMatches(e.Url, urlOrPredicate), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> WaitForResponseAsync(Regex urlOrPredicate, PageWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, null, e => urlOrPredicate.IsMatch(e.Url), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> WaitForResponseAsync(Func<IResponse, bool> urlOrPredicate, PageWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, null, e => urlOrPredicate(e), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IConsoleMessage> RunAndWaitForConsoleMessageAsync(Func<Task> action, PageRunAndWaitForConsoleMessageOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Console, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IDownload> WaitForDownloadAsync(PageWaitForDownloadOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Download, null, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IDownload> RunAndWaitForDownloadAsync(Func<Task> action, PageRunAndWaitForDownloadOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Download, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IFileChooser> RunAndWaitForFileChooserAsync(Func<Task> action, PageRunAndWaitForFileChooserOptions options = default)
         => InnerWaitForEventAsync(PageEvent.FileChooser, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IPage> RunAndWaitForPopupAsync(Func<Task> action, PageRunAndWaitForPopupOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Popup, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> RunAndWaitForRequestFinishedAsync(Func<Task> action, PageRunAndWaitForRequestFinishedOptions options = default)
         => InnerWaitForEventAsync(PageEvent.RequestFinished, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IWebSocket> RunAndWaitForWebSocketAsync(Func<Task> action, PageRunAndWaitForWebSocketOptions options = default)
         => InnerWaitForEventAsync(PageEvent.WebSocket, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IWorker> RunAndWaitForWorkerAsync(Func<Task> action, PageRunAndWaitForWorkerOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Worker, action, options?.Predicate, options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> RunAndWaitForRequestAsync(Func<Task> action, string urlOrPredicate, PageRunAndWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, action, e => Context.UrlMatches(e.Url, urlOrPredicate), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> RunAndWaitForRequestAsync(Func<Task> action, Regex urlOrPredicate, PageRunAndWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, action, e => urlOrPredicate.IsMatch(e.Url), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IRequest> RunAndWaitForRequestAsync(Func<Task> action, Func<IRequest, bool> urlOrPredicate, PageRunAndWaitForRequestOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Request, action, e => urlOrPredicate(e), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> RunAndWaitForResponseAsync(Func<Task> action, string urlOrPredicate, PageRunAndWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, action, e => Context.UrlMatches(e.Url, urlOrPredicate), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> RunAndWaitForResponseAsync(Func<Task> action, Regex urlOrPredicate, PageRunAndWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, action, e => urlOrPredicate.IsMatch(e.Url), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IResponse> RunAndWaitForResponseAsync(Func<Task> action, Func<IResponse, bool> urlOrPredicate, PageRunAndWaitForResponseOptions options = default)
         => InnerWaitForEventAsync(PageEvent.Response, action, e => urlOrPredicate(e), options?.Timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IJSHandle> WaitForFunctionAsync(string expression, object arg = default, PageWaitForFunctionOptions options = default)
         => MainFrame.WaitForFunctionAsync(expression, arg, new() { PollingInterval = options?.PollingInterval, Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> InnerWaitForEventAsync<T>(PlaywrightEvent<T> pageEvent, Func<Task> action = default, Func<T, bool> predicate = default, float? timeout = default)
     {
         if (pageEvent == null)
@@ -435,6 +478,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         return await waitForEventTask.ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task CloseAsync(PageCloseOptions options = default)
     {
         try
@@ -451,13 +495,17 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<T> EvaluateAsync<T>(string expression, object arg) => MainFrame.EvaluateAsync<T>(expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<JsonElement?> EvalOnSelectorAsync(string selector, string expression, object arg) => MainFrame.EvalOnSelectorAsync(selector, expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<T> EvalOnSelectorAsync<T>(string selector, string expression, object arg = null, PageEvalOnSelectorOptions options = null)
         => MainFrame.EvalOnSelectorAsync<T>(selector, expression, arg, new() { Strict = options?.Strict });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator Locator(string selector, PageLocatorOptions options = default)
         => MainFrame.Locator(selector, new()
         {
@@ -467,30 +515,40 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             HasTextRegex = options?.HasTextRegex,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IElementHandle> QuerySelectorAsync(string selector, PageQuerySelectorOptions options = null)
         => MainFrame.QuerySelectorAsync(selector, new() { Strict = options?.Strict });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<T> EvalOnSelectorAsync<T>(string selector, string expression, object arg) => MainFrame.EvalOnSelectorAsync<T>(selector, expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<JsonElement?> EvalOnSelectorAllAsync(string selector, string expression, object arg) => MainFrame.EvalOnSelectorAllAsync(selector, expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<T> EvalOnSelectorAllAsync<T>(string selector, string expression, object arg) => MainFrame.EvalOnSelectorAllAsync<T>(selector, expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FillAsync(string selector, string value, PageFillOptions options = default)
         => MainFrame.FillAsync(selector, value, new() { NoWaitAfter = options?.NoWaitAfter, Timeout = options?.Timeout, Force = options?.Force, Strict = options?.Strict });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, string files, PageSetInputFilesOptions options = default)
         => MainFrame.SetInputFilesAsync(selector, files, Map(options));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, IEnumerable<string> files, PageSetInputFilesOptions options = default)
         => MainFrame.SetInputFilesAsync(selector, files, Map(options));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, FilePayload files, PageSetInputFilesOptions options = default)
         => MainFrame.SetInputFilesAsync(selector, files, Map(options));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetInputFilesAsync(string selector, IEnumerable<FilePayload> files, PageSetInputFilesOptions options = default)
         => MainFrame.SetInputFilesAsync(selector, files, Map(options));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TypeAsync(string selector, string text, PageTypeOptions options = default)
         => MainFrame.TypeAsync(selector, text, new()
         {
@@ -500,6 +558,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FocusAsync(string selector, PageFocusOptions options = default)
         => MainFrame.FocusAsync(selector, new()
         {
@@ -507,6 +566,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task HoverAsync(string selector, PageHoverOptions options = default)
         => MainFrame.HoverAsync(
             selector,
@@ -521,6 +581,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
                 Strict = options?.Strict,
             });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task PressAsync(string selector, string key, PagePressOptions options = default)
         => MainFrame.PressAsync(selector, key, new()
         {
@@ -530,15 +591,19 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, string values, PageSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<string> values, PageSelectOptionOptions options = default)
         => SelectOptionAsync(selector, values.Select(x => new SelectOptionValueProtocol() { ValueOrLabel = x }), options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IElementHandle values, PageSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<IElementHandle> values, PageSelectOptionOptions options = default)
         => MainFrame.SelectOptionAsync(selector, values, new()
         {
@@ -548,9 +613,11 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, SelectOptionValue values, PageSelectOptionOptions options = default)
         => SelectOptionAsync(selector, new[] { values }, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<SelectOptionValue> values, PageSelectOptionOptions options = default)
         => SelectOptionAsync(selector, values.Select(x => SelectOptionValueProtocol.From(x)), options);
 
@@ -563,8 +630,10 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForTimeoutAsync(float timeout) => MainFrame.WaitForTimeoutAsync(timeout);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IElementHandle> WaitForSelectorAsync(string selector, PageWaitForSelectorOptions options = default)
         => MainFrame.WaitForSelectorAsync(selector, new()
         {
@@ -573,8 +642,10 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<JsonElement?> EvaluateAsync(string expression, object arg) => MainFrame.EvaluateAsync(expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<byte[]> ScreenshotAsync(PageScreenshotOptions options = default)
     {
         options ??= new PageScreenshotOptions();
@@ -606,21 +677,28 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetContentAsync(string html, PageSetContentOptions options = default)
         => MainFrame.SetContentAsync(html, new() { WaitUntil = options?.WaitUntil, Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> ContentAsync() => MainFrame.ContentAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetExtraHTTPHeadersAsync(IEnumerable<KeyValuePair<string, string>> headers)
         => _channel.SetExtraHTTPHeadersAsync(headers);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IElementHandle> QuerySelectorAsync(string selector) => MainFrame.QuerySelectorAsync(selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<IElementHandle>> QuerySelectorAllAsync(string selector)
         => MainFrame.QuerySelectorAllAsync(selector);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IJSHandle> EvaluateHandleAsync(string expression, object arg) => MainFrame.EvaluateHandleAsync(expression, arg);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IElementHandle> AddScriptTagAsync(PageAddScriptTagOptions options = default)
         => MainFrame.AddScriptTagAsync(new()
         {
@@ -630,6 +708,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Type = options?.Type,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IElementHandle> AddStyleTagAsync(PageAddStyleTagOptions options = default)
         => MainFrame.AddStyleTagAsync(new()
         {
@@ -638,6 +717,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Content = options?.Content,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ClickAsync(string selector, PageClickOptions options = default)
         => MainFrame.ClickAsync(
             selector,
@@ -655,6 +735,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
                 Strict = options?.Strict,
             });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DblClickAsync(string selector, PageDblClickOptions options = default)
         => MainFrame.DblClickAsync(selector, new()
         {
@@ -669,63 +750,83 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> GoBackAsync(PageGoBackOptions options = default)
         => (await _channel.GoBackAsync(options?.Timeout, options?.WaitUntil).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> GoForwardAsync(PageGoForwardOptions options = default)
         => (await _channel.GoForwardAsync(options?.Timeout, options?.WaitUntil).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> ReloadAsync(PageReloadOptions options = default)
         => (await _channel.ReloadAsync(options?.Timeout, options?.WaitUntil).ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync(string name, Action callback, PageExposeBindingOptions options = default)
         => InnerExposeBindingAsync(name, (Delegate)callback, options?.Handle ?? false);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync(string name, Action<BindingSource> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T>(string name, Action<BindingSource, T> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback, true);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, TResult>(string name, Func<BindingSource, T1, T2, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, T3, TResult>(string name, Func<BindingSource, T1, T2, T3, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeBindingAsync<T1, T2, T3, T4, TResult>(string name, Func<BindingSource, T1, T2, T3, T4, TResult> callback)
         => InnerExposeBindingAsync(name, (Delegate)callback);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync(string name, Action callback)
         => ExposeBindingAsync(name, (BindingSource _) => callback());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T>(string name, Action<T> callback)
         => ExposeBindingAsync(name, (BindingSource _, T t) => callback(t));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<TResult>(string name, Func<TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _) => callback());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T, TResult>(string name, Func<T, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T t) => callback(t));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, TResult>(string name, Func<T1, T2, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2) => callback(t1, t2));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, T3, TResult>(string name, Func<T1, T2, T3, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2, T3 t3) => callback(t1, t2, t3));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task ExposeFunctionAsync<T1, T2, T3, T4, TResult>(string name, Func<T1, T2, T3, T4, TResult> callback)
         => ExposeBindingAsync(name, (BindingSource _, T1 t1, T2 t2, T3 t3, T4 t4) => callback(t1, t2, t3, t4));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<byte[]> PdfAsync(PagePdfOptions options = default)
     {
         if (!Context.IsChromium)
@@ -756,54 +857,70 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task AddInitScriptAsync(string script, string scriptPath)
         => _channel.AddInitScriptAsync(ScriptsHelper.EvaluationScript(script, scriptPath));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(string url, Func<IRoute, Task> handler, PageRouteOptions options = null)
         => RouteAsync(new Regex(Context.CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(string url, Action<IRoute> handler, PageRouteOptions options = null)
         => RouteAsync(new Regex(Context.CombineUrlWithBase(url).GlobToRegex()), null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Regex url, Action<IRoute> handler, PageRouteOptions options = null)
          => RouteAsync(url, null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Regex url, Func<IRoute, Task> handler, PageRouteOptions options = null)
          => RouteAsync(url, null, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Func<string, bool> url, Action<IRoute> handler, PageRouteOptions options = null)
         => RouteAsync(null, url, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task RouteAsync(Func<string, bool> url, Func<IRoute, Task> handler, PageRouteOptions options = null)
         => RouteAsync(null, url, handler, options);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(string urlString, Action<IRoute> handler)
         => UnrouteAsync(new Regex(Context.CombineUrlWithBase(urlString).GlobToRegex()), null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(string urlString, Func<IRoute, Task> handler)
         => UnrouteAsync(new Regex(Context.CombineUrlWithBase(urlString).GlobToRegex()), null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Regex urlString, Action<IRoute> handler)
         => UnrouteAsync(urlString, null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Regex urlString, Func<IRoute, Task> handler)
         => UnrouteAsync(urlString, null, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Func<string, bool> urlFunc, Action<IRoute> handler)
         => UnrouteAsync(null, urlFunc, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UnrouteAsync(Func<string, bool> urlFunc, Func<IRoute, Task> handler)
         => UnrouteAsync(null, urlFunc, handler);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForLoadStateAsync(LoadState? state = default, PageWaitForLoadStateOptions options = default)
         => MainFrame.WaitForLoadStateAsync(state, new() { Timeout = options?.Timeout });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetViewportSizeAsync(int width, int height)
     {
         ViewportSize = new() { Width = width, Height = height };
         return _channel.SetViewportSizeAsync(ViewportSize);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetCheckedAsync(string selector, bool checkedState, PageSetCheckedOptions options = null)
         => checkedState ?
         MainFrame.CheckAsync(selector, new()
@@ -825,6 +942,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CheckAsync(string selector, PageCheckOptions options = default)
         => MainFrame.CheckAsync(selector, new()
         {
@@ -836,6 +954,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Trial = options?.Trial,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UncheckAsync(string selector, PageUncheckOptions options = default)
         => MainFrame.UncheckAsync(selector, new()
         {
@@ -847,9 +966,11 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DispatchEventAsync(string selector, string type, object eventInit = default, PageDispatchEventOptions options = default)
          => MainFrame.DispatchEventAsync(selector, type, eventInit, new() { Timeout = options?.Timeout, Strict = options?.Strict });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> GetAttributeAsync(string selector, string name, PageGetAttributeOptions options = default)
          => MainFrame.GetAttributeAsync(selector, name, new()
          {
@@ -857,6 +978,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
              Strict = options?.Strict,
          });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InnerHTMLAsync(string selector, PageInnerHTMLOptions options = default)
          => MainFrame.InnerHTMLAsync(selector, new()
          {
@@ -864,6 +986,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
              Strict = options?.Strict,
          });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InnerTextAsync(string selector, PageInnerTextOptions options = default)
          => MainFrame.InnerTextAsync(selector, new()
          {
@@ -871,6 +994,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
              Strict = options?.Strict,
          });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> TextContentAsync(string selector, PageTextContentOptions options = default)
          => MainFrame.TextContentAsync(selector, new()
          {
@@ -878,6 +1002,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
              Strict = options?.Strict,
          });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TapAsync(string selector, PageTapOptions options = default)
         => MainFrame.TapAsync(
             selector,
@@ -892,6 +1017,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
                 Strict = options?.Strict,
             });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsCheckedAsync(string selector, PageIsCheckedOptions options = default)
         => MainFrame.IsCheckedAsync(selector, new()
         {
@@ -899,6 +1025,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsDisabledAsync(string selector, PageIsDisabledOptions options = default)
         => MainFrame.IsDisabledAsync(selector, new()
         {
@@ -906,6 +1033,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsEditableAsync(string selector, PageIsEditableOptions options = default)
         => MainFrame.IsEditableAsync(selector, new()
         {
@@ -913,6 +1041,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsEnabledAsync(string selector, PageIsEnabledOptions options = default)
         => MainFrame.IsEnabledAsync(selector, new()
         {
@@ -921,6 +1050,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         });
 
 #pragma warning disable CS0612 // Type or member is obsolete
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsHiddenAsync(string selector, PageIsHiddenOptions options = default)
         => MainFrame.IsHiddenAsync(selector, new()
         {
@@ -928,6 +1058,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<bool> IsVisibleAsync(string selector, PageIsVisibleOptions options = default)
         => MainFrame.IsVisibleAsync(selector, new()
         {
@@ -936,6 +1067,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         });
 #pragma warning restore CS0612 // Type or member is obsolete
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task PauseAsync()
     {
         var defaultNavigationTimeout = _timeoutSettings.DefaultNavigationTimeout;
@@ -953,19 +1085,21 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         }
     }
 
-
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void SetDefaultNavigationTimeout(float timeout)
     {
         _timeoutSettings.SetDefaultNavigationTimeout(timeout);
         WrapApiCallAsync(() => Channel.SetDefaultNavigationTimeoutNoReplyAsync(timeout), true).IgnoreException();
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void SetDefaultTimeout(float timeout)
     {
         _timeoutSettings.SetDefaultTimeout(timeout);
         WrapApiCallAsync(() => Channel.SetDefaultTimeoutNoReplyAsync(timeout), true).IgnoreException();
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<string> InputValueAsync(string selector, PageInputValueOptions options = null)
         => MainFrame.InputValueAsync(selector, new()
         {
@@ -973,6 +1107,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
             Strict = options?.Strict,
         });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DragAndDropAsync(string source, string target, PageDragAndDropOptions options = null)
         => MainFrame.DragAndDropAsync(source, target, new()
         {
@@ -1156,6 +1291,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         };
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task RouteFromHARAsync(string har, PageRouteFromHAROptions options = null)
     {
         if (options?.Update == true)
@@ -1178,42 +1314,55 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
         await harRouter.AddPageRouteAsync(this).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByAltText(string text, PageGetByAltTextOptions options = null)
         => MainFrame.GetByAltText(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByAltText(Regex text, PageGetByAltTextOptions options = null)
         => MainFrame.GetByAltText(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByLabel(string text, PageGetByLabelOptions options = null)
         => MainFrame.GetByLabel(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByLabel(Regex text, PageGetByLabelOptions options = null)
         => MainFrame.GetByLabel(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByPlaceholder(string text, PageGetByPlaceholderOptions options = null)
         => MainFrame.GetByPlaceholder(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByPlaceholder(Regex text, PageGetByPlaceholderOptions options = null)
         => MainFrame.GetByPlaceholder(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByRole(AriaRole role, PageGetByRoleOptions options = null)
         => Locator(Core.Locator.GetByRoleSelector(role, new(options)));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTestId(string testId)
         => MainFrame.GetByTestId(testId);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTestId(Regex testId)
         => MainFrame.GetByTestId(testId);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByText(string text, PageGetByTextOptions options = null)
         => MainFrame.GetByText(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByText(Regex text, PageGetByTextOptions options = null)
         => MainFrame.GetByText(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTitle(string text, PageGetByTitleOptions options = null)
         => MainFrame.GetByTitle(text, new() { Exact = options?.Exact });
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ILocator GetByTitle(Regex text, PageGetByTitleOptions options = null)
         => MainFrame.GetByTitle(text, new() { Exact = options?.Exact });
 }

--- a/src/Playwright/Core/Request.cs
+++ b/src/Playwright/Core/Request.cs
@@ -24,6 +24,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -131,8 +132,10 @@ internal class Request : ChannelOwnerBase, IChannelOwner<Request>, IRequest
 
     internal BrowserContext _context => (BrowserContext)Frame.Page.Context;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse> ResponseAsync() => (await _channel.GetResponseAsync().ConfigureAwait(false))?.Object;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public JsonElement? PostDataJSON()
     {
         if (PostData == null)
@@ -163,6 +166,7 @@ internal class Request : ChannelOwnerBase, IChannelOwner<Request>, IRequest
         return JsonDocument.Parse(content).RootElement;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<RequestSizesResult> SizesAsync()
     {
         if (await ResponseAsync().ConfigureAwait(false) is not IChannelOwner<Response> res)
@@ -173,12 +177,15 @@ internal class Request : ChannelOwnerBase, IChannelOwner<Request>, IRequest
         return await ((ResponseChannel)res.Channel).SizesAsync().ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<Dictionary<string, string>> AllHeadersAsync()
         => (await ActualHeadersAsync().ConfigureAwait(false)).Headers;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<Header>> HeadersArrayAsync()
         => (await ActualHeadersAsync().ConfigureAwait(false)).HeadersArray;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> HeaderValueAsync(string name)
         => (await ActualHeadersAsync().ConfigureAwait(false)).Get(name);
 

--- a/src/Playwright/Core/Response.cs
+++ b/src/Playwright/Core/Response.cs
@@ -24,6 +24,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -71,11 +72,14 @@ internal class Response : ChannelOwnerBase, IChannelOwner<Response>, IResponse
 
     IChannel<Response> IChannelOwner<Response>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<Dictionary<string, string>> AllHeadersAsync()
         => (await GetRawHeadersAsync().ConfigureAwait(false)).Headers;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<byte[]> BodyAsync() => _channel.GetBodyAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> FinishedAsync()
     {
         var targetClosedTask = _initializer.Request.TargetClosedAsync();
@@ -86,28 +90,36 @@ internal class Response : ChannelOwnerBase, IChannelOwner<Response>, IResponse
         return await _finishedTask.Task.ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<Header>> HeadersArrayAsync()
         => (await GetRawHeadersAsync().ConfigureAwait(false)).HeadersArray;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> HeaderValueAsync(string name)
         => (await GetRawHeadersAsync().ConfigureAwait(false)).Get(name);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<string>> HeaderValuesAsync(string name)
         => (await GetRawHeadersAsync().ConfigureAwait(false)).GetAll(name);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<JsonElement?> JsonAsync()
     {
         byte[] content = await BodyAsync().ConfigureAwait(false);
         return JsonDocument.Parse(content).RootElement;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> JsonAsync<T>()
         => JsonSerializer.Deserialize<T>(await BodyAsync().ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<ResponseSecurityDetailsResult> SecurityDetailsAsync() => _channel.SecurityDetailsAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<ResponseServerAddrResult> ServerAddrAsync() => _channel.ServerAddrAsync();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> TextAsync()
     {
         byte[] content = await BodyAsync().ConfigureAwait(false);

--- a/src/Playwright/Core/Route.cs
+++ b/src/Playwright/Core/Route.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
@@ -59,6 +60,7 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
 
     IChannel<Route> IChannelOwner<Route>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task FulfillAsync(RouteFulfillOptions options = default)
     {
         CheckNotHandled();
@@ -77,6 +79,7 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
         ReportHandled(true);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task AbortAsync(string errorCode = RequestAbortErrorCode.Failed)
     {
         CheckNotHandled();
@@ -84,6 +87,7 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
         ReportHandled(true);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task ContinueAsync(RouteContinueOptions options = default)
     {
         CheckNotHandled();
@@ -217,6 +221,7 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
         };
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FallbackAsync(RouteFallbackOptions options = null)
     {
         CheckNotHandled();
@@ -253,6 +258,7 @@ internal class Route : ChannelOwnerBase, IChannelOwner<Route>, IRoute
         chain.SetResult(handled);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAPIResponse> FetchAsync(RouteFetchOptions options)
         => _request._context.Channel.Connection.WrapApiCallAsync(
             () =>

--- a/src/Playwright/Core/Stream.cs
+++ b/src/Playwright/Core/Stream.cs
@@ -50,6 +50,7 @@ internal class Stream : ChannelOwnerBase, IChannelOwner<Stream>, IAsyncDisposabl
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<byte[]> ReadAsync(int size) => Channel.ReadAsync(size);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Playwright/Core/Stream.cs
+++ b/src/Playwright/Core/Stream.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
@@ -46,10 +47,12 @@ internal class Stream : ChannelOwnerBase, IChannelOwner<Stream>, IAsyncDisposabl
 
     public StreamImpl StreamImpl => new(this);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<byte[]> ReadAsync(int size) => Channel.ReadAsync(size);
 
     public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CloseAsync() => Channel.CloseAsync();
 }
 

--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
 using Microsoft.Playwright.Transport.Channels;
@@ -45,6 +46,7 @@ internal class Tracing : ChannelOwnerBase, IChannelOwner<Tracing>, ITracing
 
     IChannel<Tracing> IChannelOwner<Tracing>.Channel => _channel;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task StartAsync(TracingStartOptions options = default)
     {
         _includeSources = options?.Sources == true;
@@ -61,6 +63,7 @@ internal class Tracing : ChannelOwnerBase, IChannelOwner<Tracing>, ITracing
         await StartCollectingStacksAsync(traceName).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task StartChunkAsync(TracingStartChunkOptions options = default)
     {
         var traceName = await _channel.StartChunkAsync(title: options?.Title, name: options?.Name).ConfigureAwait(false);
@@ -77,8 +80,10 @@ internal class Tracing : ChannelOwnerBase, IChannelOwner<Tracing>, ITracing
         _stacksId = await _channel.Connection.LocalUtils.TracingStartedAsync(tracesDir: _tracesDir, traceName: traceName).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task StopChunkAsync(TracingStopChunkOptions options = default) => DoStopChunkAsync(filePath: options?.Path);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task StopAsync(TracingStopOptions options = default)
     {
         await _channel.Connection.WrapApiCallAsync(async () =>

--- a/src/Playwright/Core/Worker.cs
+++ b/src/Playwright/Core/Worker.cs
@@ -23,6 +23,7 @@
  */
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
 using Microsoft.Playwright.Transport;
@@ -72,12 +73,14 @@ internal class Worker : ChannelOwnerBase, IChannelOwner<Worker>, IWorker
 
     internal TaskCompletionSource<bool> ClosedTcs { get; } = new();
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<T> EvaluateAsync<T>(string expression, object arg = null)
         => ScriptsHelper.ParseEvaluateResult<T>(await _channel.EvaluateExpressionAsync(
             expression,
             null,
             ScriptsHelper.SerializedArgument(arg)).ConfigureAwait(false));
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> EvaluateHandleAsync(string expression, object arg = null)
         => await _channel.EvaluateExpressionHandleAsync(
             expression,
@@ -85,6 +88,7 @@ internal class Worker : ChannelOwnerBase, IChannelOwner<Worker>, IWorker
             ScriptsHelper.SerializedArgument(arg))
         .ConfigureAwait(false);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IWorker> WaitForCloseAsync(Func<Task> action = default, float? timeout = default)
     {
         using var waiter = new Waiter(this, "worker.WaitForCloseAsync");

--- a/src/Playwright/Core/WritableStream.cs
+++ b/src/Playwright/Core/WritableStream.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Transport;
@@ -46,10 +47,12 @@ internal class WritableStream : ChannelOwnerBase, IChannelOwner<WritableStream>,
 
     public WritableStreamImpl WritableStreamImpl => new(this);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WriteAsync(string binary) => Channel.WriteAsync(binary);
 
     public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CloseAsync() => Channel.CloseAsync();
 }
 

--- a/src/Playwright/Core/WritableStream.cs
+++ b/src/Playwright/Core/WritableStream.cs
@@ -50,6 +50,7 @@ internal class WritableStream : ChannelOwnerBase, IChannelOwner<WritableStream>,
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WriteAsync(string binary) => Channel.WriteAsync(binary);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ValueTask DisposeAsync() => new ValueTask(CloseAsync());
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Playwright/Transport/ChannelOwnerBase.cs
+++ b/src/Playwright/Transport/ChannelOwnerBase.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
 using Microsoft.Playwright.Transport.Channels;
@@ -91,6 +92,7 @@ internal class ChannelOwnerBase : IChannelOwner
 
     public Task WrapApiCallAsync(Func<Task> action, bool isInternal = false) => _connection.WrapApiCallAsync(action, isInternal);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WrapApiBoundaryAsync(Func<Task> action) => _connection.WrapApiBoundaryAsync(action);
 
     internal EventHandler<T> UpdateEventHandler<T>(string eventName, EventHandler<T> handlers, EventHandler<T> handler, bool add)

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -29,6 +29,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -462,6 +463,7 @@ internal class Connection : IDisposable
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal async Task<T> WrapApiCallAsync<T>(Func<Task<T>> action, bool isInternal = false)
     {
         EnsureApiZoneExists();
@@ -536,6 +538,7 @@ internal class Connection : IDisposable
             namespaceName.StartsWith("Microsoft.Playwright.Helpers", StringComparison.InvariantCultureIgnoreCase));
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)] // This method is also a stacktrace marker.
     internal async Task WrapApiBoundaryAsync(Func<Task> action)
     {
         EnsureApiZoneExists();


### PR DESCRIPTION
Fixes #2617 

I've recreated the issue locally on macOS on my M2 MBP, this fixes the exception, I need to check that the traces have the right API names captured still.