### PR TITLE
fix: hide cmd.exe window when invoking CLI programmatically

### DIFF
--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -52,6 +52,9 @@ public class Program
         var playwrightStartInfo = new ProcessStartInfo(pwPath, allArgs)
         {
             UseShellExecute = false,
+            // This works after net8.0-preview-4
+            // https://github.com/dotnet/runtime/pull/82662
+            WindowStyle = ProcessWindowStyle.Hidden,
         };
         foreach (var pair in Driver.GetEnvironmentVariables())
         {


### PR DESCRIPTION
After net8.0-preview4 https://github.com/dotnet/runtime/pull/82662 got landed upstream, which adds support for WindowStyle when Shell=false (default). This fixes the customer reported issue for us. It should not regress any behaviour for previous .NET users, so we can always set this flag when the CLI gets invoked.

Note: This does not require us to change any TFM. Only the customers need to use net8-preview4+. (which is LTS in November this year).

Appreciate the work @Jozkee and cc @nohwnd.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2462
Relates https://github.com/microsoft/playwright-dotnet/pull/2489
Closes https://github.com/dotnet/runtime/issues/68259#issuecomment-1605093489 (not needed anymore).