### PR TITLE
fix: allow RegexOptions.Compiled in GetInlineFlags

### DIFF
--- a/src/Playwright.Tests/ExtensionTests.cs
+++ b/src/Playwright.Tests/ExtensionTests.cs
@@ -35,7 +35,9 @@ public class ExtensionTests
         Assert.AreEqual(new Regex("foo", RegexOptions.IgnoreCase).Options.GetInlineFlags(), "i");
         Assert.AreEqual(new Regex("foo", RegexOptions.Multiline).Options.GetInlineFlags(), "m");
         Assert.AreEqual(new Regex("foo", RegexOptions.Singleline).Options.GetInlineFlags(), "s");
+        Assert.AreEqual(new Regex("foo", RegexOptions.Compiled).Options.GetInlineFlags(), "");
         Assert.AreEqual(new Regex("foo", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline).Options.GetInlineFlags(), "ism");
+        Assert.AreEqual(new Regex("foo", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled).Options.GetInlineFlags(), "ism");
         Assert.Throws<System.ArgumentException>(() =>
         {
             Assert.AreEqual(new Regex("foo", RegexOptions.IgnorePatternWhitespace).Options.GetInlineFlags(), "ism");

--- a/src/Playwright.Tests/Locator/LocatorQueryTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorQueryTests.cs
@@ -146,6 +146,13 @@ public class LocatorQueryTests : PageTestEx
         await Expect(Page.Locator("div", new() { HasTextRegex = new Regex("^first/\\\".*\\\"second\\\\$", RegexOptions.IgnoreCase | RegexOptions.Singleline) })).ToHaveClassAsync("test");
     }
 
+    [PlaywrightTest("locator-query.spec.ts", "should support filter by compiled regex")]
+    public async Task ShouldSupportFilterByCompiledRegex()
+    {
+        await Page.SetContentAsync("<div>Foobar</div><div>Bar</div>");
+        StringAssert.Contains(await Page.Locator("div", new() { HasTextRegex = new Regex("Foo.*", RegexOptions.Compiled) }).InnerTextAsync(), "Foobar");
+    }
+
     [PlaywrightTest("locator-query.spec.ts", "")]
     public async Task ShouldNotEncodeUnicode()
     {

--- a/src/Playwright/Helpers/RegexOptionsExtensions.cs
+++ b/src/Playwright/Helpers/RegexOptionsExtensions.cs
@@ -47,7 +47,7 @@ internal static class RegexOptionsExtensions
         {
             flags += "m";
         }
-        if ((options & ~(RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Multiline)) != 0)
+        if ((options & ~(RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Multiline | RegexOptions.Compiled)) != 0)
         {
             throw new ArgumentException("Unsupported RegularExpression flags");
         }


### PR DESCRIPTION
Fix #2615