### PR TITLE
chore: enable Microsoft.CodeAnalysis.NetAnalyzers

### DIFF
--- a/src/Common/Dependencies.props
+++ b/src/Common/Dependencies.props
@@ -18,6 +18,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -53,8 +53,6 @@
     <None Include="build\**" Pack="true" PackagePath="buildTransitive" />
     <None Include="build\**" Pack="true" PackagePath="build" />
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />
-    <None Remove="Roslynator.Analyzers" />
-    <None Remove="Microsoft.VisualStudio.Threading.Analyzers" />
   </ItemGroup>
   <Target Name="EnsurePrerequisitsRan" BeforeTargets="DedupeDriver">
     <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />


### PR DESCRIPTION
When this project changed from multitargeting to only targeting netstandard, it also lost all `Microsoft.CodeAnalysis.NetAnalyzers`.
See https://learn.microsoft.com/visualstudio/code-quality/install-net-analyzers?view=vs-2022

Ref: #2637