### PR TITLE
Fix Video Hanging

### DIFF
--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -179,14 +179,14 @@ public class ScreencastTests : BrowserTestEx
         using var userDirectory = new TempDirectory();
         using var tempDirectory = new TempDirectory();
 
-        await using var context = await BrowserType.LaunchPersistentContextAsync(userDirectory.Path, new()
+        var context = await BrowserType.LaunchPersistentContextAsync(userDirectory.Path, new()
         {
             RecordVideoDir = tempDirectory.Path,
             Headless = false
         });
 
         var page = await context.NewPageAsync();
-        await page.CloseAsync();
+        await context.CloseAsync();
 
         try
         {

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -187,6 +187,8 @@ public class ScreencastTests : BrowserTestEx
         var page = await context.NewPageAsync();
         await context.CloseAsync();
 
+        Assert.That(() => page.Video!.PathAsync(), Throws.TypeOf<TaskCanceledException>());
+
         Assert.That(page.Video!.IsCompleted, Is.True);
         Assert.That(page.Video!.IsCanceled, Is.True);
     }

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -171,4 +171,33 @@ public class ScreencastTests : BrowserTestEx
 
         Assert.IsNotEmpty(new DirectoryInfo(tempDirectory.Path).GetFiles("*.webm"));
     }
+
+    [PlaywrightTest("screencast.spec.ts", "Video does not hang if page not interacted with")]
+    [Timeout(30_000)]
+    public async Task VideoDoesNotHangIfNotHeadlessAndPageNotInteractedWith()
+    {
+        using var tempDirectory = new TempDirectory();
+
+        var chrome = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = false
+        });
+
+        var context = await chrome.NewContextAsync(new BrowserNewContextOptions
+        {
+            RecordVideoDir = tempDirectory.Path,
+        });
+
+        var page = await context.NewPageAsync();
+        await page.CloseAsync();
+
+        try
+        {
+            await page.Video!.PathAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignored
+        }
+    }
 }

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -187,9 +187,15 @@ public class ScreencastTests : BrowserTestEx
         var page = await context.NewPageAsync();
         await context.CloseAsync();
 
-        Assert.That(() => page.Video!.PathAsync(), Throws.TypeOf<TaskCanceledException>());
+        try
+        {
+            await page.Video!.PathAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore
+        }
 
         Assert.That(page.Video!.IsCompleted, Is.True);
-        Assert.That(page.Video!.IsCanceled, Is.True);
     }
 }

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -176,16 +176,13 @@ public class ScreencastTests : BrowserTestEx
     [Timeout(30_000)]
     public async Task VideoDoesNotHangIfNotHeadlessAndPageNotInteractedWith()
     {
+        using var userDirectory = new TempDirectory();
         using var tempDirectory = new TempDirectory();
 
-        await using var chrome = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
-        {
-            Headless = false
-        });
-
-        var context = await chrome.NewContextAsync(new BrowserNewContextOptions
+        await using var context = await BrowserType.LaunchPersistentContextAsync(userDirectory.Path, new()
         {
             RecordVideoDir = tempDirectory.Path,
+            Headless = false
         });
 
         var page = await context.NewPageAsync();

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -174,27 +174,20 @@ public class ScreencastTests : BrowserTestEx
 
     [PlaywrightTest("screencast.spec.ts", "Video does not hang if page not interacted with")]
     [Timeout(30_000)]
-    public async Task VideoDoesNotHangIfNotHeadlessAndPageNotInteractedWith()
+    public async Task VideoDoesNotHangIfPageNotInteractedWith()
     {
         using var userDirectory = new TempDirectory();
         using var tempDirectory = new TempDirectory();
 
         var context = await BrowserType.LaunchPersistentContextAsync(userDirectory.Path, new()
         {
-            RecordVideoDir = tempDirectory.Path,
-            Headless = false
+            RecordVideoDir = tempDirectory.Path
         });
 
         var page = await context.NewPageAsync();
         await context.CloseAsync();
 
-        try
-        {
-            await page.Video!.PathAsync();
-        }
-        catch (TaskCanceledException)
-        {
-            // Ignored
-        }
+        Assert.That(page.Video!.IsCompleted, Is.True);
+        Assert.That(page.Video!.IsCanceled, Is.True);
     }
 }

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -178,7 +178,7 @@ public class ScreencastTests : BrowserTestEx
     {
         using var tempDirectory = new TempDirectory();
 
-        var chrome = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        await using var chrome = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
         {
             Headless = false
         });

--- a/src/Playwright/API/Generated/IVideo.cs
+++ b/src/Playwright/API/Generated/IVideo.cs
@@ -58,6 +58,12 @@ public partial interface IVideo
     /// </summary>
     /// <param name="path">Path where the video should be saved.</param>
     Task SaveAsAsync(string path);
+
+    /// <summary><para>True if the video file is not waiting for completion.</para></summary>
+    bool IsCompleted();
+
+    /// <summary><para>True if the video file was canceled.</para></summary>
+    bool IsCanceled();
 }
 
 #nullable disable

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -100,7 +100,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
         if (Context.Options.RecordVideoDir != null)
         {
-            _video = new Video(this,  _channel.Connection);
+            _video = new Video(this, _channel.Connection);
         }
 
         _channel.FileChooser += (_, e) => _fileChooserImpl?.Invoke(this, new FileChooser(this, e.Element.Object, e.IsMultiple));

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -95,7 +95,13 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
             PageError?.Invoke(this, $"{e.Error.Name}: {e.Error.Message}");
         };
-        _channel.Video += (_, artifact) => ForceVideo().ArtifactReady(artifact);
+
+        _channel.Video += (_, artifact) => _video.ArtifactReady(artifact);
+
+        if (Context.Options.RecordVideoDir != null)
+        {
+            _video = new Video(this,  _channel.Connection);
+        }
 
         _channel.FileChooser += (_, e) => _fileChooserImpl?.Invoke(this, new FileChooser(this, e.Element.Object, e.IsMultiple));
         _channel.Worker += (_, worker) =>
@@ -237,15 +243,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     public IVideo Video
     {
-        get
-        {
-            if (Context.Options.RecordVideoDir == null)
-            {
-                return null;
-            }
-
-            return ForceVideo();
-        }
+        get => _video;
         set => _video = value as Video;
     }
 
@@ -1275,8 +1273,6 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
         return _channel.ExposeBindingAsync(name, handle);
     }
-
-    private Video ForceVideo() => _video ??= new(this, _channel.Connection);
 
     private FrameSetInputFilesOptions Map(PageSetInputFilesOptions options)
     {

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -95,13 +95,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
             PageError?.Invoke(this, $"{e.Error.Name}: {e.Error.Message}");
         };
-
-        _channel.Video += (_, artifact) => _video.ArtifactReady(artifact);
-
-        if (Context.Options.RecordVideoDir != null)
-        {
-            _video = new Video(this, _channel.Connection);
-        }
+        _channel.Video += (_, artifact) => ForceVideo().ArtifactReady(artifact);
 
         _channel.FileChooser += (_, e) => _fileChooserImpl?.Invoke(this, new FileChooser(this, e.Element.Object, e.IsMultiple));
         _channel.Worker += (_, worker) =>
@@ -243,7 +237,15 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     public IVideo Video
     {
-        get => _video;
+        get
+        {
+            if (Context.Options.RecordVideoDir == null)
+            {
+                return null;
+            }
+
+            return ForceVideo();
+        }
         set => _video = value as Video;
     }
 
@@ -1273,6 +1275,8 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
         return _channel.ExposeBindingAsync(name, handle);
     }
+
+    private Video ForceVideo() => _video ??= new(this, _channel.Connection);
 
     private FrameSetInputFilesOptions Map(PageSetInputFilesOptions options)
     {

--- a/src/Playwright/Core/Video.cs
+++ b/src/Playwright/Core/Video.cs
@@ -36,13 +36,7 @@ internal class Video : IVideo
     {
         _isRemote = connection.IsRemote;
 
-        page.Close += (_, _) => _artifactTcs.TrySetCanceled();
-        page.Crash += (_, _) => _artifactTcs.TrySetCanceled();
-
-        if (page.ClosedOrCrashedTcs.Task.IsCompleted)
-        {
-            _artifactTcs.TrySetCanceled();
-        }
+        TrySetCanceledOnPageClose(page);
     }
 
     public async Task DeleteAsync()
@@ -68,4 +62,6 @@ internal class Video : IVideo
     }
 
     internal void ArtifactReady(Artifact artifact) => _artifactTcs.TrySetResult(artifact);
+
+    private void TrySetCanceledOnPageClose(Page page) => page.ClosedOrCrashedTcs.Task.ContinueWith(_ => _artifactTcs.TrySetCanceled(), TaskScheduler.Default);
 }

--- a/src/Playwright/Core/Video.cs
+++ b/src/Playwright/Core/Video.cs
@@ -35,8 +35,14 @@ internal class Video : IVideo
     public Video(Page page, Connection connection)
     {
         _isRemote = connection.IsRemote;
+
         page.Close += (_, _) => _artifactTcs.TrySetCanceled();
         page.Crash += (_, _) => _artifactTcs.TrySetCanceled();
+
+        if (page.ClosedOrCrashedTcs.Task.IsCompleted)
+        {
+            _artifactTcs.TrySetCanceled();
+        }
     }
 
     public async Task DeleteAsync()

--- a/src/Playwright/Core/Video.cs
+++ b/src/Playwright/Core/Video.cs
@@ -61,6 +61,10 @@ internal class Video : IVideo
         await artifact.SaveAsAsync(path).ConfigureAwait(false);
     }
 
+    public bool IsCompleted() => _artifactTcs.Task.IsCompleted;
+
+    public bool IsCanceled() => _artifactTcs.Task.IsCanceled;
+
     internal void ArtifactReady(Artifact artifact) => _artifactTcs.TrySetResult(artifact);
 
     private void TrySetCanceledOnPageClose(Page page) => page.ClosedOrCrashedTcs.Task.ContinueWith(_ => _artifactTcs.TrySetCanceled(), TaskScheduler.Default);


### PR DESCRIPTION
#2658 

I think the issue is the video is only newed up within a getter. If this happens after a page close, then the Close event handlers are never hit and therefore the TaskCompletionSource never has a result set 