### PR TITLE
fix: init without console

### DIFF
--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -147,8 +147,14 @@ internal class StdIOTransport : IDisposable
         var originalOutputEncoding = Console.OutputEncoding;
 
         var hasConsole = true;
-        try { var height = Console.WindowHeight; }
-        catch { hasConsole = false; }
+        try
+        {
+            var height = Console.WindowHeight;
+        }
+        catch
+        {
+            hasConsole = false;
+        }
 
         if (hasConsole)
         {

--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -146,8 +146,15 @@ internal class StdIOTransport : IDisposable
         var originalInputEncoding = Console.InputEncoding;
         var originalOutputEncoding = Console.OutputEncoding;
 
-        Console.InputEncoding = encoding;
-        Console.OutputEncoding = encoding;
+        var hasConsole = true;
+        try { var height = Console.WindowHeight; }
+        catch { hasConsole = false; }
+
+        if (hasConsole)
+        {
+            Console.InputEncoding = encoding;
+            Console.OutputEncoding = encoding;
+        }
 
         try
         {
@@ -155,9 +162,12 @@ internal class StdIOTransport : IDisposable
         }
         finally
         {
-            // Restore the original encodings
-            Console.InputEncoding = originalInputEncoding;
-            Console.OutputEncoding = originalOutputEncoding;
+            if (hasConsole)
+            {
+                // Restore the original encodings
+                Console.InputEncoding = originalInputEncoding;
+                Console.OutputEncoding = originalOutputEncoding;
+            }
         }
     }
 


### PR DESCRIPTION
https://github.com/microsoft/playwright-dotnet/issues/2663

Tested with a net6.0-windows WinForms application, was able to reproduce it without the fix and it worked after the fix.