### PR TITLE
fix: throw when serializing FilePayload in Form Fetch request

### DIFF
--- a/src/Playwright.Tests/BrowserContextFetchTests.cs
+++ b/src/Playwright.Tests/BrowserContextFetchTests.cs
@@ -703,6 +703,21 @@ public class BrowserContextFetchTests : PageTestEx
         Assert.AreEqual(200, response.Status);
     }
 
+    [PlaywrightTest("browsercontext-fetch.spec.ts", "should not allow file payloads in Form parameter")]
+    public async Task ShouldNotAllowFilePayloadsInFormParameter()
+    {
+        var file = new FilePayload()
+        {
+            Name = "f.js",
+            MimeType = "text/javascript",
+            Buffer = Array.Empty<byte>()
+        };
+        var formData = Context.APIRequest.CreateFormData();
+        formData.Set("file", file);
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Context.APIRequest.PostAsync(Server.EmptyPage, new() { Form = formData }));
+        StringAssert.Contains("Form requests don't support file payloads, use MultiPart=formData instead.", exception.Message);
+    }
+
     [PlaywrightTest("browsercontext-fetch.spec.ts", "should serialize data to json regardless of content-type")]
     public async Task ShouldSerializeDatatoJsonRegardlessOfContentType()
     {

--- a/src/Playwright.Tests/BrowserContextFetchTests.cs
+++ b/src/Playwright.Tests/BrowserContextFetchTests.cs
@@ -715,7 +715,7 @@ public class BrowserContextFetchTests : PageTestEx
         var formData = Context.APIRequest.CreateFormData();
         formData.Set("file", file);
         var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Context.APIRequest.PostAsync(Server.EmptyPage, new() { Form = formData }));
-        StringAssert.Contains("Form requests don't support file payloads, use MultiPart=formData instead.", exception.Message);
+        StringAssert.Contains("Form requests don't support file payloads, use Multipart=formData instead.", exception.Message);
     }
 
     [PlaywrightTest("browsercontext-fetch.spec.ts", "should serialize data to json regardless of content-type")]

--- a/src/Playwright/Core/FormData.cs
+++ b/src/Playwright/Core/FormData.cs
@@ -51,13 +51,17 @@ public class FormData : IFormData
 
     public IFormData Set(string name, FilePayload value) => SetImpl(name, value);
 
-    internal IList<object> ToProtocol()
+    internal IList<object> ToProtocol(bool throwWhenSerializingFilePayloads = false)
     {
         var output = new List<object>();
         foreach (var kvp in Values)
         {
             if (kvp.Value is FilePayload file)
             {
+                if (throwWhenSerializingFilePayloads)
+                {
+                    throw new PlaywrightException("Form requests don't support file payloads, use MultiPart=formData instead.");
+                }
                 output.Add(new Dictionary<string, object>()
                 {
                     ["name"] = kvp.Key,

--- a/src/Playwright/Core/FormData.cs
+++ b/src/Playwright/Core/FormData.cs
@@ -60,7 +60,7 @@ public class FormData : IFormData
             {
                 if (throwWhenSerializingFilePayloads)
                 {
-                    throw new PlaywrightException("Form requests don't support file payloads, use MultiPart=formData instead.");
+                    throw new PlaywrightException("Form requests don't support file payloads, use Multipart=formData instead.");
                 }
                 output.Add(new Dictionary<string, object>()
                 {

--- a/src/Playwright/Transport/Channels/APIRequestContextChannel.cs
+++ b/src/Playwright/Transport/Channels/APIRequestContextChannel.cs
@@ -64,7 +64,7 @@ internal class APIRequestContextChannel : Channel<APIRequestContext>
             ["headers"] = headers?.ToProtocol(),
             ["jsonData"] = jsonData,
             ["postData"] = postData != null ? Convert.ToBase64String(postData) : null,
-            ["formData"] = formData?.ToProtocol(),
+            ["formData"] = formData?.ToProtocol(throwWhenSerializingFilePayloads: true),
             ["multipartData"] = multipartData?.ToProtocol(),
         };
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2662

This might affect Java as well.