### PR TITLE
fix: video.PathAsync() should not hang after direct launch/close

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,13 +109,13 @@ The resulting code will follow our style guides. This is also enforced in our CI
 Tests can either be executed in their entirety:
 
 ```bash
-dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed"
+dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed"
 ```
 
 You can also specify a single test to run:
 
 ```bash
-dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" --filter Playwright.Tests.TapTests
+dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" --filter Playwright.Tests.TapTests
 ```
 
 Additionally, you can use the Test Explorer if you're using Visual Studio.
@@ -137,7 +137,7 @@ This will re-generate the neccessary files for the new driver version.
 ```shell
 dotnet tool install -g dotnet-reportgenerator-globaltool
 
-dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput="coverage.xml" --filter "Playwright.Tests.Assertions.PageAssertionsTests"
+dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput="coverage.xml" --filter "Playwright.Tests.Assertions.PageAssertionsTests"
 reportgenerator -reports:src/Playwright.Tests/coverage.net6.0.xml -targetdir:coverage-report -reporttypes:HTML
 open coverage-report/index.html
 ```

--- a/src/Playwright/Core/Video.cs
+++ b/src/Playwright/Core/Video.cs
@@ -35,12 +35,12 @@ internal class Video : IVideo
     public Video(Page page, Connection connection)
     {
         _isRemote = connection.IsRemote;
+        page.Close += (_, _) => _artifactTcs.TrySetResult(null);
+        page.Crash += (_, _) => _artifactTcs.TrySetResult(null);
         if (page.IsClosed)
         {
             _artifactTcs.TrySetResult(null);
         }
-        page.Close += (_, _) => _artifactTcs.TrySetResult(null);
-        page.Crash += (_, _) => _artifactTcs.TrySetResult(null);
     }
 
     public async Task DeleteAsync()


### PR DESCRIPTION
The issue was that the artifact came after the page close event has fired. So it was waiting for a page.close event inside the Video.cs but it already arrived, so it stalled.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2658
Closes https://github.com/microsoft/playwright-dotnet/pull/2664