### PR TITLE
fix: adjust way of detecting if its launched with attached Console

### DIFF
--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -146,15 +146,7 @@ internal class StdIOTransport : IDisposable
         var originalInputEncoding = Console.InputEncoding;
         var originalOutputEncoding = Console.OutputEncoding;
 
-        var hasConsole = true;
-        try
-        {
-            var height = Console.WindowHeight;
-        }
-        catch
-        {
-            hasConsole = false;
-        }
+        var hasConsole = (Console.CursorLeft != 0) || (Console.CursorTop != 0);
 
         if (hasConsole)
         {


### PR DESCRIPTION
https://github.com/microsoft/playwright-dotnet/commit/657f415d3eaa05df2d3dbff0a56526aad285d6f1#commitcomment-124959681

https://stackoverflow.com/questions/70997254/c-sharp-console-application-is-there-a-way-to-detect-whether-the-exe-was-run-fr