### PR TITLE
chore: fix windows PlaywrightPlatform detection

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -27,7 +27,7 @@
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\darwin-arm64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'osx-arm64'">
         <PlaywrightFolder>node\darwin-arm64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'win'">
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'win' OR '%(_PlaywrightPlatforms.Identity)' == 'win-x64' OR '%(_PlaywrightPlatforms.Identity)' == 'win-x86'">
         <PlaywrightFolder>node\win32_x64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\**" Condition="'@(_PlaywrightCopyItems->Count())' == '0'">

--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -27,7 +27,7 @@
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\darwin-arm64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'osx-arm64'">
         <PlaywrightFolder>node\darwin-arm64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
-      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'win' OR '%(_PlaywrightPlatforms.Identity)' == 'win-x64' OR '%(_PlaywrightPlatforms.Identity)' == 'win-x86'">
+      <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\win32_x64\**" Condition="'%(_PlaywrightPlatforms.Identity)' == 'win' OR '%(_PlaywrightPlatforms.Identity)' == 'win-x64'">
         <PlaywrightFolder>node\win32_x64\</PlaywrightFolder>
       </_PlaywrightCopyItems>
       <_PlaywrightCopyItems Include="$(MSBuildThisFileDirectory)..\.playwright\node\**" Condition="'@(_PlaywrightCopyItems->Count())' == '0'">


### PR DESCRIPTION
[Windows RIDs / RuntimeIdentifier are `win-x64` / `win-x86`](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#windows-rids). Specifying `PlaywrightPlatform=win` still worked.
Not sure why I missed that in #2531

Fixes #2687