### PR TITLE
chore: pass Activator.CreateInstance exception as inner exception

### DIFF
--- a/src/Playwright.Tests/PageEvaluateTests.cs
+++ b/src/Playwright.Tests/PageEvaluateTests.cs
@@ -39,6 +39,7 @@ public class PageEvaluateTests : PageTestEx
         Assert.AreEqual(21, result);
     }
 
+    [PlaywrightTest()]
     public async Task ShouldSerializeArguments()
     {
         int result = await Page.EvaluateAsync<int>("a => a.m * a.n", new { m = 7, n = 3 });
@@ -656,6 +657,7 @@ public class PageEvaluateTests : PageTestEx
         Assert.AreEqual(new DateTime(2020, 05, 27, 1, 31, 38, 506), result.date);
     }
 
+    [PlaywrightTest()]
     public async Task ShouldSerializeEnumProperty()
     {
         int result = await Page.EvaluateAsync<int>("a => a.TestEnum", new ClassWithEnumProperty());
@@ -718,4 +720,15 @@ public class PageEvaluateTests : PageTestEx
         Assert.AreEqual(600, result.Width);
         Assert.AreEqual(400, result.Height);
     }
+
+#if NET6_0_OR_GREATER
+    private record ShapeRecord(int Width, int Height);
+
+    [PlaywrightTest()]
+    public async Task ShouldParseRecordProperties()
+    {
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.EvaluateAsync<ShapeRecord>("() => ({ width: 600, height: 400 })"));
+        Assert.IsInstanceOf<MissingMethodException>(exception.InnerException);
+    }
+#endif
 }

--- a/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
+++ b/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
@@ -241,9 +241,9 @@ internal static class EvaluateArgumentValueConverter
             {
                 objResult = Activator.CreateInstance(t);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                throw new PlaywrightException("Return type mismatch. Expecting " + t.ToString() + ", got Object");
+                throw new PlaywrightException("Return type mismatch. Expecting " + t.ToString() + ", got Object", ex);
             }
             visited.Add(parsed, objResult);
 


### PR DESCRIPTION
To make it easier to debug issues like #2701 because `Activator.CreateInstance` can throw for a lot of different reasons.

The issue there is that there is no parameterless constructor which playwright requires as it uses `Activator.CreateInstance`.

