### PR TITLE
fix: use minimum 6.0.0 System.Text.Json version

### DIFF
--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -31,9 +31,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove=".drivers\**" />


### PR DESCRIPTION
This does it like the Azure CLI folks: https://github.com/Azure/azure-sdk-for-net/blob/ff337a1ce38c57f770d28a36198d90ad7be27f80/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj#L21

But this most likely will regress https://github.com/microsoft/playwright-dotnet/issues/2408 since it reverts https://github.com/microsoft/playwright-dotnet/pull/2410, requires testing.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2696