### PR TITLE
fix: return copy of list in IPage.Frames

### DIFF
--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -211,7 +211,7 @@ internal class Page : ChannelOwnerBase, IChannelOwner<Page>, IPage
 
     public string Url => MainFrame.Url;
 
-    public IReadOnlyList<IFrame> Frames => _frames.AsReadOnly();
+    public IReadOnlyList<IFrame> Frames => _frames.ToList().AsReadOnly();
 
     public IKeyboard Keyboard
     {


### PR DESCRIPTION
We do that in the other places too:

<img width="543" alt="image" src="https://github.com/microsoft/playwright-dotnet/assets/17984549/fab3c567-c73f-4774-b280-af3c764ea6cc">

Fixes https://github.com/microsoft/playwright-dotnet/issues/2719