### PR TITLE
chore: Simplify the implementation of the driver environment variables

### DIFF
--- a/src/Playwright.Tests/BrowserTypeConnectTests.cs
+++ b/src/Playwright.Tests/BrowserTypeConnectTests.cs
@@ -473,7 +473,7 @@ public class BrowserTypeConnectTests : PlaywrightTestEx
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                 };
-                foreach (var pair in Driver.GetEnvironmentVariables())
+                foreach (var pair in Driver.EnvironmentVariables)
                 {
                     startInfo.EnvironmentVariables[pair.Key] = pair.Value;
                 }

--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -32,6 +32,13 @@ namespace Microsoft.Playwright.Helpers;
 
 internal static class Driver
 {
+    internal static Dictionary<string, string> EnvironmentVariables { get; } = new()
+    {
+        ["PW_LANG_NAME"] = "csharp",
+        ["PW_LANG_NAME_VERSION"] = $"{Environment.Version.Major}.{Environment.Version.Minor}",
+        ["PW_CLI_DISPLAY_VERSION"] = typeof(Driver).Assembly.GetName().Version.ToString(3),
+    };
+
     internal static string GetExecutablePath()
     {
         DirectoryInfo assemblyDirectory = null;
@@ -97,23 +104,5 @@ internal static class Driver
         }
 
         return Path.Combine(driversPath, ".playwright", "node", platformId, runnerName);
-    }
-
-    internal static Dictionary<string, string> GetEnvironmentVariables()
-    {
-        var environmentVariables = new Dictionary<string, string>();
-        environmentVariables.Add("PW_LANG_NAME", "csharp");
-        environmentVariables.Add("PW_LANG_NAME_VERSION", $"{Environment.Version.Major}.{Environment.Version.Minor}");
-        environmentVariables.Add("PW_CLI_DISPLAY_VERSION", GetSemVerPackageVersion());
-        return environmentVariables;
-    }
-
-    private static string GetSemVerPackageVersion()
-    {
-        // AssemblyName.Version returns a 4 digit version number, this method
-        // drops the last number which represents the build revision.
-        string version = typeof(Driver).Assembly.GetName().Version.ToString();
-        string[] versionParts = version.Split('.');
-        return $"{versionParts[0]}.{versionParts[1]}.{versionParts[2]}";
     }
 }

--- a/src/Playwright/Program.cs
+++ b/src/Playwright/Program.cs
@@ -56,7 +56,7 @@ public class Program
             // https://github.com/dotnet/runtime/pull/82662
             WindowStyle = ProcessWindowStyle.Hidden,
         };
-        foreach (var pair in Driver.GetEnvironmentVariables())
+        foreach (var pair in Driver.EnvironmentVariables)
         {
             playwrightStartInfo.EnvironmentVariables[pair.Key] = pair.Value;
         }

--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -121,7 +121,7 @@ internal class StdIOTransport : IDisposable
             RedirectStandardError = true,
             CreateNoWindow = true,
         };
-        foreach (var pair in Driver.GetEnvironmentVariables())
+        foreach (var pair in Driver.EnvironmentVariables)
         {
             startInfo.EnvironmentVariables[pair.Key] = pair.Value;
         }


### PR DESCRIPTION
* Since everything is static ("csharp" constant string + environment version + assembly version) the dictionary is only created once and thus changed from a method to a property.
* Using the built-in `Version.ToString(3)` instead of the equivalent custom method `GetSemVerPackageVersion`.
