### PR TITLE
chore: move to .NET 8 (LTS)

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -28,16 +28,10 @@ stages:
     steps:
 
     - task: UseDotNet@2
-      displayName: 'Use .NET 3.1 SDK'
+      displayName: 'Use .NET 8 SDK'
       inputs:
         packageType: sdk
-        version: 3.1.x
-
-    - task: UseDotNet@2
-      displayName: 'Use .NET 6 SDK'
-      inputs:
-        packageType: sdk
-        version: 6.x
+        version: 8.x
 
     - task: MicroBuildSigningPlugin@3
       inputs:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Install dotnet-format
       run: dotnet tool install --global dotnet-format
     - name: Check formatting

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
+          dotnet-version: 8.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: |

--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -15,9 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
+        dotnet-version: 8.0.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -21,9 +21,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
+        dotnet-version: 8.0.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -25,19 +25,17 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
+        dotnet-version: 8.0.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver
     - name: Build Docker image
-      run: bash utils/docker/build.sh --amd64 focal playwright-dotnet:localbuild-focal
+      run: bash utils/docker/build.sh --amd64 jammy playwright-dotnet:localbuild-jammy
     - name: Cleanup
       run: dotnet clean src/ || true
     - name: Test
       run: |
-        CONTAINER_ID="$(docker run --rm --ipc=host -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -d -t playwright-dotnet:localbuild-focal /bin/bash)"
-        docker exec -e BROWSER=chromium "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger:"console;verbosity=detailed"
-        docker exec -e BROWSER=firefox "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger:"console;verbosity=detailed"
-        docker exec -e BROWSER=webkit "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger:"console;verbosity=detailed"
+        CONTAINER_ID="$(docker run --rm --ipc=host -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -d -t playwright-dotnet:localbuild-jammy /bin/bash)"
+        docker exec -e BROWSER=chromium "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net8.0 --logger:"console;verbosity=detailed"
+        docker exec -e BROWSER=firefox "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net8.0 --logger:"console;verbosity=detailed"
+        docker exec -e BROWSER=webkit "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net8.0 --logger:"console;verbosity=detailed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.browser }}/${{ matrix.os }}/.NET 6
+    name: ${{ matrix.browser }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -25,9 +25,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
+          dotnet-version: 8.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: ./build.sh --download-driver
@@ -39,34 +37,9 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         env:
           BROWSER: ${{ matrix.browser }}
-        run: dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger:"console;verbosity=detailed" -- Playwright.Retries=1
+        run: dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net8.0 --logger:"console;verbosity=detailed" -- Playwright.Retries=1
       - name: Running tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         env:
           BROWSER: ${{ matrix.browser }}
-        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net6.0 --logger:"console;verbosity=detailed" -- Playwright.Retries=1
-
-  test-net31:
-    name: chromium/ubuntu/.NET 3.1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
-      - name: Install prerequisites and download drivers
-        shell: bash
-        run: ./build.sh --download-driver
-      - name: Building
-        run: |
-          dotnet build -f netstandard2.0 ./src/Playwright/Playwright.csproj
-          dotnet build -f netcoreapp3.1 ./src/Playwright.Tests/Playwright.Tests.csproj
-      - name: Installing Browsers and dependencies
-        run: pwsh src/Playwright/bin/Debug/netstandard2.0/playwright.ps1 install --with-deps
-      - name: Running tests
-        env:
-          BROWSER: CHROMIUM
-        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f netcoreapp3.1 --logger:"console;verbosity=detailed" -- Playwright.Retries=1
+        run: xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net8.0 --logger:"console;verbosity=detailed" -- Playwright.Retries=1

--- a/.github/workflows/tests_harness.yml
+++ b/.github/workflows/tests_harness.yml
@@ -20,9 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
+          dotnet-version: 8.0.x
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,13 +109,13 @@ The resulting code will follow our style guides. This is also enforced in our CI
 Tests can either be executed in their entirety:
 
 ```bash
-dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed"
+dotnet test -f net8.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed"
 ```
 
 You can also specify a single test to run:
 
 ```bash
-dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" --filter Playwright.Tests.TapTests
+dotnet test -f net8.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" --filter Playwright.Tests.TapTests
 ```
 
 Additionally, you can use the Test Explorer if you're using Visual Studio.
@@ -137,7 +137,7 @@ This will re-generate the neccessary files for the new driver version.
 ```shell
 dotnet tool install -g dotnet-reportgenerator-globaltool
 
-dotnet test -f net6.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput="coverage.xml" --filter "Playwright.Tests.Assertions.PageAssertionsTests"
-reportgenerator -reports:src/Playwright.Tests/coverage.net6.0.xml -targetdir:coverage-report -reporttypes:HTML
+dotnet test -f net8.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed" -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput="coverage.xml" --filter "Playwright.Tests.Assertions.PageAssertionsTests"
+reportgenerator -reports:src/Playwright.Tests/coverage.net8.0.xml -targetdir:coverage-report -reporttypes:HTML
 open coverage-report/index.html
 ```

--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -6,7 +6,7 @@
     <Summary>The Playwright CLI dotnet tool.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>
     <RootNamespace>Microsoft.Playwright.CLI</RootNamespace>
@@ -16,7 +16,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>playwright</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>

--- a/src/Playwright.Examples/Playwright.Examples.csproj
+++ b/src/Playwright.Examples/Playwright.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
+++ b/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Playwright.MSTest/Playwright.MSTest.csproj
+++ b/src/Playwright.MSTest/Playwright.MSTest.csproj
@@ -16,7 +16,6 @@
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <BuildFromSource>True</BuildFromSource>
     <AssemblyName>Microsoft.Playwright.MSTest</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -16,7 +16,6 @@
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <BuildFromSource>True</BuildFromSource>
     <AssemblyName>Microsoft.Playwright.NUnit</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/Playwright.TestAdapter/Playwright.TestAdapter.csproj
+++ b/src/Playwright.TestAdapter/Playwright.TestAdapter.csproj
@@ -15,7 +15,6 @@
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <BuildFromSource>True</BuildFromSource>
     <AssemblyName>Microsoft.Playwright.TestAdapter</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <LangVersion>10</LangVersion>

--- a/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
+++ b/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <ReleaseVersion>0.0.0</ReleaseVersion>
     <RootNamespace>Microsoft.Playwright.Tests.TestServer</RootNamespace>

--- a/src/Playwright.Tests.TestServer/SimpleServer.cs
+++ b/src/Playwright.Tests.TestServer/SimpleServer.cs
@@ -118,7 +118,7 @@ public class SimpleServer
 
                     if (_auths.TryGetValue(context.Request.Path, out var auth) && !Authenticate(auth.username, auth.password, context))
                     {
-                        context.Response.Headers.Add("WWW-Authenticate", "Basic realm=\"Secure Area\"");
+                        context.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"Secure Area\"");
 
                         if (!context.Response.HasStarted)
                         {

--- a/src/Playwright.Tests/PageEvaluateTests.cs
+++ b/src/Playwright.Tests/PageEvaluateTests.cs
@@ -728,7 +728,6 @@ public class PageEvaluateTests : PageTestEx
         Assert.AreEqual(400, result.Height);
     }
 
-#if NET6_0_OR_GREATER
     private record ShapeRecord(int Width, int Height);
 
     [PlaywrightTest()]
@@ -737,5 +736,4 @@ public class PageEvaluateTests : PageTestEx
         var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.EvaluateAsync<ShapeRecord>("() => ({ width: 600, height: 400 })"));
         Assert.IsInstanceOf<MissingMethodException>(exception.InnerException);
     }
-#endif
 }

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsTestProject>true</IsTestProject>
         <ReleaseVersion>0.0.0</ReleaseVersion>
         <NoWarn>1701;1702</NoWarn>

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -19,7 +19,6 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <NoWarn>1701;1702;CS0067;1734;NU5110;NU5111</NoWarn>
     <AssemblyName>Microsoft.Playwright</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <Import Project="../Common/Version.props" />
   <Import Project="../Common/Dependencies.props" />

--- a/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
+++ b/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ReleaseVersion>0.0.0</ReleaseVersion>
         <IsTool>true</IsTool>
     </PropertyGroup>

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
@@ -33,8 +33,8 @@ RUN mkdir /ms-playwright && \
     echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><add key="local" value="/tmp/"/></packageSources></configuration>' > nuget.config && \
     dotnet add package Microsoft.Playwright --prerelease && \
     dotnet build && \
-    ./bin/Debug/net6.0/playwright.ps1 install --with-deps && \
-    ./bin/Debug/net6.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    ./bin/Debug/net8.0/playwright.ps1 install --with-deps && \
+    ./bin/Debug/net8.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
     dotnet nuget locals all --clear && rm -rf /root/.nuget && \


### PR DESCRIPTION
This gets merged around November 14-16, 2023, when .NET 8 is the new LTS.

Changes include:
- Do not target `netcoreapp3.1` anymore for the CLI, since its EOL, target .NET 6/ .NET 7/.NET 8 instead.
  - These are the currently supported .NET versions
  - dotnet tools only work under these two target frameworks
- Had to remove `GeneratePackageOnBuild` which made dotnet pack work, seems like not to have other bad side effects
