### PR TITLE
chore: remove TracingChannel JsonSerializerOptions

### DIFF
--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -126,7 +126,7 @@ internal class Tracing : ChannelOwnerBase, IChannelOwner<Tracing>, ITracing
             return;
         }
 
-        var (artifact, entries) = await _channel.TracingStopChunkAsync("archive").ConfigureAwait(false);
+        var (artifact, _) = await _channel.TracingStopChunkAsync("archive").ConfigureAwait(false);
 
         // The artifact may be missing if the browser closed while stopping tracing.
         if (artifact == null)

--- a/src/Playwright/Transport/Channels/TracingChannel.cs
+++ b/src/Playwright/Transport/Channels/TracingChannel.cs
@@ -33,11 +33,6 @@ namespace Microsoft.Playwright.Transport.Channels;
 
 internal class TracingChannel : Channel<Tracing>
 {
-    private static readonly JsonSerializerOptions _tracingChannelSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
     public TracingChannel(string guid, Connection connection, Tracing owner) : base(guid, connection, owner)
     {
     }
@@ -75,14 +70,12 @@ internal class TracingChannel : Channel<Tracing>
         }).ConfigureAwait(false);
 
         var artifact = result.GetObject<Artifact>("artifact", Connection);
-        List<NameValue> entries = new() { };
+        List<NameValue> entries = new();
         if (result.Value.TryGetProperty("entries", out var entriesElement))
         {
-            var entriesEnumerator = entriesElement.EnumerateArray();
-            while (entriesEnumerator.MoveNext())
+            foreach (var current in entriesElement.EnumerateArray())
             {
-                JsonElement current = entriesEnumerator.Current;
-                entries.Add(current.Deserialize<NameValue>(_tracingChannelSerializerOptions));
+                entries.Add(current.Deserialize<NameValue>());
             }
         }
         return (artifact, entries);


### PR DESCRIPTION
Since `NameValue` uses `JsonPropertyNameAttribute` I don't think the `PropertyNameCaseInsensitive = true` is needed anymore and the `_tracingChannelSerializerOptions` aren't needed.

https://github.com/microsoft/playwright-dotnet/blob/1322ae0e8679ced3ce2842dc8997800891be9cbf/src/Playwright/Transport/Protocol/Generated/NameValue.cs#L29-L36