### PR TITLE
chore: remove explicit Microsoft.AspNetCore PackageReferences from TestServer

### DIFF
--- a/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
+++ b/src/Playwright.Tests.TestServer/Playwright.Tests.TestServer.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
   <Import Project="../Common/SignAssembly.props" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <None Update="key.pfx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Since `Playwright.Tests.TestServer` uses `Microsoft.NET.Sdk.Web` they aren't needed.