### PR TITLE
Throws exception when preview have wrong utf string

### DIFF
--- a/src/Playwright.Tests/ElementHandleQuerySelectorTests.cs
+++ b/src/Playwright.Tests/ElementHandleQuerySelectorTests.cs
@@ -26,6 +26,16 @@ namespace Microsoft.Playwright.Tests;
 
 public class ElementHandleQuerySelectorTests : PageTestEx
 {
+    [PlaywrightTest()]
+    public async Task ShouldQuerySpecialCharElement()
+    {
+        await Page.SetContentAsync("<p title=\"曾全网封禁的《𝑭𝒂𝒍𝒍𝒊𝒏𝒈 𝑨𝒈𝒂𝒊𝒏》如今治愈了无数人的心灵\" class=\"title\">曾全网封禁的《𝑭𝒂𝒍𝒍𝒊𝒏𝒈 𝑨𝒈𝒂𝒊𝒏》如今治愈了无数人的心灵</p>");
+
+        var titleA = await Page.QuerySelectorAsync(".title");
+        var innerText = await titleA.InnerTextAsync();
+        Assert.AreEqual("曾全网封禁的《𝑭𝒂𝒍𝒍𝒊𝒏𝒈 𝑨𝒈𝒂𝒊𝒏》如今治愈了无数人的心灵", innerText);
+    }
+
     [PlaywrightTest("elementhandle-query-selector.spec.ts", "should query existing element")]
     public async Task ShouldQueryExistingElement()
     {

--- a/src/Playwright/Transport/Channels/ElementHandleChannel.cs
+++ b/src/Playwright/Transport/Channels/ElementHandleChannel.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Core;
 using Microsoft.Playwright.Helpers;
@@ -49,7 +50,25 @@ internal class ElementHandleChannel : JSHandleChannel, IChannel<ElementHandle>
         switch (method)
         {
             case "previewUpdated":
-                PreviewUpdated?.Invoke(this, serverParams.Value.GetProperty("preview").ToString());
+                var preview = string.Empty;
+                try
+                {
+                    preview = serverParams.Value.GetProperty("preview").ToString();
+                }
+                catch
+                {
+                    var matchResult = Regex.Match(serverParams.Value.ToString(), "\"preview\":\"(.*)\"");
+                    if (matchResult.Success)
+                    {
+                        preview = matchResult.Groups[1].ToString();
+                    }
+                    else
+                    {
+                        preview = serverParams.Value.ToString();
+                    }
+                }
+
+                PreviewUpdated?.Invoke(this, preview);
                 break;
         }
     }


### PR DESCRIPTION
#2748 

 when preview have wrong utf string, syste.text.json cannot convert it to object.

However, the preview only use to print, should not affect the normal operation of the program

