### PR TITLE
Improve the driver downloader

### DIFF
--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -54,7 +54,7 @@
     <None Include="build\**" Pack="true" PackagePath="build" />
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />
   </ItemGroup>
-  <Target Name="EnsurePrerequisitsRan" BeforeTargets="DedupeDriver">
-    <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />
+  <Target Name="EnsurePrerequisitsRan" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />
   </Target>
 </Project>

--- a/src/tools/Playwright.Tooling/Options/DownloadDriversOptions.cs
+++ b/src/tools/Playwright.Tooling/Options/DownloadDriversOptions.cs
@@ -22,13 +22,18 @@
  * SOFTWARE.
  */
 
-using CommandLine;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Spectre.Console.Cli;
 
 namespace Playwright.Tooling.Options;
 
-[Verb("download-drivers")]
-internal class DownloadDriversOptions
+internal class DownloadDriversOptions : CommandSettings
 {
-    [Option(Required = true, HelpText = "Solution path.")]
-    public string BasePath { get; set; }
+    [CommandOption("--basepath")]
+    [Description("Solution path.")]
+    public string BasePath { get; init; } = GetDefaultPath();
+
+    private static string GetDefaultPath([CallerFilePath] string path = "") => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, "..", "..", "..", ".."));
 }

--- a/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
+++ b/src/tools/Playwright.Tooling/Playwright.Tooling.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
     <Import Project="../../Common/Dependencies.props" />
     <ItemGroup>
-        <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
     </ItemGroup>
 </Project>

--- a/src/tools/Playwright.Tooling/Program.cs
+++ b/src/tools/Playwright.Tooling/Program.cs
@@ -23,16 +23,16 @@
  */
 
 using System.Threading.Tasks;
-using CommandLine;
-using Playwright.Tooling.Options;
+using Spectre.Console.Cli;
 
 namespace Playwright.Tooling;
 
 internal static class Program
 {
-    internal static async Task Main(string[] args)
+    internal static async Task<int> Main(string[] args)
     {
-        ParserResult<DownloadDriversOptions> result = Parser.Default.ParseArguments<DownloadDriversOptions>(args);
-        await result.WithParsedAsync(DriverDownloader.RunAsync).ConfigureAwait(false);
+        var app = new CommandApp();
+        app.Configure(config => config.AddCommand<DriverDownloader>("download-drivers"));
+        return await app.RunAsync(args).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
* Use Spectre.Console.Cli instead of CommandLineParser, which provides a _free_ spinner while downloading drivers.
* Automatically compute a default for the `--basepath` option (it would not even be required anymore).
* Actually run the `EnsurePrerequisitsRan` target so that people trying to build the Playwright project have a clear error with the solution to download the missing drivers.