### PR TITLE
chore: update dev nunit dependencies

### DIFF
--- a/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
+++ b/src/Playwright.LocalNugetTest/Playwright.LocalNugetTest.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.*" />
     <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.*" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -12,10 +12,10 @@
   <Import Project="../Playwright.Tests/build/Playwright.Tests.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -22,9 +22,9 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NUnit" Version="3.14.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
         <PackageReference Include="NETStandard.Library" Version="2.0.3" />


### PR DESCRIPTION
This broke the VSCode integration, so we had to bump it.

This does not affect any shipped/prod dependencies.