### PR TITLE
devops: fix .NET publishing

### DIFF
--- a/.github/workflows/publish_canary_docker.yml
+++ b/.github/workflows/publish_canary_docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish-canary:
     name: "Publish canary Docker"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'microsoft/playwright-dotnet'
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Set up Docker QEMU for arm64 docker builds
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
     - name: publish docker canary

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -31,7 +31,7 @@ jobs:
         username: playwright
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Set up Docker QEMU for arm64 docker builds
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
     - run: ./utils/docker/publish_docker.sh stable

--- a/utils/docker/Dockerfile.focal
+++ b/utils/docker/Dockerfile.focal
@@ -20,23 +20,15 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
-COPY ./dist/* /tmp/
+COPY ./dist/ /tmp/playwright-dotnet
 
 # 2. Bake in browsers & deps.
 #    Browsers will be downloaded in `/ms-playwright`.
 #    Note: make sure to set 777 to the registry so that any user can access
 #    registry.
 RUN mkdir /ms-playwright && \
-    mkdir /ms-playwright-agent && \
-    cd /ms-playwright-agent && \
-    dotnet new console && \
-    echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><add key="local" value="/tmp/"/></packageSources></configuration>' > nuget.config && \
-    dotnet add package Microsoft.Playwright --prerelease && \
-    dotnet build && \
-    ./bin/Debug/net6.0/playwright.ps1 install --with-deps && \
-    ./bin/Debug/net6.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    /tmp/playwright-dotnet/playwright.ps1 install --with-deps && \
+    /tmp/playwright-dotnet/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
-    dotnet nuget locals all --clear && rm -rf /root/.nuget && \
-    rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -20,21 +20,15 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # 1. Add tip-of-tree Playwright package to install its browsers.
 #    The package should be built beforehand from tip-of-tree Playwright.
-COPY ./dist/* /tmp/
+COPY ./dist/ /tmp/playwright-dotnet
 
 # 2. Bake in browsers & deps.
 #    Browsers will be downloaded in `/ms-playwright`.
 #    Note: make sure to set 777 to the registry so that any user can access
 #    registry.
 RUN mkdir /ms-playwright && \
-    mkdir /ms-playwright-agent && \
-    cd /ms-playwright-agent && \
-    dotnet new console && \
-    echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><add key="local" value="/tmp/"/></packageSources></configuration>' > nuget.config && \
-    dotnet add package Microsoft.Playwright --prerelease && \
-    dotnet build && \
-    ./bin/Debug/net8.0/playwright.ps1 install --with-deps && \
-    ./bin/Debug/net8.0/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    /tmp/playwright-dotnet/playwright.ps1 install --with-deps && \
+    /tmp/playwright-dotnet/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
     # Workaround for https://github.com/microsoft/playwright/issues/27313
     # While the gstreamer plugin load process can be in-process, it ended up throwing
     # an error that it can't have libsoup2 and libsoup3 in the same process because
@@ -46,6 +40,4 @@ RUN mkdir /ms-playwright && \
     fi && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/* && \
-    dotnet nuget locals all --clear && rm -rf /root/.nuget && \
-    rm -rf /ms-playwright-agent && \
     chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -23,27 +23,19 @@ function cleanup() {
 trap "cleanup; cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
-# .NET internally has two sources when we install a tool with --add-source
-# so our local version needs to be higher that it gets priority over the remote one.
-# Also it should not include any pre-release versions (include next).
-xml_file_path="../../src/Common/Version.props"
-xml_file_contents=$(cat "${xml_file_path}")
-xml_file_contents=$(echo "${xml_file_contents}" | sed "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>1.99.99</AssemblyVersion>|")
-xml_file_contents=$(echo "${xml_file_contents}" | sed "s|<PackageVersion>.*</PackageVersion>|<PackageVersion>1.99.99</PackageVersion>|")
-echo "${xml_file_contents}" > "${xml_file_path}"
-
-mkdir dist
-dotnet build ../../src/Playwright
-dotnet pack ../../src/Playwright -o dist/
-
-PLATFORM=""
+DOCKER_PLATFORM=""
+DOTNET_ARCH=""
 if [[ "$1" == "--arm64" ]]; then
-  PLATFORM="linux/arm64";
+  DOCKER_PLATFORM="linux/arm64";
+  DOTNET_ARCH="linux-arm64";
 elif [[ "$1" == "--amd64" ]]; then
-  PLATFORM="linux/amd64"
+  DOCKER_PLATFORM="linux/amd64"
+  DOTNET_ARCH="linux-amd64"
 else
   echo "ERROR: unknown platform specifier - $1. Only --arm64 or --amd64 is supported"
   exit 1
 fi
 
-docker build --progress=plain --platform "${PLATFORM}" -t "$3" -f "Dockerfile.$2" .
+dotnet publish ../../src/Playwright -o dist/ --arch $DOTNET_ARCH
+
+docker build --progress=plain --platform "${DOCKER_PLATFORM}" -t "$3" -f "Dockerfile.$2" .


### PR DESCRIPTION
As per https://github.com/dotnet/runtime/issues/95120 QEMU is not supported. We'll instead cross-compile in the outside and use it's artifacts inside the container.

This worked on my Ubuntu 22.04 machine when testing.