### PR TITLE
fix: Microsoft.Playwright.dll is in use

### DIFF
--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -65,14 +65,17 @@ internal static class Driver
 
         string executableFile;
 
+        // When loading the Assembly via the memory we don't have any references where the driver might be located.
+        // To workaround this we pass this env from the .ps1 wrapper over to the Assembly.
         var driverSearchPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
         if (!string.IsNullOrEmpty(driverSearchPath))
         {
             executableFile = GetPath(driverSearchPath);
-            if (File.Exists(executableFile))
+            if (!File.Exists(executableFile))
             {
-                return executableFile;
+                throw new PlaywrightException("Couldn't find driver in \"PLAYWRIGHT_DRIVER_SEARCH_PATH\"");
             }
+            return executableFile;
         }
 
         executableFile = GetPath(assemblyDirectory.FullName);

--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -63,7 +63,19 @@ internal static class Driver
             assemblyDirectory = new FileInfo(assemblyLocation).Directory;
         }
 
-        string executableFile = GetPath(assemblyDirectory.FullName);
+        string executableFile;
+
+        var driverSearchPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH");
+        if (!string.IsNullOrEmpty(driverSearchPath))
+        {
+            executableFile = GetPath(driverSearchPath);
+            if (File.Exists(executableFile))
+            {
+                return executableFile;
+            }
+        }
+
+        executableFile = GetPath(assemblyDirectory.FullName);
         if (File.Exists(executableFile))
         {
             return executableFile;

--- a/src/Playwright/build/playwright.ps1
+++ b/src/Playwright/build/playwright.ps1
@@ -2,5 +2,6 @@
 
 $Env:PLAYWRIGHT_DRIVER_SEARCH_PATH = $PSScriptRoot;
 $playwrightLibrary = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "Microsoft.Playwright.dll"))
+# We load the library via the memory to not keep the .dll file locked/opened.
 [Reflection.Assembly]::Load([System.IO.File]::ReadAllBytes($playwrightLibrary)) | Out-Null
 exit [Microsoft.Playwright.Program]::Main($args)

--- a/src/Playwright/build/playwright.ps1
+++ b/src/Playwright/build/playwright.ps1
@@ -1,5 +1,6 @@
 #!/usr/bin/env pwsh
 
-$PlaywrightFileName = Join-Path $PSScriptRoot "Microsoft.Playwright.dll"
-[Reflection.Assembly]::LoadFile($PlaywrightFileName) | Out-Null
+$Env:PLAYWRIGHT_DRIVER_SEARCH_PATH = $PSScriptRoot;
+$playwrightLibrary = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PSScriptRoot, "Microsoft.Playwright.dll"))
+[Reflection.Assembly]::Load([System.IO.File]::ReadAllBytes($playwrightLibrary)) | Out-Null
 exit [Microsoft.Playwright.Program]::Main($args)


### PR DESCRIPTION
Motivation: If you run `playwright.ps1` inside a PowerShell session, the `Microsoft.Playwright.dll` got loaded but never unloaded. This resulted that the `Microsoft.Playwright.dll` file stayed open on Windows. Future calls to `dotnet build` or `dotnet clean` did misbehave.

Fix: Read the content: around 1 MB and load the Assembly. This has the drawback that the program (when running the CLI) doesn't know anymore where it was running, so it is not able to find the `.playwright` path etc.