### PR TITLE
chore: align Microsoft.Playwright.NUnit TFM with NUnit3TestAdapter TFM

### DIFF
--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -9,7 +9,7 @@
       and fixtures to enable using it within NUnit.
     </Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>
     <RootNamespace>Microsoft.Playwright.NUnit</RootNamespace>

--- a/src/Playwright.NUnit/WorkerAwareTest.cs
+++ b/src/Playwright.NUnit/WorkerAwareTest.cs
@@ -61,7 +61,7 @@ public class WorkerAwareTest
     [SetUp]
     public void WorkerSetup()
     {
-        if (!_allWorkers.TryPop(out _currentWorker))
+        if (!_allWorkers.TryPop(out _currentWorker!))
         {
             _currentWorker = new();
         }


### PR DESCRIPTION
This fixes:

```
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.NUnit/Playwright.NUnit.csproj : warning NU1701: Package 'NUnit3TestAdapter 4.0.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.sln]
  All projects are up-to-date for restore.
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.NUnit/Playwright.NUnit.csproj : warning NU1701: Package 'NUnit3TestAdapter 4.0.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.
```

by aligning the `Microsoft.Playwright.NUnit` TFM with the [`NUnit3TestAdapter` TFM](https://www.nuget.org/packages/NUnit3TestAdapter).