### PR TITLE
chore: get rid of build warnings

### DIFF
--- a/src/Common/Dependencies.props
+++ b/src/Common/Dependencies.props
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Playwright.Tests/BrowserContextRouteTests.cs
+++ b/src/Playwright.Tests/BrowserContextRouteTests.cs
@@ -88,11 +88,11 @@ public class BrowserContextRouteTests : BrowserTestEx
             route.ContinueAsync();
         });
 
-        Action<IRoute> handler4 = (route) =>
+        void handler4(IRoute route)
         {
             intercepted.Add(4);
             route.ContinueAsync();
-        };
+        }
         await context.RouteAsync(new Regex("/empty.html"), handler4);
 
         await page.GotoAsync(Server.EmptyPage);
@@ -125,11 +125,11 @@ public class BrowserContextRouteTests : BrowserTestEx
             route.ContinueAsync();
         });
 
-        Action<IRoute> handler2 = (route) =>
+        void handler2(IRoute route)
         {
             intercepted.Add(2);
             route.ContinueAsync();
-        };
+        }
         await page.RouteAsync("/empty.html", handler2);
 
         await page.GotoAsync(Server.EmptyPage);
@@ -363,7 +363,7 @@ public class BrowserContextRouteTests : BrowserTestEx
         await using var context = await Browser.NewContextAsync();
         var page = await context.NewPageAsync();
         var intercepted = new List<string>();
-        async Task handler(IRoute route)
+        void handler(IRoute route)
         {
             intercepted.Add("first");
             route.ContinueAsync();

--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -81,11 +81,11 @@ public class PageRouteTests : PageTestEx
         });
 
 
-        Action<IRoute> handler4 = (route) =>
+        void handler4(IRoute route)
         {
             intercepted.Add(4);
             route.FallbackAsync();
-        };
+        }
 
         await Page.RouteAsync(new Regex("/empty.html"), handler4);
         await Page.GotoAsync(Server.EmptyPage);
@@ -771,7 +771,7 @@ public class PageRouteTests : PageTestEx
     public async Task ShouldWorkIfHandlerWithTimesParameterWasRemovedFromAnotherHandler()
     {
         var intercepted = new List<string>();
-        async Task handler(IRoute route)
+        void handler(IRoute route)
         {
             intercepted.Add("first");
             route.ContinueAsync();

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -534,7 +535,7 @@ internal class Locator : ILocator
         }
         if (options.Level != null)
         {
-            props.Add(new List<string> { "level", options.Level.ToString() });
+            props.Add(new List<string> { "level", options.Level?.ToString(CultureInfo.InvariantCulture) });
         }
         if (options.Name != null)
         {


### PR DESCRIPTION
This fixes:

```
/Users/maxschmitt/.nuget/packages/microsoft.codeanalysis.netanalyzers/7.0.3/build/Microsoft.CodeAnalysis.NetAnalyzers.targets(593,5): warning : The .NET SDK has newer analyzers with version '8.0.0' than what version '7.0.3' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Playwright.csproj]
CSC : warning SA0001: XML comment analysis is disabled due to project configuration (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md) [/Users/maxschmitt/Developer/playwright-dotnet/src/tools/Playwright.Tooling/Playwright.Tooling.csproj]
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/BrowserContextRouteTests.cs(369,13): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/Playwright.Tests.csproj::TargetFramework=net8.0]
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/BrowserContextRouteTests.cs(366,20): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/Playwright.Tests.csproj::TargetFramework=net8.0]
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/PageRouteTests.cs(777,13): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/Playwright.Tests.csproj::TargetFramework=net8.0]
/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/PageRouteTests.cs(774,20): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [/Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Tests/Playwright.Tests.csproj::TargetFramework=net8.0]
    9 Warning(s)
```