### PR TITLE
chore: migrate dotnet-format to dotnet format

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Check formatting
-      run: dotnet format ./src/ --verify-no-changes -v:diag --verbosity diag
+      run: dotnet format ./src/ --verify-no-changes -v:diag
     - name: Download driver
       run: ./build.sh --download-driver
     - name: Build projects (runs .NET analyzers)

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Check formatting
-      run: dotnet format ./src/ --verify-no-changes -v:diag
+      run: dotnet format ./src/ --verify-no-changes -v:diag --verbosity diag
     - name: Download driver
       run: ./build.sh --download-driver
     - name: Build projects (runs .NET analyzers)

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          6.0.x
+          8.0.x
     - name: Check formatting
       run: dotnet format ./src/ --verify-no-changes -v:diag
     - name: Download driver

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -17,10 +17,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.0.x
-    - name: Install dotnet-format
-      run: dotnet tool install --global dotnet-format
     - name: Check formatting
-      run: dotnet-format -f ./src/ --check -v:diag
+      run: dotnet format ./src/ --verify-no-changes -v:diag
     - name: Download driver
       run: ./build.sh --download-driver
     - name: Build projects (runs .NET analyzers)

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,9 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
+        dotnet-version: 8.0.x
     - name: Check formatting
       run: dotnet format ./src/ --verify-no-changes -v:diag
     - name: Download driver

--- a/.github/workflows/nuget-package-tests.yml
+++ b/.github/workflows/nuget-package-tests.yml
@@ -24,9 +24,7 @@ jobs:
           dotnet-version: 8.0.x
       - name: Install prerequisites and download drivers
         shell: bash
-        run: |
-          ./build.sh --download-driver
-          ./build.sh --setup-dotnet-deps
+        run: ./build.sh --download-driver
       # .NET internally has two sources when we install a tool with --add-source
       # so our local version needs to be higher that it gets priority over the remote one.
       # Also it should not include any pre-release versions (include next).

--- a/.gitignore
+++ b/.gitignore
@@ -356,7 +356,6 @@ src/Playwright/.drivers
 src/Playwright.Tests/Screenshots/**/test.png
 src/Playwright/Microsoft.Playwright.xml
 
-dotnet-format/
 testCert.cer
 
 coverage-report/

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,6 @@ if [[ ($1 == '--help') || ($1 == '-h') ]]; then
   echo "  --init                - download .NET deps and download driver"
   echo "  --roll <version>      - roll the .NET language binding to a specific driver version"
   echo "  --download-driver     - download the driver"
-  echo "  --setup-dotnet-deps   - download and install the .NET tool deps"
   echo "  --update-assets       - sync the assets from 'playwright' to 'playwright-dotnet'"
   echo "  --help                - show this help"
   echo
@@ -29,12 +28,6 @@ if [[ -n "$PW_SRC_DIR" ]]; then
   upstream_repo_path="$PW_SRC_DIR"
 fi
 echo "Upstream repo path: ${upstream_repo_path}"
-
-function download_dotnet_tool_deps() {
-  echo "Downloading .NET tool dependencies"
-  dotnet tool install --global dotnet-format || true
-  echo "done"
-}
 
 function download_driver() {
   echo "downloading driver..."
@@ -76,7 +69,6 @@ function roll_driver() {
 
 CMD="$1"
 if [[ ("$CMD" == "--init") ]]; then
-  download_dotnet_tool_deps
   download_driver
 elif [[ ("$CMD" == "--roll") ]]; then
   roll_driver $2
@@ -84,8 +76,6 @@ elif [[ ("$CMD" == "--download-driver") ]]; then
   download_driver
 elif [[ ("$CMD" == "--update-assets") ]]; then
   update_assets
-elif [[ ("$CMD" == "--setup-dotnet-deps") ]]; then
-  download_dotnet_tool_deps
 else
   echo "ERROR: unknown command - $CMD"
   echo "Pass --help for supported commands"

--- a/src/Playwright.Tests/InterceptionTests.cs
+++ b/src/Playwright.Tests/InterceptionTests.cs
@@ -27,7 +27,7 @@ using Microsoft.Playwright.Helpers;
 
 namespace Microsoft.Playwright.Tests;
 
-public class GlobTests : PageTestEx
+public class InterceptionTests : PageTestEx
 {
     [PlaywrightTest("interception.spec.ts", "should work with glob")]
     public void ShouldWorkWithGlob()

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -32,11 +32,6 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="CompareNETObjects" Version="4.77.0" />
-        <Compile Include="..\Playwright\Helpers\StringExtensions.cs" Link="StringExtensions.cs" />
-        <Compile Include="..\Playwright\Helpers\DoubleExtensions.cs" Link="DoubleExtensions.cs" />
-        <Compile Include="..\Playwright\Helpers\RegexOptionsExtensions.cs" Link="RegexOptionsExtensions.cs" />
-        <Compile Include="..\Playwright\Helpers\TaskHelper.cs" Link="TaskHelper.cs" />
-        <Compile Include="..\Playwright\Helpers\Driver.cs" Link="Driver.cs" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Playwright\Playwright.csproj" />

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -35,6 +35,9 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Playwright.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100059a04ca5ca77c9b4eb2addd1afe3f8464b20ee6aefe73b8c23c0e6ca278d1a378b33382e7e18d4aa8300dd22d81f146e528d88368f73a288e5b8157da9710fe6f9fa9911fb786193f983408c5ebae0b1ba5d1d00111af2816f5db55871db03d7536f4a7a6c5152d630c1e1886b1a0fb68ba5e7f64a7f24ac372090889be2ffb" />
+  </ItemGroup>
+  <ItemGroup>
     <None Remove=".drivers\**" />
     <None Include=".drivers\linux\package\**" Link=".playwright\package\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\package" />
     <None Include=".drivers\linux\LICENSE" Pack="true" PackagePath=".playwright\node" />

--- a/src/Playwright/Transport/Converters/ChannelOwnerConverterFactory.cs
+++ b/src/Playwright/Transport/Converters/ChannelOwnerConverterFactory.cs
@@ -23,7 +23,6 @@
  */
 
 using System;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 


### PR DESCRIPTION
Changes:

- Migrated to the new tool: https://github.com/dotnet/format/issues/1268.
- Exposing all internals to the test project
- Drive-by rename InterceptionTests
