### PR TITLE
fix: build with --output without trailing slash

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -60,7 +60,7 @@
     <Target Name="PlaywrightChmodExecutables" AfterTargets="CopyFilesToOutputDirectory;CopyFilesToPublishDirectory" Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
     <ItemGroup>
       <_PlaywrightChmodItems Include="$([MSBuild]::EnsureTrailingSlash('$(OutputPath)')).playwright\node\*\node" />
-      <_PlaywrightChmodItems Include="$(PublishDir).playwright\node\*\node" />
+      <_PlaywrightChmodItems Include="$([MSBuild]::EnsureTrailingSlash('$(PublishDir)')).playwright\node\*\node" />
     </ItemGroup>
     <Exec Command="chmod +x &quot;%(_PlaywrightChmodItems.FullPath)&quot;" />
   </Target>

--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -59,7 +59,7 @@
   </Target>
     <Target Name="PlaywrightChmodExecutables" AfterTargets="CopyFilesToOutputDirectory;CopyFilesToPublishDirectory" Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
     <ItemGroup>
-      <_PlaywrightChmodItems Include="$(OutputPath).playwright\node\*\node" />
+      <_PlaywrightChmodItems Include="$([MSBuild]::EnsureTrailingSlash('$(OutputPath)')).playwright\node\*\node" />
       <_PlaywrightChmodItems Include="$(PublishDir).playwright\node\*\node" />
     </ItemGroup>
     <Exec Command="chmod +x &quot;%(_PlaywrightChmodItems.FullPath)&quot;" />


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2827

My first attempt was using `OutDir` but it broke some of the LocalNugetTests. Instead we now call EnsureTrailingSlash.