### PR TITLE
fix: PdfAsync without passing options

### DIFF
--- a/src/Playwright.Tests/PdfTests.cs
+++ b/src/Playwright.Tests/PdfTests.cs
@@ -48,6 +48,15 @@ public class PdfTests : PageTestEx
         }
     }
 
+    [PlaywrightTest("pdf.spec.ts", "should be able to save file without passing options")]
+    [Skip(SkipAttribute.Targets.Firefox, SkipAttribute.Targets.Webkit)]
+    public async Task ShouldBeAbleToSaveFileWithoutPassingOptions()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        var result = await Page.PdfAsync();
+        Assert.True(result.Length > 0);
+    }
+
     [PlaywrightTest("pdf.spec.ts", "should only have pdf in chromium")]
     [Skip(SkipAttribute.Targets.Chromium)]
     public Task ShouldOnlyHavePdfInChromium()

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -866,6 +866,7 @@ internal class Page : ChannelOwner, IPage
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<byte[]> PdfAsync(PagePdfOptions options = default)
     {
+        options ??= new();
         if (!Context.IsChromium)
         {
             throw new NotSupportedException("This browser doesn't support this action.");


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2841