### PR TITLE
chore: improve invalid browser name by env exception

### DIFF
--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -42,13 +42,13 @@ public class PlaywrightSettingsProvider : ISettingsProvider
             var browserFromEnv = Environment.GetEnvironmentVariable("BROWSER")?.ToLowerInvariant();
             if (!string.IsNullOrEmpty(browserFromEnv))
             {
-                ValidateBrowserName(browserFromEnv!);
+                ValidateBrowserName(browserFromEnv!, "'BROWSER' environment variable");
                 return browserFromEnv!;
             }
             if (_settings != null && !string.IsNullOrEmpty(_settings.BrowserName))
             {
                 var browser = _settings.BrowserName!.ToLowerInvariant();
-                ValidateBrowserName(browser);
+                ValidateBrowserName(browser, "run settings");
                 return browser;
             }
             return BrowserType.Chromium;
@@ -93,13 +93,15 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         }
     }
 
-    private static void ValidateBrowserName(string browserName)
+    private static void ValidateBrowserName(string browserName, string fromText)
     {
         if (browserName != BrowserType.Chromium &&
             browserName != BrowserType.Firefox &&
             browserName != BrowserType.Webkit)
         {
-            throw new ArgumentException($"Invalid browser name: {browserName}");
+            throw new ArgumentException($"Invalid browser name from {fromText}.\n" +
+                $"Supported browsers: '{BrowserType.Chromium}', '{BrowserType.Firefox}', '{BrowserType.Webkit}'\n" +
+                $"Actual browser: '{browserName}'");
         }
     }
 

--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -42,13 +42,13 @@ public class PlaywrightSettingsProvider : ISettingsProvider
             var browserFromEnv = Environment.GetEnvironmentVariable("BROWSER")?.ToLowerInvariant();
             if (!string.IsNullOrEmpty(browserFromEnv))
             {
-                ValidateBrowserName(browserFromEnv!, "'BROWSER' environment variable");
+                ValidateBrowserName(browserFromEnv!, "'BROWSER' environment variable", "\nTry to remove 'BROWSER' environment variable for using default browser");
                 return browserFromEnv!;
             }
             if (_settings != null && !string.IsNullOrEmpty(_settings.BrowserName))
             {
                 var browser = _settings.BrowserName!.ToLowerInvariant();
-                ValidateBrowserName(browser, "run settings");
+                ValidateBrowserName(browser, "run settings", string.Empty);
                 return browser;
             }
             return BrowserType.Chromium;
@@ -93,15 +93,15 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         }
     }
 
-    private static void ValidateBrowserName(string browserName, string fromText)
+    private static void ValidateBrowserName(string browserName, string fromText, string suffix)
     {
         if (browserName != BrowserType.Chromium &&
             browserName != BrowserType.Firefox &&
             browserName != BrowserType.Webkit)
         {
             throw new ArgumentException($"Invalid browser name from {fromText}.\n" +
-                $"Supported browsers: '{BrowserType.Chromium}', '{BrowserType.Firefox}', '{BrowserType.Webkit}'\n" +
-                $"Actual browser: '{browserName}'");
+                $"Supported browsers: '{BrowserType.Chromium}', '{BrowserType.Firefox}', and '{BrowserType.Webkit}'\n" +
+                $"Actual browser: '{browserName}'{suffix}");
         }
     }
 

--- a/src/Playwright.TestingHarnessTest/tests/baseTest.ts
+++ b/src/Playwright.TestingHarnessTest/tests/baseTest.ts
@@ -69,13 +69,9 @@ export const test = base.extend<{
         console.log('=========================================');
         console.log(`Command: ${testResult.command}`);
         console.log(`Exit code: ${testResult.exitCode}`);
-        if (testResult.stdout) {
+        if (testResult.rawStdout) {
           console.log(`Stdout:`);
-          console.log(testResult.stdout);
-        }
-        if (testResult.stderr) {
-          console.log(`Stderr:`);
-          console.log(testResult.stderr);
+          console.log(testResult.rawStdout);
         }
         console.log('=========================================');
       }


### PR DESCRIPTION
We could warn as well, but it seems not a helpful warning where the user can act on.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2847.