### PR TITLE
feat: expose SetDefaultExpectTimeout()

### DIFF
--- a/src/Playwright.MSTest/PlaywrightTest.cs
+++ b/src/Playwright.MSTest/PlaywrightTest.cs
@@ -130,6 +130,8 @@ public class PlaywrightTest
 
     public TestContext TestContext { get; set; } = null!;
 
+    public void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
+
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
 
     public IPageAssertions Expect(IPage page) => Assertions.Expect(page);

--- a/src/Playwright.NUnit/PlaywrightTest.cs
+++ b/src/Playwright.NUnit/PlaywrightTest.cs
@@ -46,6 +46,8 @@ public class PlaywrightTest : WorkerAwareTest
         Playwright.Selectors.SetTestIdAttribute("data-testid");
     }
 
+    public void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
+
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
 
     public IPageAssertions Expect(IPage page) => Assertions.Expect(page);

--- a/src/Playwright.Tests/Assertions/LocatorAssertionsTests.cs
+++ b/src/Playwright.Tests/Assertions/LocatorAssertionsTests.cs
@@ -47,6 +47,22 @@ public class LocatorAssertionsTests : PageTestEx
         StringAssert.Contains("LocatorAssertions.ToBeCheckedAsync with timeout 300ms", exception.Message);
     }
 
+    [PlaywrightTest("playwright-test/playwright.expect.spec.ts", "should be able to set default timeout")]
+    public async Task ShouldBeAbleToSetDefaultTimeout()
+    {
+        try
+        {
+            SetDefaultExpectTimeout(1111);
+            var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Expect(Page.Locator("input")).Not.ToBeCheckedAsync());
+            StringAssert.Contains("Locator expected not to be checked", exception.Message);
+            StringAssert.Contains("LocatorAssertions.ToBeCheckedAsync with timeout 1111ms", exception.Message);
+        }
+        finally
+        {
+            SetDefaultExpectTimeout(5000);
+        }
+    }
+
     [PlaywrightTest("page/expect-boolean.spec.ts", "toBeAttached > default")]
     public async Task ToBeAttachedDefault()
     {

--- a/src/Playwright/Assertions.cs
+++ b/src/Playwright/Assertions.cs
@@ -28,6 +28,15 @@ namespace Microsoft.Playwright;
 
 public static class Assertions
 {
+    /// <summary>
+    /// Sets the default timeout for all future <c>Expect</c> calls.
+    /// </summary>
+    /// <param name="timeout">The timeout in milliseconds.</param>
+    /// <remarks>
+    /// <para>
+    /// The default timeout is 5 seconds.
+    /// </para>
+    /// </remarks>
     public static void SetDefaultExpectTimeout(float timeout) => AssertionsBase.SetDefaultTimeout(timeout);
 
     public static ILocatorAssertions Expect(ILocator locator) => new LocatorAssertions(locator, false);

--- a/src/Playwright/Assertions.cs
+++ b/src/Playwright/Assertions.cs
@@ -1,9 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 using Microsoft.Playwright.Core;
 
 namespace Microsoft.Playwright;
 
 public static class Assertions
 {
+    public static void SetDefaultExpectTimeout(float timeout) => AssertionsBase.SetDefaultTimeout(timeout);
+
     public static ILocatorAssertions Expect(ILocator locator) => new LocatorAssertions(locator, false);
 
     public static IPageAssertions Expect(IPage page) => new PageAssertions(page, false);


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2259
Fixes https://github.com/microsoft/playwright-dotnet/issues/2603

~~Maybe we should introduce Expect().Configure like we have in Node.js: https://playwright.dev/docs/test-assertions#expectconfigure~~