### PR TITLE
devops: migrate to 1ES PT

### DIFF
--- a/.build/azure-pipeline-nuget.yml
+++ b/.build/azure-pipeline-nuget.yml
@@ -1,260 +1,247 @@
 trigger: none # We don't want CI builds, just a manual release process
-pool: $(PlaywrightPoolName)
 parameters:
-  - name: doRelease
-    displayName: Push the Playwright Release to NuGet.org
-    default: false
-    type: boolean
+- name: doRelease
+  displayName: Push the Playwright Release to NuGet.org
+  default: false
+  type: boolean
 
-  - name: doReleaseCLI
-    displayName: Push the CLI Release to NuGet.org
-    default: false
-    type: boolean
+- name: doReleaseCLI
+  displayName: Push the CLI Release to NuGet.org
+  default: false
+  type: boolean
 
-  - name: signType
-    displayName: Sign Type
-    default: 'test'
-    type: string
-    values:
-    - test
-    - real
+- name: signType
+  displayName: Sign Type
+  default: 'test'
+  type: string
+  values:
+  - test
+  - real
 
-stages:
-- stage: BuildPackageSign
-  displayName: Build, Package & Sign
-  jobs:
-  - job: BuildPackage
-    displayName: Build & Package
-    steps:
+variables:
+- name: BuildConfiguration
+  value: 'Release' 
 
-    - task: UseDotNet@2
-      displayName: 'Use .NET 8 SDK'
-      inputs:
-        packageType: sdk
-        version: 8.x
-
-    - task: MicroBuildSigningPlugin@3
-      inputs:
-        signType: '${{ parameters.signType }}'
-        feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-        
-      # We need to download the driver first, so we can build
-    - task: DotNetCoreCLI@2
-      displayName: Download the driver
-      inputs:
-        command: 'run'
-        arguments: '--project $(Build.SourcesDirectory)/src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath $(Build.SourcesDirectory)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Build Playwright CLI
-      inputs:
-        command: 'build'
-        projects: '**/Playwright.CLI.csproj'
-        arguments: '-c $(BuildConfiguration)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Pack Playwright CLI
-      inputs:
-        command: 'pack'
-        packagesToPack: '**/Playwright.CLI.csproj'
-        packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-        versioningScheme: 'off'
-
-    - task: DotNetCoreCLI@2
-      displayName: Build Playwright
-      inputs:
-        command: 'build'
-        projects: '**/Playwright.csproj'
-        arguments: '-c $(BuildConfiguration)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Pack Playwright NuGet
-      inputs:
-        command: 'pack'
-        packagesToPack: '**/Playwright.csproj'
-        packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-        versioningScheme: 'off'
-
-    - task: DotNetCoreCLI@2
-      displayName: Build Playwright.NUnit
-      inputs:
-        command: 'build'
-        projects: '**/Playwright.NUnit.csproj'
-        arguments: '-c $(BuildConfiguration)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Pack Playwright.NUnit NuGet
-      inputs:
-        command: 'pack'
-        packagesToPack: '**/Playwright.NUnit.csproj'
-        packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-        versioningScheme: 'off'
-
-    - task: DotNetCoreCLI@2
-      displayName: Build Playwright.MSTest
-      inputs:
-        command: 'build'
-        projects: '**/Playwright.MSTest.csproj'
-        arguments: '-c $(BuildConfiguration)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Pack Playwright.MSTest NuGet
-      inputs:
-        command: 'pack'
-        packagesToPack: '**/Playwright.MSTest.csproj'
-        packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-        versioningScheme: 'off'
-
-    - task: DotNetCoreCLI@2
-      displayName: Build Playwright.TestAdapter
-      inputs:
-        command: 'build'
-        projects: '**/Playwright.TestAdapter.csproj'
-        arguments: '-c $(BuildConfiguration)'
-
-    - task: DotNetCoreCLI@2
-      displayName: Pack Playwright.TestAdapter NuGet
-      inputs:
-        command: 'pack'
-        packagesToPack: '**/Playwright.TestAdapter.csproj'
-        packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-        versioningScheme: 'off'
-
-    - task: PublishBuildArtifacts@1
-      displayName: Copy NuGet Artifacts to Build Results
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-        ArtifactName: 'drop'
-        publishLocation: 'Container'
-
-    - task: MicroBuildCleanup@1
-
-- stage: ReleasePlaywright
-  dependsOn: BuildPackageSign
-
-  jobs:
-  - job: ReleaseNuget
-    displayName: Publish on Nuget.org
-    condition: eq('${{parameters.doRelease}}', true)
-
-    steps:
-    - checkout: none
-    - task: DownloadBuildArtifacts@1
-      displayName: Download the NuGet Packages from Build System
-      inputs:
-        buildType: 'current'
-        downloadType: 'specific'
-        itemPattern: '**/Microsoft.Playwright.1.*'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-    - task: NuGetCommand@2
-      displayName: Push Playwright NuGet to NuGet.org
-      inputs:
-        command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NuGet-Playwright'
-
-- stage: ReleasePlaywrightCLI
-  dependsOn: BuildPackageSign
-
-  jobs:
-  - job: ReleaseNugetCLI
-    displayName: Publish CLI on Nuget.org
-    condition: eq('${{parameters.doReleaseCLI}}', true)
-
-    steps:
-    - checkout: none
-    - task: DownloadBuildArtifacts@1
-      displayName: Download the NuGet Packages from Build System
-      inputs:
-        buildType: 'current'
-        downloadType: 'specific'
-        itemPattern: '**/*.CLI.*'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-    - task: NuGetCommand@2
-      displayName: Push CLI NuGet to Nuget.org
-      inputs:
-        command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NuGet-Playwright'
-
-- stage: ReleasePlaywrightNUnit
-  dependsOn: BuildPackageSign
-
-  jobs:
-  - job: ReleaseNugetNUnit
-    displayName: Publish Playwright.NUnit on Nuget.org
-    condition: eq('${{parameters.doRelease}}', true)
-
-    steps:
-    - checkout: none
-    - task: DownloadBuildArtifacts@1
-      displayName: Download the NuGet Packages from Build System
-      inputs:
-        buildType: 'current'
-        downloadType: 'specific'
-        itemPattern: '**/*.NUnit.*'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-    - task: NuGetCommand@2
-      displayName: Push NUnit NuGet to Nuget.org
-      inputs:
-        command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NuGet-Playwright'
-
-- stage: ReleasePlaywrightMSTest
-  dependsOn: BuildPackageSign
-
-  jobs:
-  - job: ReleaseNugetMSTest
-    displayName: Publish Playwright.MSTest on Nuget.org
-    condition: eq('${{parameters.doRelease}}', true)
-
-    steps:
-    - checkout: none
-    - task: DownloadBuildArtifacts@1
-      displayName: Download the NuGet Packages from Build System
-      inputs:
-        buildType: 'current'
-        downloadType: 'specific'
-        itemPattern: '**/*.MSTest.*'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-    - task: NuGetCommand@2
-      displayName: Push MSTest NuGet to Nuget.org
-      inputs:
-        command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NuGet-Playwright'
-
-- stage: ReleasePlaywrightTestAdapter
-  dependsOn: BuildPackageSign
-
-  jobs:
-  - job: ReleaseNugetTestAdapter
-    displayName: Publish Playwright.TestAdapter on Nuget.org
-    condition: eq('${{parameters.doRelease}}', true)
-
-    steps:
-    - checkout: none
-    - task: DownloadBuildArtifacts@1
-      displayName: Download the NuGet Packages from Build System
-      inputs:
-        buildType: 'current'
-        downloadType: 'specific'
-        itemPattern: '**/*.TestAdapter.*'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-    - task: NuGetCommand@2
-      displayName: Push TestAdapter NuGet to Nuget.org
-      inputs:
-        command: 'push'
-        packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
-        nuGetFeedType: 'external'
-        publishFeedCredentials: 'NuGet-Playwright'
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+      os: windows
+    sdl:
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\.build\guardian\SDL\.gdnsuppress
+    stages:
+    - stage: BuildPackageSign
+      displayName: Build, Package & Sign
+      jobs:
+      - job: BuildPackage
+        displayName: Build & Package
+        steps:
+        - task: UseDotNet@2
+          displayName: 'Use .NET 8 SDK'
+          inputs:
+            packageType: sdk
+            version: 8.x
+        - task: MicroBuildSigningPlugin@3
+          inputs:
+            signType: '${{ parameters.signType }}'
+            feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+        # We need to download the driver first, so we can build
+        - task: DotNetCoreCLI@2
+          displayName: Download the driver
+          inputs:
+            command: 'run'
+            arguments: '--project $(Build.SourcesDirectory)/src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath $(Build.SourcesDirectory)'
+        - task: DotNetCoreCLI@2
+          displayName: Build Playwright CLI
+          inputs:
+            command: 'build'
+            projects: '**/Playwright.CLI.csproj'
+            arguments: '-c $(BuildConfiguration)'
+        - task: DotNetCoreCLI@2
+          displayName: Pack Playwright CLI
+          inputs:
+            command: 'pack'
+            packagesToPack: '**/Playwright.CLI.csproj'
+            packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+            versioningScheme: 'off'
+        - task: DotNetCoreCLI@2
+          displayName: Build Playwright
+          inputs:
+            command: 'build'
+            projects: '**/Playwright.csproj'
+            arguments: '-c $(BuildConfiguration)'
+        - task: DotNetCoreCLI@2
+          displayName: Pack Playwright NuGet
+          inputs:
+            command: 'pack'
+            packagesToPack: '**/Playwright.csproj'
+            packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+            versioningScheme: 'off'
+        - task: DotNetCoreCLI@2
+          displayName: Build Playwright.NUnit
+          inputs:
+            command: 'build'
+            projects: '**/Playwright.NUnit.csproj'
+            arguments: '-c $(BuildConfiguration)'
+        - task: DotNetCoreCLI@2
+          displayName: Pack Playwright.NUnit NuGet
+          inputs:
+            command: 'pack'
+            packagesToPack: '**/Playwright.NUnit.csproj'
+            packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+            versioningScheme: 'off'
+        - task: DotNetCoreCLI@2
+          displayName: Build Playwright.MSTest
+          inputs:
+            command: 'build'
+            projects: '**/Playwright.MSTest.csproj'
+            arguments: '-c $(BuildConfiguration)'
+        - task: DotNetCoreCLI@2
+          displayName: Pack Playwright.MSTest NuGet
+          inputs:
+            command: 'pack'
+            packagesToPack: '**/Playwright.MSTest.csproj'
+            packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+            versioningScheme: 'off'
+        - task: DotNetCoreCLI@2
+          displayName: Build Playwright.TestAdapter
+          inputs:
+            command: 'build'
+            projects: '**/Playwright.TestAdapter.csproj'
+            arguments: '-c $(BuildConfiguration)'
+        - task: DotNetCoreCLI@2
+          displayName: Pack Playwright.TestAdapter NuGet
+          inputs:
+            command: 'pack'
+            packagesToPack: '**/Playwright.TestAdapter.csproj'
+            packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+            versioningScheme: 'off'
+        - task: 1ES.PublishBuildArtifacts@1
+          displayName: Copy NuGet Artifacts to Build Results
+          inputs:
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+            ArtifactName: 'drop'
+        - task: MicroBuildCleanup@1
+    - stage: ReleasePlaywright
+      dependsOn: BuildPackageSign
+      jobs:
+      - job: ReleaseNuget
+        displayName: Publish on Nuget.org
+        condition: eq('${{parameters.doRelease}}', true)
+        steps:
+        - checkout: none
+        - task: DownloadBuildArtifacts@1
+          displayName: Download the NuGet Packages from Build System
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            itemPattern: '**/Microsoft.Playwright.1.*'
+            downloadPath: '$(System.ArtifactsDirectory)'
+        - task: 1ES.PublishNuget@1
+          displayName: Publish Nuget package
+          inputs:
+            useDotNetTask: false
+            packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            nuGetFeedType: external
+            publishFeedCredentials: 'NuGet-Playwright'
+    - stage: ReleasePlaywrightCLI
+      dependsOn: BuildPackageSign
+      jobs:
+      - job: ReleaseNugetCLI
+        displayName: Publish CLI on Nuget.org
+        condition: eq('${{parameters.doReleaseCLI}}', true)
+        steps:
+        - checkout: none
+        - task: DownloadBuildArtifacts@1
+          displayName: Download the NuGet Packages from Build System
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            itemPattern: '**/*.CLI.*'
+            downloadPath: '$(System.ArtifactsDirectory)'
+        - task: 1ES.PublishNuget@1
+          displayName: Publish Nuget package
+          inputs:
+            useDotNetTask: false
+            packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            nuGetFeedType: external
+            publishFeedCredentials: 'NuGet-Playwright'
+    - stage: ReleasePlaywrightNUnit
+      dependsOn: BuildPackageSign
+      jobs:
+      - job: ReleaseNugetNUnit
+        displayName: Publish Playwright.NUnit on Nuget.org
+        condition: eq('${{parameters.doRelease}}', true)
+        steps:
+        - checkout: none
+        - task: DownloadBuildArtifacts@1
+          displayName: Download the NuGet Packages from Build System
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            itemPattern: '**/*.NUnit.*'
+            downloadPath: '$(System.ArtifactsDirectory)'
+        - task: 1ES.PublishNuget@1
+          displayName: Publish Nuget package
+          inputs:
+            useDotNetTask: false
+            packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            nuGetFeedType: external
+            publishFeedCredentials: 'NuGet-Playwright'
+    - stage: ReleasePlaywrightMSTest
+      dependsOn: BuildPackageSign
+      jobs:
+      - job: ReleaseNugetMSTest
+        displayName: Publish Playwright.MSTest on Nuget.org
+        condition: eq('${{parameters.doRelease}}', true)
+        steps:
+        - checkout: none
+        - task: DownloadBuildArtifacts@1
+          displayName: Download the NuGet Packages from Build System
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            itemPattern: '**/*.MSTest.*'
+            downloadPath: '$(System.ArtifactsDirectory)'
+        - task: 1ES.PublishNuget@1
+          displayName: Publish Nuget package
+          inputs:
+            useDotNetTask: false
+            packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            nuGetFeedType: external
+            publishFeedCredentials: 'NuGet-Playwright'
+    - stage: ReleasePlaywrightTestAdapter
+      dependsOn: BuildPackageSign
+      jobs:
+      - job: ReleaseNugetTestAdapter
+        displayName: Publish Playwright.TestAdapter on Nuget.org
+        condition: eq('${{parameters.doRelease}}', true)
+        steps:
+        - checkout: none
+        - task: DownloadBuildArtifacts@1
+          displayName: Download the NuGet Packages from Build System
+          inputs:
+            buildType: 'current'
+            downloadType: 'specific'
+            itemPattern: '**/*.TestAdapter.*'
+            downloadPath: '$(System.ArtifactsDirectory)'
+        - task: 1ES.PublishNuget@1
+          displayName: Publish Nuget package
+          inputs:
+            useDotNetTask: false
+            packagesToPush: '$(System.ArtifactsDirectory)/**/*.nupkg'
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            nuGetFeedType: external
+            publishFeedCredentials: 'NuGet-Playwright'

--- a/.build/guardian/SDL/.gdnsuppress
+++ b/.build/guardian/SDL/.gdnsuppress
@@ -1,0 +1,895 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/suppressions",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "suppressionSets": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-02-07 19:36:07Z",
+      "lastUpdatedDate": "2024-02-07 19:36:07Z"
+    }
+  },
+  "results": {
+    "fee1a0108d741be1bf88ce4fb6ccc2e20c55785aeec546e0ea2720dc0da5f2e4": {
+      "signature": "fee1a0108d741be1bf88ce4fb6ccc2e20c55785aeec546e0ea2720dc0da5f2e4",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "cc67d8ea0f932c2bc0c38a936f19a0891308b47ae95a50488672bb01b8a20a17": {
+      "signature": "cc67d8ea0f932c2bc0c38a936f19a0891308b47ae95a50488672bb01b8a20a17",
+      "alternativeSignatures": [
+        "1f99540ad76960dcae391ad3cf075b66af188389031db7734d7b8a6a9000ebf8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "b16ae16427ddce10c10642ba834d335ba2c70cbd8f974accd95a416a6b011134": {
+      "signature": "b16ae16427ddce10c10642ba834d335ba2c70cbd8f974accd95a416a6b011134",
+      "alternativeSignatures": [
+        "d08840588e2e0b336adbfb985ea9e065a056f83048307f9dff1c29d952851363"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c92c2fecbbe8424cf889ee38148deaee9f0ba88e2d1641a5e38d62bdf0c34eec": {
+      "signature": "c92c2fecbbe8424cf889ee38148deaee9f0ba88e2d1641a5e38d62bdf0c34eec",
+      "alternativeSignatures": [
+        "61636c80eb212065fcbc1959f2dd868380285e34e2549700e896ebeadc1257be"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "0aa9390982f6e13c90e247c4868629d383f8da254b095b6ce44b6c5e5add1b68": {
+      "signature": "0aa9390982f6e13c90e247c4868629d383f8da254b095b6ce44b6c5e5add1b68",
+      "alternativeSignatures": [
+        "d5c6ac2c9a29069fe0c85547646acd3f023c6c5cde196be4374a78ab12c97578"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e96fac852c0f1222b2a11974d3026e7ed453e5715702093489291a93426ea1cc": {
+      "signature": "e96fac852c0f1222b2a11974d3026e7ed453e5715702093489291a93426ea1cc",
+      "alternativeSignatures": [
+        "d33433a20f955f1ae696af8d3f1193b90acf275b7a53370d037cbbc4b2f69ad5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a40d45ecfe9df39cda2f083a82d8e9a9361403e381000d95cdac7c12401dc071": {
+      "signature": "a40d45ecfe9df39cda2f083a82d8e9a9361403e381000d95cdac7c12401dc071",
+      "alternativeSignatures": [
+        "cda947681bda0a30b0c50a1653aeaecc09c5aa1abd612e5f0e1995a1fce58b57"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c5ed2e98ad08f82ceeb94f6db4b47841a96e1594a7ea6fe7a8b34bd4ce21f2c0": {
+      "signature": "c5ed2e98ad08f82ceeb94f6db4b47841a96e1594a7ea6fe7a8b34bd4ce21f2c0",
+      "alternativeSignatures": [
+        "b97cf8f7c2a6b9d7a0a7ff7cb61f9cd13bbc1e9e0dc110f7b64ed59806c474a7"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "934b17e736e03ab841b5e695d1fe4ab779f81d8b0172defaa04d0ec5fd9d1081": {
+      "signature": "934b17e736e03ab841b5e695d1fe4ab779f81d8b0172defaa04d0ec5fd9d1081",
+      "alternativeSignatures": [
+        "477c9d3a2073dabfab7059281e16f9779c88e1d33db963207ed6d79d0de2f1b5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "5b9a01fe50d69636058acac07a8d65b14ba626b9b7ccaafcd58a2fdd1bfbf0ca": {
+      "signature": "5b9a01fe50d69636058acac07a8d65b14ba626b9b7ccaafcd58a2fdd1bfbf0ca",
+      "alternativeSignatures": [
+        "ac29a86a141fbea28f8cacd2dfdc817c7dc0f58277b79635879ce8dfc81ab1e8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "55af7c34180ab95f5443f1bce7ffcc96cfc1688acfcdc0d4296cec40a4d48601": {
+      "signature": "55af7c34180ab95f5443f1bce7ffcc96cfc1688acfcdc0d4296cec40a4d48601",
+      "alternativeSignatures": [
+        "be010e7107ced8410d1258bf18dfad6eb32f8f5a28778b31084e62188111dd9f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "0d83de4508b520ae9c8c11f90bf246c1cd5ffba24c2bb903dd80a7e0df8cc844": {
+      "signature": "0d83de4508b520ae9c8c11f90bf246c1cd5ffba24c2bb903dd80a7e0df8cc844",
+      "alternativeSignatures": [
+        "6ae2791b4170001848aa5cf96b4426373db9cf924df166e30e3f4a8361f2561f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a21870d75ba42b1cdf5db069084f34bc9b5ac64771b42e7afe5ec1a613003a48": {
+      "signature": "a21870d75ba42b1cdf5db069084f34bc9b5ac64771b42e7afe5ec1a613003a48",
+      "alternativeSignatures": [
+        "8cd332046344b9aa51626604773d101b567467cdd8d0b698afd72295bc08de23"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e0b950f5e51a72e575de6eef137d6ecbca513e3add538aae33cf526597a839fc": {
+      "signature": "e0b950f5e51a72e575de6eef137d6ecbca513e3add538aae33cf526597a839fc",
+      "alternativeSignatures": [
+        "851ae4ea7f826a419068d24dcccf406e7154166eb02d04c335e0019bf642ae5b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c807565dc75342c8dbb2f94d61b76250418f11a212204af20057dd3290da2e3a": {
+      "signature": "c807565dc75342c8dbb2f94d61b76250418f11a212204af20057dd3290da2e3a",
+      "alternativeSignatures": [
+        "dd9a2d5fda9322bb43b3c9ebae665436775b95d891ac542d090431c6d2bf739c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "9d1228574cc6be593497287ea00cb2956832c691a2dc4f9c77c2c8e49062f024": {
+      "signature": "9d1228574cc6be593497287ea00cb2956832c691a2dc4f9c77c2c8e49062f024",
+      "alternativeSignatures": [
+        "61fc24c5399bfb632b149ad72289f8457569ecc05ee2ad6951b9840e2bff563a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c7b1cacf2eace5bdb7ed80340b7be7eebbc9b9e727dce613445d27ea8fbc0974": {
+      "signature": "c7b1cacf2eace5bdb7ed80340b7be7eebbc9b9e727dce613445d27ea8fbc0974",
+      "alternativeSignatures": [
+        "5ededcb1814c9674b2a4d0b05efe0eb7315c8aca5a2f9b818bc9ea33fd816061"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "6ffa88200c040f4b1912b6d5766f431647f7fd619d6f2ce72729390011e0cbd1": {
+      "signature": "6ffa88200c040f4b1912b6d5766f431647f7fd619d6f2ce72729390011e0cbd1",
+      "alternativeSignatures": [
+        "dfa6b17dd85c869224665e835be540937eee30abcc42dacf6f46c996e3dabc6d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "170415259e807a523edd358d75de53f1f8cf2b5ffd96ffe61ae12e8f18dbfc8a": {
+      "signature": "170415259e807a523edd358d75de53f1f8cf2b5ffd96ffe61ae12e8f18dbfc8a",
+      "alternativeSignatures": [
+        "0b0e8963ca2d4f20903c88f80fade223b926762979bbaffa91c12f6a765c0252"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "f528e128456e64064a4f67efc5595bdb148f62ca327c8141826b2ef151289a5e": {
+      "signature": "f528e128456e64064a4f67efc5595bdb148f62ca327c8141826b2ef151289a5e",
+      "alternativeSignatures": [
+        "d8fca15fc72a895a01832ef2047a3a9f058ec55d7192f7b5aa778ac64b0a9913"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "aeeca9f66b1cce53e94071354d2b465a19eac3a65804fd1e5fba390867267b5f": {
+      "signature": "aeeca9f66b1cce53e94071354d2b465a19eac3a65804fd1e5fba390867267b5f",
+      "alternativeSignatures": [
+        "c85206a6888bd50614b9918b04f07dc9686d89f1ef2231dd33a7695156a79b8f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "8590946433b753308a5446e3f5a6e8a37781b22972fd39771748edadd33991a9": {
+      "signature": "8590946433b753308a5446e3f5a6e8a37781b22972fd39771748edadd33991a9",
+      "alternativeSignatures": [
+        "59829e2979765de50bfb84cc4232beb5b8a2a9b73fc3088e37db972551e3ab85"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e97fe704b5ffc49fddd05eefff96478d4de0b3990cc60c68829d2a97231d5751": {
+      "signature": "e97fe704b5ffc49fddd05eefff96478d4de0b3990cc60c68829d2a97231d5751",
+      "alternativeSignatures": [
+        "b94a7f1e02cb777152a3a72db6d4d1accdc5d4f6abfb66ba9b6f13992bd76346"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "b1b69586f276afdb05345ef702ef85571b2ac895bb9ca0da04779296f5a34654": {
+      "signature": "b1b69586f276afdb05345ef702ef85571b2ac895bb9ca0da04779296f5a34654",
+      "alternativeSignatures": [
+        "62aa0f8e92d643dc2a3cd1c9de522b34d9899449dba8149e5663714a677ba83e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "9ce6eb4d0b0a8e7a973b0a2b0b460ce33548d5b0fc65e975f92e65f6e305e856": {
+      "signature": "9ce6eb4d0b0a8e7a973b0a2b0b460ce33548d5b0fc65e975f92e65f6e305e856",
+      "alternativeSignatures": [
+        "8daa70c0af206eba8ee9389d252ea740f6f3b1f49a44cc744f5fb61e8360a9ee"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "fcf792def105ab3b2776a9988cf045a086d6d0c34de7685b1732d98d526e5012": {
+      "signature": "fcf792def105ab3b2776a9988cf045a086d6d0c34de7685b1732d98d526e5012",
+      "alternativeSignatures": [
+        "269d333d1c00e48689e67ec9bcf07131942546c77c50ffb65db3edc5ce4aed52"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "147e771a0ba15d9ecae548a62260c926fd7b5bd48faed672b2d019f33fce2163": {
+      "signature": "147e771a0ba15d9ecae548a62260c926fd7b5bd48faed672b2d019f33fce2163",
+      "alternativeSignatures": [
+        "33dc2044a3275f6bf9a91b6eefcc006e6a93f1260ac852329d567ada344f954f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e929ce06627e413b643e58b35387b66ab9685eada8b4adffd9372855ee44b6a5": {
+      "signature": "e929ce06627e413b643e58b35387b66ab9685eada8b4adffd9372855ee44b6a5",
+      "alternativeSignatures": [
+        "6d5beafa486df6dc98b2bfa2ae2e4ee99b30bb515286fd9b6e40e421994360dc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "9c12723b97fba9db3ae8787c7ae9c2160e7be3f44941c4f81d7a41bc22c27cda": {
+      "signature": "9c12723b97fba9db3ae8787c7ae9c2160e7be3f44941c4f81d7a41bc22c27cda",
+      "alternativeSignatures": [
+        "2b5d87d5016cfa495649c43e58ee2a9db41c10568722f56672267c804aaa1734"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "9020e0777f1b170b71e1fb68c0e90cafd861af7450476dfaca197135a8ba7055": {
+      "signature": "9020e0777f1b170b71e1fb68c0e90cafd861af7450476dfaca197135a8ba7055",
+      "alternativeSignatures": [
+        "1ed36130b6bec1701296b09aa2e4f1ae6071ebe7e0b758d596a02f5b42a9b00b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "192dceea098b1b4a3d6a5efa4b67f0366f2543b43a0b7a3a121cb6f8e27d03c2": {
+      "signature": "192dceea098b1b4a3d6a5efa4b67f0366f2543b43a0b7a3a121cb6f8e27d03c2",
+      "alternativeSignatures": [
+        "1c0295c00734b2d582cd98e7b39e27029fb7110c244b6ae741e5a133c3d0d3dc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "5d8aa09e54b7fec78dff1b46a460c753f7a82b6b294126fab1555b891add884a": {
+      "signature": "5d8aa09e54b7fec78dff1b46a460c753f7a82b6b294126fab1555b891add884a",
+      "alternativeSignatures": [
+        "8f20081acb75fc24117b4d084e4f6620465dda738a77f92ed4bc94666573b9d2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "0f6e4c7cb049f771c01b088e741e7e6ba8a7b3ab3494847f3ad4c24c6db17205": {
+      "signature": "0f6e4c7cb049f771c01b088e741e7e6ba8a7b3ab3494847f3ad4c24c6db17205",
+      "alternativeSignatures": [
+        "1dc4d848a823316b295e8dc5eb86c18206a57431d42327a885186b857ab658ce"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "24ec69e4c9c2c1240fa87894fcf3fa3fa512532add73a4aa44b3cd54e6045cd6": {
+      "signature": "24ec69e4c9c2c1240fa87894fcf3fa3fa512532add73a4aa44b3cd54e6045cd6",
+      "alternativeSignatures": [
+        "5e9041a94a1519e0c5fd83e4d74280886a6de5c3e8b7238d66dbf5a57a560c48"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e9492b91cf0be85b4bf00ffcb162633f461693517fb7cd7d43bff6087eb57f3b": {
+      "signature": "e9492b91cf0be85b4bf00ffcb162633f461693517fb7cd7d43bff6087eb57f3b",
+      "alternativeSignatures": [
+        "df95969ef1eb607aee940b5309f6202949191678d59fc720bfd39a878087f9f0"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "af7a5334909d348a44510ce06cb058796f01b9ddb87b8c8d8cc78c12ade153dd": {
+      "signature": "af7a5334909d348a44510ce06cb058796f01b9ddb87b8c8d8cc78c12ade153dd",
+      "alternativeSignatures": [
+        "1aaabe9e8cbaa470ac041ccce0e326fa15457886df913cae13c4e66518e4a5c2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "28caabe8be1b9abb443a8fdc12f8da4da6e1e6e5178725738434898b6d02f9c6": {
+      "signature": "28caabe8be1b9abb443a8fdc12f8da4da6e1e6e5178725738434898b6d02f9c6",
+      "alternativeSignatures": [
+        "bb5f322e1bf2f7df43530e3ce2120bc48a93fa6f0fb6d66903e846ebc63bad0c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "b61b73a92a8ed34d9cb25de7c00054481b2d6e369d715d426df638d5da18d666": {
+      "signature": "b61b73a92a8ed34d9cb25de7c00054481b2d6e369d715d426df638d5da18d666",
+      "alternativeSignatures": [
+        "490c9569a802efe2980f701a8439fe8acd835cb58da182bc55de7ecf8283c3f2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "3349109e1617fc8bfb8e8baef0beedb4e1a084c705a1707115e38f47e0566c97": {
+      "signature": "3349109e1617fc8bfb8e8baef0beedb4e1a084c705a1707115e38f47e0566c97",
+      "alternativeSignatures": [
+        "0e71717307d996956c91a6d18707cd4be00037ef94e33a38feb1fabdb1b1c9a8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "2e2d625d4d86c1f356edaf30947ea445c79e6e1af6bce1dfd56c99cb07a6e5c9": {
+      "signature": "2e2d625d4d86c1f356edaf30947ea445c79e6e1af6bce1dfd56c99cb07a6e5c9",
+      "alternativeSignatures": [
+        "c4b5d60a2b0588c1a0ab40254625b722c0711a91a7a35e2bd2120681dc6ac71c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c25919e3ba83e196c612f9303eddadffdd1ad6c593375205184b7f5f63119a9a": {
+      "signature": "c25919e3ba83e196c612f9303eddadffdd1ad6c593375205184b7f5f63119a9a",
+      "alternativeSignatures": [
+        "6b0bb598436b89160a77a2f1efe4ce8b84a1d8003bf0e752363c723a53e91c4f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "6e88df958b0e44b361539417e90818b77cc442a4acd6631f9c3271fcf9bf5a6d": {
+      "signature": "6e88df958b0e44b361539417e90818b77cc442a4acd6631f9c3271fcf9bf5a6d",
+      "alternativeSignatures": [
+        "2fb0b321cd1d9e1dd0a5ef4eb24adc851ef02f58270bbddecd2aa522a48099fe"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "c25ef9d2feb451b2a98c2695fe41ef325c0821cf1348ae415dede185a0f43fed": {
+      "signature": "c25ef9d2feb451b2a98c2695fe41ef325c0821cf1348ae415dede185a0f43fed",
+      "alternativeSignatures": [
+        "3210d7796bc8dfa9315b27a75d849b3d7c6c9abc302a53ff267a469dbd4666d5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a4f71b11fbe875e682d703b8e6c7de139c878d7fc7de7027540677ce484adba9": {
+      "signature": "a4f71b11fbe875e682d703b8e6c7de139c878d7fc7de7027540677ce484adba9",
+      "alternativeSignatures": [
+        "c8515841f3d8688284734ac1b6bf8e043c515fbeb929f1ffb4ba7ee76390d52c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "2303d2b51024e8a885c6f1b52da18c6da10cc7b46da238e8da39d1c899649995": {
+      "signature": "2303d2b51024e8a885c6f1b52da18c6da10cc7b46da238e8da39d1c899649995",
+      "alternativeSignatures": [
+        "c57697c94227fca1dabc2167f3f10ef40679854df2ad9811dc19cd80fcd968f8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "04b443147bb75a47c48219a8707e83366a6f10c83fbc57245f4e8b3823c8a8f0": {
+      "signature": "04b443147bb75a47c48219a8707e83366a6f10c83fbc57245f4e8b3823c8a8f0",
+      "alternativeSignatures": [
+        "ee18aba6eabcc43dba4e0bdca550b2775d85d6da6565352c965ac489ce521221"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "1b13fbedbeb1aafa834c6c6b732b410b0ff4b2c5809d9a1a73044ff9ee178b4f": {
+      "signature": "1b13fbedbeb1aafa834c6c6b732b410b0ff4b2c5809d9a1a73044ff9ee178b4f",
+      "alternativeSignatures": [
+        "3fa680b126fa5ae5dd236128cfb3a29f4f59e47da01bf1af3909fb41cea9a5af"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a13e5572ca7c07380f0059009271bbf3938207edf070113cd6a6e15be439cd7d": {
+      "signature": "a13e5572ca7c07380f0059009271bbf3938207edf070113cd6a6e15be439cd7d",
+      "alternativeSignatures": [
+        "49ee4a10c871174579fdb62c8ab1a4045ecd6b09f1dac8e79ebc4bb3bdb78e9b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "87ec4d0340216304379719b8c514a363c918d67f4c2bb81c2a8bcff92568f953": {
+      "signature": "87ec4d0340216304379719b8c514a363c918d67f4c2bb81c2a8bcff92568f953",
+      "alternativeSignatures": [
+        "91a88ed091175709b9f5e625d7193874f00262b97cc889b2ad68670ae81f627b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "66bab427e78237beacd5430b03394b474a91892b1f8648d6e80607a0b6edd93a": {
+      "signature": "66bab427e78237beacd5430b03394b474a91892b1f8648d6e80607a0b6edd93a",
+      "alternativeSignatures": [
+        "54ca41c87f3b48018de615c877fb0437509147b23ce012758b966607308f1f65"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "77408142be32c92921fe1db214ac0ea7c91c251ca2bc92ab0161d95cff5be942": {
+      "signature": "77408142be32c92921fe1db214ac0ea7c91c251ca2bc92ab0161d95cff5be942",
+      "alternativeSignatures": [
+        "00a9e2e90dfe3d1dc377832626942334d26747d4e549f0f4abe31f602a61df06"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "33bd0a9062e1843ca07a7d4a2112119346e0edf56cc0cd92c6c6ccb45e815b73": {
+      "signature": "33bd0a9062e1843ca07a7d4a2112119346e0edf56cc0cd92c6c6ccb45e815b73",
+      "alternativeSignatures": [
+        "5feae7e9b66eb42fd192588626ba85a8896038256adda8141c9e84e57917fcc2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "8a3f8ec68d43dccb570f448c51f05797ef897eab56564e34ebf0a1ab2efd0094": {
+      "signature": "8a3f8ec68d43dccb570f448c51f05797ef897eab56564e34ebf0a1ab2efd0094",
+      "alternativeSignatures": [
+        "005c40180e2bfa12f26abb0dc09134a841fed2c78e59642d95493274aa80b6a9"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a0ab6a347ec0e6dca9fca1cf70eb5c83c4a568ed88cc3a74bbd251511e740d89": {
+      "signature": "a0ab6a347ec0e6dca9fca1cf70eb5c83c4a568ed88cc3a74bbd251511e740d89",
+      "alternativeSignatures": [
+        "6ed542f9bf959a08cb858929ec2aaed3de6d264e1102a4ab4bd42ce0dd63621a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "ff7c0288004f8d46a2283e61ad3883620c21aaccc85b822d8cf8a6421fcc4e9f": {
+      "signature": "ff7c0288004f8d46a2283e61ad3883620c21aaccc85b822d8cf8a6421fcc4e9f",
+      "alternativeSignatures": [
+        "0c02ddbaddc8484114cd4b4b605167d242828f2e1dea923122d5f8ccc7477449"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "04d3964967f7a903b523a74dcbca271bb1a785a9dd0e56ea05c8a223e1802223": {
+      "signature": "04d3964967f7a903b523a74dcbca271bb1a785a9dd0e56ea05c8a223e1802223",
+      "alternativeSignatures": [
+        "b1ca095482ef4acc7858baefe6df9d8c7a486779d4e928e74ddaeda6a6e299d5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "2eebf7b417391d1d8df56663ed26377367e33f8b3c5ee8f0d5c108396bdd2bdc": {
+      "signature": "2eebf7b417391d1d8df56663ed26377367e33f8b3c5ee8f0d5c108396bdd2bdc",
+      "alternativeSignatures": [
+        "f67cc1f1ca4c9946f7806e407c88d8ac441ab00491c2ee97b5a0049d77e2f3a3"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "f26413f4ea4d05aca4f5e01089c420d2d742a94986490f6bdbfa7e9488f5bdaf": {
+      "signature": "f26413f4ea4d05aca4f5e01089c420d2d742a94986490f6bdbfa7e9488f5bdaf",
+      "alternativeSignatures": [
+        "6d506884db0c702280912366a43a653879266187dc6e3859f7ad5bda4ecea42c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "3273d137c1d3cd3479583e1a391403b579ed03a9403a3cc0c1efc90d2931a2da": {
+      "signature": "3273d137c1d3cd3479583e1a391403b579ed03a9403a3cc0c1efc90d2931a2da",
+      "alternativeSignatures": [
+        "43866cc28db34fb9a2026f8f21a830eaf7f36a855f693ab399a8f8e166162c5b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "cd2744092fb6103331a854c569f364275bb1b990afa5d2f6ac87a8a9f31013e4": {
+      "signature": "cd2744092fb6103331a854c569f364275bb1b990afa5d2f6ac87a8a9f31013e4",
+      "alternativeSignatures": [
+        "c0bc3f040a170c800eb9f136f871a02e770570fd114e23513ef7811b30607c98"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "0c2bef2ef4798b3f38e399bd9fac6457e29b27ca7042405ed510e9ea093be9a4": {
+      "signature": "0c2bef2ef4798b3f38e399bd9fac6457e29b27ca7042405ed510e9ea093be9a4",
+      "alternativeSignatures": [
+        "fc6af104cb0e049e76fe32efb3a0e149a28127c52c6d3ae5e5a037cac8b2ba30"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "76d457b4bdac53e38a04d973270dc264f58191e937a30b010e44f474483c1d53": {
+      "signature": "76d457b4bdac53e38a04d973270dc264f58191e937a30b010e44f474483c1d53",
+      "alternativeSignatures": [
+        "03360931ffd9ea64d28f899993980c3b286df685a830f8522057fc5797d9fb15"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "de1721c0df2c158412164716e7beeb1c8a3b7179bccfecd7bead653536e2cb8f": {
+      "signature": "de1721c0df2c158412164716e7beeb1c8a3b7179bccfecd7bead653536e2cb8f",
+      "alternativeSignatures": [
+        "f54e22ab42d06d77a140d8ca07fa1d3049ff5f93d034b05c66b2dd1e64b7e6fa"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "b84f735d5f87c98d73a2e47c6cc779ef206438482899edbbb07e10570298320c": {
+      "signature": "b84f735d5f87c98d73a2e47c6cc779ef206438482899edbbb07e10570298320c",
+      "alternativeSignatures": [
+        "889a3df901ddcaba823099055c009773d3d20d6a888ca2809204a74cc11f0b94"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "2222123253a5d97ed9c45173f9a14fde014ffb4a9a1446e12a270f9b1ec10ad6": {
+      "signature": "2222123253a5d97ed9c45173f9a14fde014ffb4a9a1446e12a270f9b1ec10ad6",
+      "alternativeSignatures": [
+        "cbfdd60c24534ad62fe8565e2349014613cce6b7a647e7983a370824832cf7ce"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e09ee8f6a91bb2ddd812a263b93bdd3b4dee0f879bf75bde2829bc941c344156": {
+      "signature": "e09ee8f6a91bb2ddd812a263b93bdd3b4dee0f879bf75bde2829bc941c344156",
+      "alternativeSignatures": [
+        "69023c63d0e6a9bcfa5705096dcf5cbeeb5b47eefc40699512d3121d62f5b84c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "cfc637e1090209db60be124bb79af235d1665b98c53edc08386e28d8fba6967d": {
+      "signature": "cfc637e1090209db60be124bb79af235d1665b98c53edc08386e28d8fba6967d",
+      "alternativeSignatures": [
+        "503ab42a956e4a9963d9b9579a8e33d6017903f7d68b02b9dba5213359df486c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "02aeed49d15d0a876f7ecf83467f649eddc49e176b3df7758acd791e61b98e7a": {
+      "signature": "02aeed49d15d0a876f7ecf83467f649eddc49e176b3df7758acd791e61b98e7a",
+      "alternativeSignatures": [
+        "6f175efb6ef23f4ef5362b9607a034a300958b808a81d62adbcd15f084e54cfe"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "b6a32ea9589398c9fb828f0c71962615e9841916d78913e28d5a86a62133bec6": {
+      "signature": "b6a32ea9589398c9fb828f0c71962615e9841916d78913e28d5a86a62133bec6",
+      "alternativeSignatures": [
+        "4a76d9004326a8817f02fbad17365cbf55ed5c0649eae7f06b2e19e0bc89fa4c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e686cae4637e634069d4384bb0b4445d6d2194c433ab2a0e5e7612ebe9eed04a": {
+      "signature": "e686cae4637e634069d4384bb0b4445d6d2194c433ab2a0e5e7612ebe9eed04a",
+      "alternativeSignatures": [
+        "88a02bb51e96b74f92230bfdab0a2a3b85958f1f5d0a62140fb0b26568f71acc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "0558e510c100c125883242413b62bb4aff65bc53e7e7be6e811733423028cfe2": {
+      "signature": "0558e510c100c125883242413b62bb4aff65bc53e7e7be6e811733423028cfe2",
+      "alternativeSignatures": [
+        "3ec0a11add4e45b3270007bbf57c219383cd7f60d1cddbf703b5cd4334cfbc8b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "f0b1964d41b0d6a9fc384a440a50ca0ba64868ff6329715a365793d11cbeeafd": {
+      "signature": "f0b1964d41b0d6a9fc384a440a50ca0ba64868ff6329715a365793d11cbeeafd",
+      "alternativeSignatures": [
+        "bb09cc565dae60c403b01333907ee95e1d3e0a15d656f11eee1c60749064e66d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "6bc19f0fbcedb2bc90fef458a460c38aa87a5762b8474b43a5750e216c6a84b8": {
+      "signature": "6bc19f0fbcedb2bc90fef458a460c38aa87a5762b8474b43a5750e216c6a84b8",
+      "alternativeSignatures": [
+        "3c36b2c0fde3409b1933b789f4fb27c78a1592c7ee9754c9ce4e77362392a30d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "de833107519f633bff58d59c4bd904d2cea7ef1783621ff594579bf1ab4939c8": {
+      "signature": "de833107519f633bff58d59c4bd904d2cea7ef1783621ff594579bf1ab4939c8",
+      "alternativeSignatures": [
+        "d3ffadc1fd751ca46bd7d6ffc12fe6d240a78a35e2b15648d4da5c4eb3d54778"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "03cbadec21255e92a1b440abb76507a9b2720ab7ef62a7c15cf0a2b5e6eb6cd6": {
+      "signature": "03cbadec21255e92a1b440abb76507a9b2720ab7ef62a7c15cf0a2b5e6eb6cd6",
+      "alternativeSignatures": [
+        "939cc85e10ced68302f50e88113dd3fb4db1a1154c347d730f9e6e2e68fcb5c1"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "e032513b0ec53e2d2ce785b96bb2591b7026f023ed9cb2c50634b07b4033e164": {
+      "signature": "e032513b0ec53e2d2ce785b96bb2591b7026f023ed9cb2c50634b07b4033e164",
+      "alternativeSignatures": [
+        "2ecb463419a31b54a7a56f1b3a13b8a9117217cc0176f474d5669627d36e0c29"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "5c8188f0b0fdfdb9dd77ef394599cc5210076e4f3c33f2307bf5366a12401a4a": {
+      "signature": "5c8188f0b0fdfdb9dd77ef394599cc5210076e4f3c33f2307bf5366a12401a4a",
+      "alternativeSignatures": [
+        "c78cc44fc5f409e0b0a6469cace883284051592dddd13a3f0925878739892f73"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "96e7389c8a44fa39b49d55fffa56748c7a4de07d24623452ecbb2fdf68f30a10": {
+      "signature": "96e7389c8a44fa39b49d55fffa56748c7a4de07d24623452ecbb2fdf68f30a10",
+      "alternativeSignatures": [
+        "323e3a3037ac831487b3c89f1baf39db6a404eb1ca5948b18b0cd0b8894c54d0"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "d918705447b7a5629cb41509b035afbc7af46415f6087609ce3d64a07b170ef5": {
+      "signature": "d918705447b7a5629cb41509b035afbc7af46415f6087609ce3d64a07b170ef5",
+      "alternativeSignatures": [
+        "c04aeacfd7b14f855b1065c4c88a9bc3c888515e62ef7e4f877a2eeaa10ee8e5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "3499e7ebebe159777723f6d14baf6bead733f89b0c3454addfd7d03ce7353d3a": {
+      "signature": "3499e7ebebe159777723f6d14baf6bead733f89b0c3454addfd7d03ce7353d3a",
+      "alternativeSignatures": [
+        "1d0182b1080018a978c2da0f48477cd5ed771b2df0437a5fb123727b7ae72f12"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "df70d4fd3cdfe58a91e31b52830cd7c71d55eab89c94c80190bc3625a2a410d7": {
+      "signature": "df70d4fd3cdfe58a91e31b52830cd7c71d55eab89c94c80190bc3625a2a410d7",
+      "alternativeSignatures": [
+        "753d666455cfeabba891d42e6d54c97986c0dd55bef7716a6db8721f369a1a1a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "82c2c598229b050a7ae0482f16cf4a1d4dbefdae04a91b79188c769690e4ec1b": {
+      "signature": "82c2c598229b050a7ae0482f16cf4a1d4dbefdae04a91b79188c769690e4ec1b",
+      "alternativeSignatures": [
+        "01de35a93805de1c7c102483e5f79cbeea4c9ca7c5e34b305cf1a0254bc07c07"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "19ca8d6b9fd84fd64dc6388410cc60591d820421b6d482dc34b5d956f8f54b57": {
+      "signature": "19ca8d6b9fd84fd64dc6388410cc60591d820421b6d482dc34b5d956f8f54b57",
+      "alternativeSignatures": [
+        "f562cbb04046629ff778bf6fb810169bfa8b3b706ed768e9880d6608fffc242d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "07d66bcecc46efee44e81bae90f64cd4f40cb103355ed7866f817df427a8af32": {
+      "signature": "07d66bcecc46efee44e81bae90f64cd4f40cb103355ed7866f817df427a8af32",
+      "alternativeSignatures": [
+        "9496dfe246514ab3cb781bc3e202210bbf021301828b60ff35b485a347387337"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "dd0afcbc32d3668ad288c694bd64fb8b902af465d6bcce5d7e807c61c66b8d79": {
+      "signature": "dd0afcbc32d3668ad288c694bd64fb8b902af465d6bcce5d7e807c61c66b8d79",
+      "alternativeSignatures": [
+        "13688e518f30268e0d3fda60e36ca2fd403f7174e15ef99082d5143ba3997299"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "a4576abf92765857a68534d9c9f1e6f22d95f38474c9c06aae0528374cfdca1f": {
+      "signature": "a4576abf92765857a68534d9c9f1e6f22d95f38474c9c06aae0528374cfdca1f",
+      "alternativeSignatures": [
+        "2c6ec879f808643419cf64c45b2612d4816e71e148e128c4a8433cc70b69138c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "58629c3111da2e63aed5774cab0d0688a552c38048a576f1e55e4253833b5160": {
+      "signature": "58629c3111da2e63aed5774cab0d0688a552c38048a576f1e55e4253833b5160",
+      "alternativeSignatures": [
+        "63e2f7a6f1cfca168377c2ff8bbce9103bf4e59d265a3b586da0a4e0dba415e7"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    },
+    "4fed6db9f7619f6b7c71f0b7c7eee4748eb031fa58181da83724cea2eb2ded2f": {
+      "signature": "4fed6db9f7619f6b7c71f0b7c7eee4748eb031fa58181da83724cea2eb2ded2f",
+      "alternativeSignatures": [
+        "c4d5e91d06cdcd1a9aca957e87fc56ff63a04b4f9ef39d168f1afb5e7e71dfda"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-02-07 19:36:07Z"
+    }
+  }
+}

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.41.0</AssemblyVersion>
-    <PackageVersion>$(AssemblyVersion)</PackageVersion>
+    <AssemblyVersion>1.42.0</AssemblyVersion>
+    <PackageVersion>$(AssemblyVersion)-beta-1</PackageVersion>
     <DriverVersion>1.41.0</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>


### PR DESCRIPTION
See here: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1385/Suppressions

The `.gdnsuppress` file got obtained during a previous test-run where it was in the artifacts section of the SDL stage. They are like `.eslintignore`, but instead of the file location, they contain the location, type, reason etc. in a hashed form, for security reasons.

When to update? When SDL checks are red in Azure Pipelines.
How to update? See the link, based on the artifact it can be just downloaded / replaced.

---

How is it tested? 1.42.0-beta-1 is published.