### PR TITLE
fix: restrict access to _activeInvocations in concurrent RouteHandler methods …

### DIFF
--- a/src/Playwright.Tests/BrowserContextRouteTests.cs
+++ b/src/Playwright.Tests/BrowserContextRouteTests.cs
@@ -212,11 +212,6 @@ public class BrowserContextRouteTests : BrowserTestEx
         // let the test run for 5 second
         await Task.Delay(5000);
 
-        // trigger garbage collection which checks for unorbserved exceptions
-        // in collected tasks
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-
         // unobserved task exceptions are automatically collected by the PlaywrightTest attribute
     }
 

--- a/src/Playwright.Tests/BrowserContextRouteTests.cs
+++ b/src/Playwright.Tests/BrowserContextRouteTests.cs
@@ -177,6 +177,65 @@ public class BrowserContextRouteTests : BrowserTestEx
         Assert.AreEqual("context", await response.TextAsync());
     }
 
+
+    [PlaywrightTest("browsercontext-route.spec.ts", "should not throw on concurrent requests")]
+    public async Task ShouldNotThrowOnConcurrentRequest()
+    {
+        await using var context = await Browser.NewContextAsync();
+
+        // provide an html page which performs a high load of requests
+        await context.RouteAsync("**/empty.html", async (route) =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = (int)HttpStatusCode.OK,
+                Body = @"<script>document.addEventListener('DOMContentLoaded', async () => { while (true) { await fetch('test.json') }})</script>"
+            });
+        });
+
+        // provide a simple json to fulfill the requests
+        await context.RouteAsync("**/test.json", async (route) =>
+        {
+            await route.FulfillAsync(new()
+            {
+                Status = (int)HttpStatusCode.OK,
+                Body = @"[]"
+            });
+        });
+
+
+        // subscribe for unobserved exceptions since we can not catch the exception
+        // in RouteHandler.cs directly
+        Exception? unobservedException = null;
+        void _handleUnobservedException(object sender, UnobservedTaskExceptionEventArgs args)
+            => unobservedException = args.Exception;
+
+        try
+        {
+            TaskScheduler.UnobservedTaskException += _handleUnobservedException;
+
+            // open 10 pages to generate load on the RouteHandler
+            foreach (int pageNr in Enumerable.Range(0, 10))
+                await (await context.NewPageAsync())
+                    .GotoAsync(Server.EmptyPage);
+
+            // let the test run for 5 second
+            await Task.Delay(5000);
+
+            // trigger garbage collection which checks for unorbserved exceptions
+            // in collected tasks
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            // check for exceptions
+            Assert.Null(unobservedException);
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= _handleUnobservedException;
+        }
+    }
+
     [PlaywrightTest("browsercontext-route.spec.ts", "should support the times parameter with route matching")]
     public async Task ShouldSupportTheTimesParameterWithRouteMatching()
     {


### PR DESCRIPTION
… because HashSet is not thread-safe

Access to RouteHandle._activeInvocations must be controlled using a lock. Otherwise IndexOutOfBounds exceptions or InvalidOperation exceptions may be triggered during concurrent requests. HashSet is not thread safe.

A test "ShouldNotThrowOnConcurrentRequest" is added which reproduces the issue by having 10 pages requesting a http resource at high load for 5 seconds. 