### PR TITLE
fix(CreateAsync): try/catch restoring of Input/Output Encoding

### DIFF
--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -171,9 +171,17 @@ internal class StdIOTransport : IDisposable
         {
             if (hasConsole)
             {
-                // Restore the original encodings
-                Console.InputEncoding = originalInputEncoding;
-                Console.OutputEncoding = originalOutputEncoding;
+                try
+                {
+                    // Restore the original encodings
+                    Console.InputEncoding = originalInputEncoding;
+                    Console.OutputEncoding = originalOutputEncoding;
+                }
+                catch (System.Exception)
+                {
+                    // It can fail under some conditions:
+                    // https://github.com/microsoft/playwright-dotnet/issues/2888
+                }
             }
         }
     }


### PR DESCRIPTION
See https://github.com/microsoft/playwright-dotnet/issues/2888#issuecomment-2032027194

Fixes https://github.com/microsoft/playwright-dotnet/issues/2888