### PR TITLE
fix(cdpSession): events without payload

### DIFF
--- a/src/Playwright/Core/CDPSession.cs
+++ b/src/Playwright/Core/CDPSession.cs
@@ -45,7 +45,8 @@ internal class CDPSession : ChannelOwner, ICDPSession
         switch (method)
         {
             case "event":
-                OnCDPEvent(serverParams!.Value.GetProperty("method").ToString(), serverParams.Value.GetProperty("params"));
+                serverParams!.Value.TryGetProperty("params", out var cdpParams);
+                OnCDPEvent(serverParams!.Value.GetProperty("method").ToString(), cdpParams);
                 break;
         }
     }

--- a/src/Playwright/Core/CDPSession.cs
+++ b/src/Playwright/Core/CDPSession.cs
@@ -45,8 +45,9 @@ internal class CDPSession : ChannelOwner, ICDPSession
         switch (method)
         {
             case "event":
-                serverParams!.Value.TryGetProperty("params", out var cdpParams);
-                OnCDPEvent(serverParams!.Value.GetProperty("method").ToString(), cdpParams);
+                OnCDPEvent(
+                    serverParams!.Value.GetProperty("method").ToString(),
+                    serverParams!.Value.TryGetProperty("params", out var cdpParams) ? cdpParams : null);
                 break;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright-dotnet/issues/2912

Aligns it with JavaScript: https://github.com/microsoft/playwright/blob/82aefd24db1ba9977c3f6953347ee266845790ea/packages/playwright-core/src/client/cdpSession.ts#L31

And with Python: https://github.com/microsoft/playwright-python/pull/2411

And with Java: https://github.com/microsoft/playwright-java/pull/1553