### PR TITLE
chore: make SetDefaultExpectTimeout static

### DIFF
--- a/src/Playwright.MSTest/PlaywrightTest.cs
+++ b/src/Playwright.MSTest/PlaywrightTest.cs
@@ -124,7 +124,7 @@ public class PlaywrightTest
 
     public TestContext TestContext { get; set; } = null!;
 
-    public void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
+    public static void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
 
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
 

--- a/src/Playwright.NUnit/PlaywrightTest.cs
+++ b/src/Playwright.NUnit/PlaywrightTest.cs
@@ -46,7 +46,7 @@ public class PlaywrightTest : WorkerAwareTest
         Playwright.Selectors.SetTestIdAttribute("data-testid");
     }
 
-    public void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
+    public static void SetDefaultExpectTimeout(float timeout) => Assertions.SetDefaultExpectTimeout(timeout);
 
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
 


### PR DESCRIPTION
Semantically its a breaking change, but since csharp does allow calling static methods like instance methods, it seems fine?

Looking e.g. at this test:

https://github.com/microsoft/playwright-dotnet/blob/c4b3dc42df71596240e9bc91068a5623ef72e14d/src/Playwright.Tests/Assertions/LocatorAssertionsTests.cs#L50-L64

Alternatively we can specify both methods (static and non-static version).

Fixes https://github.com/microsoft/playwright-dotnet/issues/2957