### PR TITLE
chore: dispose APIRequestContext on BrowserContext close

### DIFF
--- a/src/Playwright.Tests/BrowserContextFetchTests.cs
+++ b/src/Playwright.Tests/BrowserContextFetchTests.cs
@@ -884,6 +884,14 @@ public class BrowserContextFetchTests : PageTestEx
         Assert.AreEqual(200, response.Status);
     }
 
+    [PlaywrightTest("browsercontext-fetch.spec.ts", "should not work after context dispose")]
+    public async Task ShouldNotWorkAfterContextDispose()
+    {
+        await Context.CloseAsync(new() { Reason = "Test ended." });
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Context.APIRequest.GetAsync(Server.EmptyPage));
+        StringAssert.Contains("Test ended.", exception.Message);
+    }
+
     private async Task ForAllMethods(IAPIRequestContext request, Func<Task<IAPIResponse>, Task> callback, string url, APIRequestContextOptions options = null)
     {
         var methodsToTest = new[] { "fetch", "delete", "get", "head", "patch", "post", "put" };

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -46,7 +46,7 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     private readonly Tracing _tracing;
     private readonly Clock _clock;
     internal readonly HashSet<IPage> _backgroundPages = new();
-    internal readonly IAPIRequestContext _request;
+    internal readonly APIRequestContext _request;
     private readonly Dictionary<string, HarRecorder> _harRecorders = new();
     internal readonly List<IWorker> _serviceWorkers = new();
     private List<RouteHandler> _routes = new();
@@ -320,6 +320,12 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
         }
         _closeReason = options?.Reason;
         CloseWasCalled = true;
+        await WrapApiCallAsync(
+            async () =>
+        {
+            await _request.DisposeAsync(options?.Reason).ConfigureAwait(false);
+        },
+            true).ConfigureAwait(false);
         await WrapApiCallAsync(
             async () =>
         {


### PR DESCRIPTION
This ports the missing two patches:

- https://github.com/microsoft/playwright/commit/776b04e5ea1f2adcc82d9459cf593775662ef3e3
- https://github.com/microsoft/playwright/commit/e7a11c0ca22881623b073f2540c21b5d2da24085

Fixes https://github.com/microsoft/playwright-dotnet/issues/2941