### PR TITLE
chore: remap persistent-context options into context options

### DIFF
--- a/src/Playwright.Tests/ClientCertficatesTests.cs
+++ b/src/Playwright.Tests/ClientCertficatesTests.cs
@@ -118,7 +118,6 @@ public class ClientCertificatesTests : BrowserTestEx
     {
         var context = await Browser.NewContextAsync(new()
         {
-            // TODO: Remove this once we can pass a custom CA.
             IgnoreHTTPSErrors = true,
             ClientCertificates =
             [
@@ -153,7 +152,6 @@ public class ClientCertificatesTests : BrowserTestEx
     {
         var page = await Browser.NewPageAsync(new()
         {
-            // TODO: Remove this once we can pass a custom CA.
             IgnoreHTTPSErrors = true,
             ClientCertificates =
             [
@@ -181,7 +179,6 @@ public class ClientCertificatesTests : BrowserTestEx
     {
         var context = await BrowserType.LaunchPersistentContextAsync("", new()
         {
-            // TODO: Remove this once we can pass a custom CA.
             IgnoreHTTPSErrors = true,
             ClientCertificates =
             [
@@ -210,7 +207,6 @@ public class ClientCertificatesTests : BrowserTestEx
     {
         var request = await Playwright.APIRequest.NewContextAsync(new()
         {
-            // TODO: Remove this once we can pass a custom CA.
             IgnoreHTTPSErrors = true,
             ClientCertificates =
             [

--- a/src/Playwright.Tests/PageRouteTests.cs
+++ b/src/Playwright.Tests/PageRouteTests.cs
@@ -513,13 +513,9 @@ public class PageRouteTests : PageTestEx
             route.ContinueAsync();
             requests.Add(route.Request);
         });
-        var response = await Page.GotoAsync($"data:text/html,<link rel=\"stylesheet\" href=\"{Server.EmptyPage}/fonts?helvetica|arial\"/>");
+        var response = await Page.GotoAsync($"data:text/html,<meta charset=utf-8><link rel=\"stylesheet\" href=\"{Server.EmptyPage}/fonts?helvetica|arial\"/>");
         Assert.Null(response);
-        // TODO: https://github.com/microsoft/playwright/issues/12789
-        if (TestConstants.IsFirefox)
-            Assert.That(requests, Has.Count.EqualTo(2));
-        else
-            Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.That(requests, Has.Count.EqualTo(1));
         Assert.AreEqual((int)HttpStatusCode.NotFound, (await requests[0].ResponseAsync()).Status);
     }
 

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -158,21 +158,9 @@ internal class BrowserType : ChannelOwner, IBrowserType
 
         var context = await SendMessageToServerAsync<BrowserContext>("launchPersistentContext", channelArgs).ConfigureAwait(false);
 
-        // TODO: unite with a single browser context options type which is derived from channels
         DidCreateContext(
             context,
-            new()
-            {
-                RecordVideoDir = options.RecordVideoDir,
-                RecordVideoSize = options.RecordVideoSize,
-                RecordHarContent = options.RecordHarContent,
-                RecordHarMode = options.RecordHarMode,
-                RecordHarOmitContent = options.RecordHarOmitContent,
-                RecordHarPath = options.RecordHarPath,
-                RecordHarUrlFilter = options.RecordHarUrlFilter,
-                RecordHarUrlFilterString = options.RecordHarUrlFilterString,
-                RecordHarUrlFilterRegex = options.RecordHarUrlFilterRegex,
-            },
+            ClassUtils.Clone<BrowserNewContextOptions>(options),
             options?.TracesDir);
 
         return context;


### PR DESCRIPTION
drive-by: address two other TODO comments.