### PR TITLE
chore: change the target closed exception public

### DIFF
--- a/src/Playwright/API/TargetClosedException.cs
+++ b/src/Playwright/API/TargetClosedException.cs
@@ -27,17 +27,17 @@ using Microsoft.Playwright.Core;
 
 namespace Microsoft.Playwright;
 
-internal class TargetClosedException : PlaywrightException
+public class TargetClosedException : PlaywrightException
 {
-    internal TargetClosedException() : base(DriverMessages.TargetClosedExceptionMessage)
+    public TargetClosedException() : base(DriverMessages.TargetClosedExceptionMessage)
     {
     }
 
-    internal TargetClosedException(string message) : base(message ?? DriverMessages.TargetClosedExceptionMessage)
+    public TargetClosedException(string message) : base(message ?? DriverMessages.TargetClosedExceptionMessage)
     {
     }
 
-    internal TargetClosedException(string message, Exception innerException) : base(message, innerException)
+    public TargetClosedException(string message, Exception innerException) : base(message, innerException)
     {
     }
 }


### PR DESCRIPTION
When we make a call to the playwright when the browser is disconnected, the method may throw the TargetClosedException, but due to the TargetClosedException is marked as internal, it is hard to catch this exception as the user. this is a trivial change to make this possible