### PR TITLE
Actually run the `EnsurePrerequisitsRan` target

### DIFF
--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -52,7 +52,7 @@
     <None Include="build\**" Pack="true" PackagePath="build" />
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />
   </ItemGroup>
-  <Target Name="EnsurePrerequisitsRan" BeforeTargets="DedupeDriver">
+  <Target Name="EnsurePrerequisitsRan" BeforeTargets="GetCopyToOutputDirectoryItems">
     <Error Text="Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`" Condition="!Exists('$(MSBuildProjectDirectory)\.drivers')" />
   </Target>
 </Project>


### PR DESCRIPTION
The `DedupeDriver` target doesn't exist anywhere so the `EnsurePrerequisitsRan` never runs. If the drivers were never downloaded by `Playwright.Tooling` then the following occurs when building `Playwright.csproj` if `EnsurePrerequisitsRan` doesn't run before:
```
Playwright failed with 5 error(s) (3.0s)
  /usr/local/share/dotnet/sdk/8.0.401/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "~/playwright-dotnet/src/Playwright/.drivers/linux/node" because it was not found.
  /usr/local/share/dotnet/sdk/8.0.401/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "~/playwright-dotnet/src/Playwright/.drivers/mac-arm64/node" because it was not found.
  /usr/local/share/dotnet/sdk/8.0.401/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "~/playwright-dotnet/src/Playwright/.drivers/win32_x64/node.exe" because it was not found.
  /usr/local/share/dotnet/sdk/8.0.401/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "~/playwright-dotnet/src/Playwright/.drivers/mac/node" because it was not found.
  /usr/local/share/dotnet/sdk/8.0.401/Microsoft.Common.CurrentVersion.targets(5321,5): error MSB3030: Could not copy the file "~/playwright-dotnet/src/Playwright/.drivers/linux-arm64/node" because it was not found.
```

By actually running the `EnsurePrerequisitsRan` target we get a much better, actionable error instead:
```
Playwright failed with 1 error(s) (2.5s)
  ~/playwright-dotnet/src/Playwright/Playwright.csproj(56,5): error : Playwright prerequisites are missing. Ensure you've ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .`
```