### PR TITLE
devops(tooling): Fix path to `README.md` in driver downloader

### DIFF
--- a/src/tools/Playwright.Tooling/DriverDownloader.cs
+++ b/src/tools/Playwright.Tooling/DriverDownloader.cs
@@ -71,7 +71,7 @@ internal class DriverDownloader
 
             var regex = new Regex("<!-- GEN:(.*?) -->(.*?)<!-- GEN:stop -->", RegexOptions.Compiled);
 
-            var basePlaywrightDir = Environment.GetEnvironmentVariable("PW_SRC_DIR") ?? Path.Combine(Environment.CurrentDirectory, "..", "playwright");
+            var basePlaywrightDir = Environment.GetEnvironmentVariable("PW_SRC_DIR") ?? Path.Combine(Environment.CurrentDirectory, "..", "playwright-dotnet");
             var readme = File.ReadAllText(Path.Combine(basePlaywrightDir, "README.md"));
             static string ReplaceBrowserVersion(string content, MatchCollection browserMatches)
             {


### PR DESCRIPTION
I followed the directions in `CONTRIBUTING.md` and ran `./build.sh --download-driver`.

When it ran `dotnet run --project ./src/tools/Playwright.Tooling/Playwright.Tooling.csproj -- download-drivers --basepath .` I got this following exception:

```bash
WARNING: Could not update the browser versions in the README file.
This is usually due to the readme file not yet existing for 1.46.0.
Could not find a part of the path 'D:\Code\RenderMichael\playwright\README.md'.
```

This fixes the issue for me. I assume it hasn't been hit before because everyone else also has the upstream `playwright` project as well.