### PR TITLE
chore: set Microsoft.NET.Test.Sdk minimum to 17.8.0

### DIFF
--- a/src/Playwright.MSTest/Playwright.MSTest.csproj
+++ b/src/Playwright.MSTest/Playwright.MSTest.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />


### PR DESCRIPTION
17.8 is the minimum which gets suggested when you create a new mstest/nunit project via the CLI in net8.0. This bumps Newtonsoft.Json to `13.0.1` which is not vulnerable.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3050