### PR TITLE
chore: drop net6.0/net7.0 from Playwright.CLI

### DIFF
--- a/src/Playwright.CLI/Playwright.CLI.csproj
+++ b/src/Playwright.CLI/Playwright.CLI.csproj
@@ -6,7 +6,7 @@
     <Summary>The Playwright CLI dotnet tool.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>
     <RootNamespace>Microsoft.Playwright.CLI</RootNamespace>


### PR DESCRIPTION
We don't plant to release a new version anymore but this produced the following warning:

```
    /usr/local/share/dotnet/sdk/9.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(32,5): warning NETSDK1138: The target framework 'net7.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
```