### PR TITLE
chore: fix 'Dereference of a possibly null reference.' warning

### DIFF
--- a/src/Playwright.NUnit/WorkerAwareTest.cs
+++ b/src/Playwright.NUnit/WorkerAwareTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Playwright.NUnit;
 public class WorkerAwareTest
 {
     private static readonly ConcurrentStack<Worker> _allWorkers = new();
-    private Worker? _currentWorker = null!;
+    private Worker _currentWorker = null!;
 
     internal class Worker
     {


### PR DESCRIPTION
This warning regressed in https://github.com/microsoft/playwright-dotnet/pull/3042. It was [non-nullable](https://github.com/microsoft/playwright-dotnet/pull/3042/files#diff-e98b51acc76a0cbe47e1e8f7eaaadac017efa17a01ea3dc1016cbe9dc8440117) before so it should be fine to restore that.