### PR TITLE
devops: AzDO publishing fixes

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -44,7 +44,7 @@ extends:
           inputs:
             packageType: sdk
             version: 8.x
-        - task: MicroBuildSigningPlugin@3
+        - task: MicroBuildSigningPlugin@4
           inputs:
             signType: real
             feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
@@ -80,11 +80,7 @@ extends:
             useDotNetTask: false
             # The reason for the 1.* after the package name is that we know the end of the package name in order to not
             # match with e.g. Microsoft.Playwright.CLI when we only want to match Microsoft.Playwright.
-            packagesToPush: |
-              $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.1.*.nupkg;
-              $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.MSTest.1.*.nupkg;
-              $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.NUnit.1.*.nupkg;
-              $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.TestAdapter.1.*.nupkg;
+            packagesToPush: $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.MSTest.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.NUnit.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.TestAdapter.1.*.nupkg
             packageParentPath: '$(Build.ArtifactStagingDirectory)'
             nuGetFeedType: external
             publishFeedCredentials: 'NuGet-Playwright'

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -80,6 +80,7 @@ extends:
             useDotNetTask: false
             # The reason for the 1.* after the package name is that we know the end of the package name in order to not
             # match with e.g. Microsoft.Playwright.CLI when we only want to match Microsoft.Playwright.
+            # Semicolon separated as per https://portal.microsofticm.com/imp/v5/incidents/details/467483180/summary
             packagesToPush: $(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.MSTest.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.NUnit.1.*.nupkg;$(Build.ArtifactStagingDirectory)/nuget/Microsoft.Playwright.TestAdapter.1.*.nupkg
             packageParentPath: '$(Build.ArtifactStagingDirectory)'
             nuGetFeedType: external


### PR DESCRIPTION
- Updates Microbuild plugin: We received a warning that it was using Node.js 10 under the hood
- Semicolon separate instead, to workaround [this](https://portal.microsofticm.com/imp/v3/incidents/details/467483180/home)