### PR TITLE
fix(xunit): support netstandard2.0

### DIFF
--- a/src/Playwright.Xunit/BrowserTest.cs
+++ b/src/Playwright.Xunit/BrowserTest.cs
@@ -48,7 +48,6 @@ public class BrowserTest : PlaywrightTest
 
     public override async Task DisposeAsync()
     {
-        await base.DisposeAsync().ConfigureAwait(false);
         if (TestOk)
         {
             foreach (var context in _contexts)
@@ -58,5 +57,6 @@ public class BrowserTest : PlaywrightTest
         }
         _contexts.Clear();
         Browser = null!;
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Playwright.Xunit/Playwright.Xunit.csproj
+++ b/src/Playwright.Xunit/Playwright.Xunit.csproj
@@ -9,7 +9,7 @@
       and fixtures to enable using it within xUnit.
     </Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>
     <RootNamespace>Microsoft.Playwright.Xunit</RootNamespace>
@@ -35,9 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />

--- a/src/Playwright.Xunit/WorkerAwareTest.cs
+++ b/src/Playwright.Xunit/WorkerAwareTest.cs
@@ -73,7 +73,6 @@ public class WorkerAwareTest : ExceptionCapturer
 
     public async override Task DisposeAsync()
     {
-        await base.DisposeAsync().ConfigureAwait(false);
         if (TestOk)
         {
             foreach (var kv in _currentWorker.Services)
@@ -90,6 +89,7 @@ public class WorkerAwareTest : ExceptionCapturer
             }
             _currentWorker.Services.Clear();
         }
+        await base.DisposeAsync().ConfigureAwait(false);
     }
 }
 

--- a/src/Playwright.Xunit/WorkerAwareTest.cs
+++ b/src/Playwright.Xunit/WorkerAwareTest.cs
@@ -25,7 +25,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Core;
@@ -34,10 +33,10 @@ using Xunit;
 
 namespace Microsoft.Playwright.Xunit;
 
-public class WorkerAwareTest : ExceptionCapturer, IAsyncLifetime
+public class WorkerAwareTest : ExceptionCapturer
 {
     private static readonly ConcurrentStack<Worker> _allWorkers = new();
-    private Worker? _currentWorker = null!;
+    private Worker _currentWorker = null!;
 
     internal class Worker
     {
@@ -58,8 +57,9 @@ public class WorkerAwareTest : ExceptionCapturer, IAsyncLifetime
         return (_currentWorker.Services[name] as T)!;
     }
 
-    public virtual Task InitializeAsync()
+    async public override Task InitializeAsync()
     {
+        await base.InitializeAsync().ConfigureAwait(false);
         if (!_allWorkers.TryPop(out _currentWorker!))
         {
             _currentWorker = new();
@@ -69,11 +69,11 @@ public class WorkerAwareTest : ExceptionCapturer, IAsyncLifetime
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);
         }
-        return Task.CompletedTask;
     }
 
-    public virtual async Task DisposeAsync()
+    public async override Task DisposeAsync()
     {
+        await base.DisposeAsync().ConfigureAwait(false);
         if (TestOk)
         {
             foreach (var kv in _currentWorker.Services)
@@ -107,16 +107,26 @@ public interface IWorkerService
 /// Note: There is no way of getting the test status in xUnit in the dispose method.
 /// For more information, see: https://stackoverflow.com/questions/28895448/current-test-status-in-xunit-net
 /// </summary>
-public class ExceptionCapturer
+public class ExceptionCapturer : IAsyncLifetime
 {
-    protected static bool TestOk { get; private set; } = true;
+    protected bool TestOk { get; private set; } = true;
 
-    [ModuleInitializer]
-    public static void Setup()
+    public ExceptionCapturer()
     {
         AppDomain.CurrentDomain.FirstChanceException += (_, e) =>
         {
             TestOk = false;
         };
+    }
+
+    public virtual Task InitializeAsync()
+    {
+        TestOk = true;
+        return Task.CompletedTask;
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
`ModuleInitializer` was something which was not supported in older .NET frameworks. This patch starts listening on the constructor instead and resets the TestOK status in TestInitialize.

Background: xUnit 2 does not provide a reliable way of determining if a test was passing or failing and reading it's status in the AfterEach. xUnit 3 allows to read its status which we'll use once its published. We want to support xUnit 2 as well.

https://github.com/microsoft/playwright-dotnet/issues/2977