### PR TITLE
chore: ignore GitHub Codespaces BROWSER env var

### DIFF
--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -41,7 +41,8 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         {
             var browserFromEnv = Environment.GetEnvironmentVariable("BROWSER")?.ToLowerInvariant();
             // GitHub Codespaces sets the BROWSER environment variable, ignore it if its bogus.
-            if (!string.IsNullOrEmpty(browserFromEnv) && !browserFromEnv!.StartsWith("/vscode/"))
+            var ignoreValueFromEnv = Environment.GetEnvironmentVariable("CODESPACES") == "true" && browserFromEnv!.StartsWith("/vscode/");
+            if (!string.IsNullOrEmpty(browserFromEnv) && !ignoreValueFromEnv)
             {
                 ValidateBrowserName(browserFromEnv!, "'BROWSER' environment variable", "\nTry to remove 'BROWSER' environment variable for using default browser");
                 return browserFromEnv!;

--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -40,7 +40,8 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         get
         {
             var browserFromEnv = Environment.GetEnvironmentVariable("BROWSER")?.ToLowerInvariant();
-            if (!string.IsNullOrEmpty(browserFromEnv))
+            // GitHub Codespaces sets the BROWSER environment variable, ignore it if its bogus.
+            if (!string.IsNullOrEmpty(browserFromEnv) && !browserFromEnv!.StartsWith("/vscode/"))
             {
                 ValidateBrowserName(browserFromEnv!, "'BROWSER' environment variable", "\nTry to remove 'BROWSER' environment variable for using default browser");
                 return browserFromEnv!;


### PR DESCRIPTION
e.g. `/vscode/bin/linux-x64/f1a4fb101478ce6ec82fe9627c43efbf9e98c813/bin/helpers/browser.sh` which prevents customers from running the getting started on GitHub Codespaces.

We respect the `BROWSER` env var for legacy reasons.

Fixes https://github.com/microsoft/playwright-dotnet/issues/2847