### PR TITLE
Depend on xunit.extensibility.core instead of xunit

### DIFF
--- a/src/Playwright.Xunit/Playwright.Xunit.csproj
+++ b/src/Playwright.Xunit/Playwright.Xunit.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />


### PR DESCRIPTION
See [xUnit.net documentation - What NuGet Packages Should I Use?][1]

[1]: https://xunit.net/docs/nuget-packages