### PR TITLE
devops: set up docker test and publish for NET 8 and 9

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -14,6 +14,10 @@ jobs:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     environment: Docker
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet-version: ["8.0", "9.0"]
     steps:
     - uses: actions/checkout@v4
     - name: Azure login
@@ -27,7 +31,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: ${{ matrix.dotnet-version }}.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver
@@ -35,4 +39,4 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
-    - run: ./utils/docker/publish_docker.sh stable
+    - run: ./utils/docker/publish_docker.sh stable ${{ matrix.dotnet-version }}

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -18,23 +18,24 @@ on:
       - release-*
 jobs:
   build:
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         flavor: [jammy, noble]
+        dotnet-version: ["8.0", "9.0"]
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: ${{ matrix.dotnet-version }}.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver
     - name: Build Docker image
-      run: bash utils/docker/build.sh --amd64 ${{ matrix.flavor }} playwright-dotnet:localbuild-${{ matrix.flavor }}
+      run: bash utils/docker/build.sh --amd64 ${{ matrix.flavor }} playwright-dotnet:localbuild-${{ matrix.flavor }} ${{ matrix.dotnet-version }}
     - name: Cleanup
       run: dotnet clean src/ || true
     - name: Test

--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy
+ARG DOTNET_VERSION
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} playwright:localbuild-noble"
+  echo "usage: $(basename $0) {--arm64,--amd64} {jammy,noble} {8.0,9.0} playwright:localbuild-noble"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-noble'."
   echo "Once image is built, you can run it with"
@@ -36,6 +36,13 @@ else
   exit 1
 fi
 
+# Set default .NET version to net8 if not specified
+DOTNET_VERSION="$4"
+if [[ "$DOTNET_VERSION" != "8.0" && "$DOTNET_VERSION" != "9.0" ]]; then
+  echo "ERROR: unknown .NET version - $DOTNET_VERSION. Must be either '8.0' or '9.0'"
+  exit 1
+fi
+
 dotnet publish ../../src/Playwright -o dist/ --arch $DOTNET_ARCH
 
-docker build --progress=plain --platform "${DOCKER_PLATFORM}" -t "$3" -f "Dockerfile.$2" .
+docker build --progress=plain --platform "${DOCKER_PLATFORM}" --build-arg DOTNET_VERSION="${DOTNET_VERSION}" -t "$3" -f "Dockerfile.$2" .

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -8,6 +8,7 @@ cd "$(dirname "$0")"
 
 MCR_IMAGE_NAME="playwright/dotnet"
 PW_VERSION=$(node -e "console.log(/\<AssemblyVersion\>(.*?)<\/AssemblyVersion\>/.exec(fs.readFileSync('../../src/Common/Version.props').toString())[1])")
+DOTNET_VERSION="$2"
 
 RELEASE_CHANNEL="$1"
 if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
@@ -23,13 +24,13 @@ fi
 
 # Ubuntu 22.04
 JAMMY_TAGS=(
-  "v${PW_VERSION}-jammy"
+  "v${PW_VERSION}-jammy-net${DOTNET_VERSION}"
 )
 
 # Ubuntu 24.04
 NOBLE_TAGS=(
-  "v${PW_VERSION}"
-  "v${PW_VERSION}-noble"
+  "v${PW_VERSION}-net${DOTNET_VERSION}"
+  "v${PW_VERSION}-noble-net${DOTNET_VERSION}"
 )
 
 tag_and_push() {
@@ -79,7 +80,7 @@ publish_docker_images_with_arch_suffix() {
   fi
   # Prune docker images to avoid platform conflicts
   docker system prune -fa
-  ./build.sh "--${ARCH}" "${FLAVOR}" "${MCR_IMAGE_NAME}:localbuild"
+  ./build.sh "--${ARCH}" "${FLAVOR}" "${MCR_IMAGE_NAME}:localbuild" "${DOTNET_VERSION}"
 
   for ((i = 0; i < ${#TAGS[@]}; i++)) do
     local TAG="${TAGS[$i]}"


### PR DESCRIPTION
Here is a PR to do docker build testing and publishing for both NET 8 and 9. I have not tested this as it's not trivial to test without setting up docker hub, secrets, etc.

Fixes #3075

- [ ] 9.0-jammy docker image does not exist. I could just change the 2 .sh scripts to exit gracefully when trying to run for that configuration.