### PR TITLE
add net8.0 target

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -184,6 +184,7 @@ dotnet_diagnostic.CA1305.severity = error
 dotnet_diagnostic.CA1307.severity = none
 dotnet_diagnostic.CA1308.severity = none
 dotnet_diagnostic.CA1508.severity = none
+dotnet_diagnostic.CA1510.severity = none
 dotnet_diagnostic.CA1725.severity = error
 dotnet_diagnostic.CA1801.severity = suggestion
 dotnet_diagnostic.CA1812.severity = none

--- a/src/Common/Dependencies.props
+++ b/src/Common/Dependencies.props
@@ -18,10 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Playwright.NUnit/Playwright.NUnit.csproj
+++ b/src/Playwright.NUnit/Playwright.NUnit.csproj
@@ -9,7 +9,7 @@
       and fixtures to enable using it within NUnit.
     </Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RunWithWarnings>true</RunWithWarnings>
     <RootNamespace>Microsoft.Playwright.NUnit</RootNamespace>

--- a/src/Playwright.NUnit/SkipAttribute.cs
+++ b/src/Playwright.NUnit/SkipAttribute.cs
@@ -63,7 +63,7 @@ public class SkipAttribute : NUnitAttribute, IApplyToTest
     {
         if (_combinations.Any(combination =>
         {
-            var requirements = (Enum.GetValues(typeof(Targets)) as Targets[]).Where(x => combination.HasFlag(x));
+            var requirements = ((Targets[])Enum.GetValues(typeof(Targets))).Where(x => combination.HasFlag(x));
             return requirements.All(flag =>
                 flag switch
                 {

--- a/src/Playwright.Tests/PageEvaluateTests.cs
+++ b/src/Playwright.Tests/PageEvaluateTests.cs
@@ -549,7 +549,7 @@ public class PageEvaluateTests : PageTestEx
     [PlaywrightTest("page-evaluate.spec.ts", "should evaluate exception with a function on the stack")]
     public async Task ShouldEvaluateExceptionWithAFunctionOnTheStack()
     {
-        var exception = await Page.EvaluateAsync<Exception>(@"() => {
+        var exception = await Page.EvaluateAsync<PlaywrightException>(@"() => {
             return (function functionOnStack() {
                 return new Error('error message');
             })();

--- a/src/Playwright/Core/APIRequest.cs
+++ b/src/Playwright/Core/APIRequest.cs
@@ -60,7 +60,11 @@ internal class APIRequest : IAPIRequest
                 throw new PlaywrightException($"The specified storage state file does not exist: {options?.StorageStatePath}");
             }
 
+#if NET
+            storageState = await File.ReadAllTextAsync(options?.StorageStatePath).ConfigureAwait(false);
+#else
             storageState = File.ReadAllText(options?.StorageStatePath);
+#endif
         }
         if (!string.IsNullOrEmpty(storageState))
         {

--- a/src/Playwright/Core/APIRequestContext.cs
+++ b/src/Playwright/Core/APIRequestContext.cs
@@ -220,7 +220,11 @@ internal class APIRequestContext : ChannelOwner, IAPIRequestContext
 
         if (!string.IsNullOrEmpty(options?.Path))
         {
+#if NET
+            await File.WriteAllTextAsync(options?.Path, state).ConfigureAwait(false);
+#else
             File.WriteAllText(options?.Path, state);
+#endif
         }
 
         return state;

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -150,7 +150,11 @@ internal class Browser : ChannelOwner, IBrowser
                 throw new PlaywrightException($"The specified storage state file does not exist: {options.StorageStatePath}");
             }
 
+#if NET
+            storageState = await File.ReadAllTextAsync(options.StorageStatePath).ConfigureAwait(false);
+#else
             storageState = File.ReadAllText(options.StorageStatePath);
+#endif
         }
 
         if (!string.IsNullOrEmpty(storageState))

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -544,7 +544,11 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
 
         if (!string.IsNullOrEmpty(options?.Path))
         {
+#if NET
+            await File.WriteAllTextAsync(options?.Path, state).ConfigureAwait(false);
+#else
             File.WriteAllText(options?.Path, state);
+#endif
         }
 
         return state;

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -181,7 +181,9 @@ internal class BrowserType : ChannelOwner, IBrowserType
         {
             pipe.CloseAsync().IgnoreException();
         }
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var connection = new Connection(_connection.LocalUtils);
+#pragma warning restore CA2000 // Dispose objects before losing scope
         connection.MarkAsRemote();
         connection.Close += (_, _) => ClosePipe();
 

--- a/src/Playwright/Core/ElementHandle.cs
+++ b/src/Playwright/Core/ElementHandle.cs
@@ -122,7 +122,11 @@ internal class ElementHandle : JSHandle, IElementHandle
         if (!string.IsNullOrEmpty(options.Path))
         {
             Directory.CreateDirectory(new FileInfo(options.Path).Directory.FullName);
+#if NET
+            await File.WriteAllBytesAsync(options.Path, result).ConfigureAwait(false);
+#else
             File.WriteAllBytes(options.Path, result);
+#endif
         }
 
         return result;
@@ -204,7 +208,7 @@ internal class ElementHandle : JSHandle, IElementHandle
         {
             throw new PlaywrightException("Cannot set input files to detached element.");
         }
-        var converted = await SetInputFilesHelpers.ConvertInputFilesAsync(files, (BrowserContext)frame.Page.Context).ConfigureAwait(false);
+        var converted = await SetInputFilesHelpers.ConvertInputFilesAsync(files.ToList(), (BrowserContext)frame.Page.Context).ConfigureAwait(false);
         await SendMessageToServerAsync("setInputFiles", new Dictionary<string, object>
         {
             ["payloads"] = converted.Payloads,
@@ -221,7 +225,7 @@ internal class ElementHandle : JSHandle, IElementHandle
 
     public async Task SetInputFilesAsync(IEnumerable<FilePayload> files, ElementHandleSetInputFilesOptions options = default)
     {
-        var converted = SetInputFilesHelpers.ConvertInputFiles(files);
+        var converted = SetInputFilesHelpers.ConvertInputFiles(files.ToList());
         await SendMessageToServerAsync("setInputFiles", new Dictionary<string, object>
         {
             ["payloads"] = converted.Payloads,

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -711,7 +711,11 @@ internal class Page : ChannelOwner, IPage
         if (!string.IsNullOrEmpty(options.Path))
         {
             Directory.CreateDirectory(new FileInfo(options.Path).Directory.FullName);
+#if NET
+            await File.WriteAllBytesAsync(options.Path, result).ConfigureAwait(false);
+#else
             File.WriteAllBytes(options.Path, result);
+#endif
         }
 
         return result;
@@ -916,7 +920,11 @@ internal class Page : ChannelOwner, IPage
         if (!string.IsNullOrEmpty(options?.Path))
         {
             Directory.CreateDirectory(new FileInfo(options.Path).Directory.FullName);
+#if NET
+            await File.WriteAllBytesAsync(options.Path, result).ConfigureAwait(false);
+#else
             File.WriteAllBytes(options.Path, result);
+#endif
         }
 
         return result;

--- a/src/Playwright/Core/Request.cs
+++ b/src/Playwright/Core/Request.cs
@@ -70,12 +70,11 @@ internal class Request : ChannelOwner, IRequest
             var frame = _initializer.Frame;
             if (frame.Page == null)
             {
-                throw new PlaywrightException(string.Join("\n", new string[]
-                {
-                    "Frame for this navigation request is not available, because the request",
-                    "was issued before the frame is created. You can check whether the request",
-                    "is a navigation request by calling isNavigationRequest() method.",
-                }));
+                throw new PlaywrightException("""
+                    Frame for this navigation request is not available, because the request
+                    was issued before the frame is created. You can check whether the request
+                    is a navigation request by calling isNavigationRequest() method.
+                    """);
             }
             return frame;
         }

--- a/src/Playwright/Core/Route.cs
+++ b/src/Playwright/Core/Route.cs
@@ -192,7 +192,11 @@ internal class Route : ChannelOwner, IRoute
 
         if (!string.IsNullOrEmpty(path))
         {
+#if NET
+            byte[] content = await File.ReadAllBytesAsync(path).ConfigureAwait(false);
+#else
             byte[] content = File.ReadAllBytes(path);
+#endif
             resultBody = Convert.ToBase64String(content);
             isBase64 = true;
             length = resultBody.Length;

--- a/src/Playwright/Helpers/Driver.cs
+++ b/src/Playwright/Helpers/Driver.cs
@@ -100,9 +100,14 @@ internal static class Driver
     {
         try
         {
-            // assembly.CodeBase might throw with:
-            // System.NotSupportedException: CodeBase is not supported on assemblies loaded from a single-file bundle.
+            // assembly.Location/CodeBase might throw with:
+            // System.NotSupportedException: Location/CodeBase is not supported on assemblies loaded from a single-file bundle.
+            // Still using CodeBase for legacy .NET because of behaviour difference with shadow-copy (see https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-8.0#remarks)
+#if NET
+            Uri.TryCreate(assembly.Location, UriKind.Absolute, out codeBase);
+#else
             Uri.TryCreate(assembly.CodeBase, UriKind.Absolute, out codeBase);
+#endif
             return true;
         }
         catch (NotSupportedException)

--- a/src/Playwright/Helpers/StringExtensions.cs
+++ b/src/Playwright/Helpers/StringExtensions.cs
@@ -615,7 +615,11 @@ internal static class StringExtensions
 
         var result = new Dictionary<string, string>();
 
+#if NET
+        if (query.StartsWith('?'))
+#else
         if (query.StartsWith("?", StringComparison.InvariantCultureIgnoreCase))
+#endif
         {
             query = query.Substring(1, query.Length - 1);
         }

--- a/src/Playwright/Helpers/URLMatch.cs
+++ b/src/Playwright/Helpers/URLMatch.cs
@@ -65,7 +65,11 @@ public class URLMatch
     internal static string JoinWithBaseURL(string baseUrl, string url)
     {
         if (string.IsNullOrEmpty(baseUrl)
+#if NET
+            || (url?.StartsWith('*') ?? false)
+#else
             || (url?.StartsWith("*", StringComparison.InvariantCultureIgnoreCase) ?? false)
+#endif
             || !Uri.IsWellFormedUriString(url, UriKind.RelativeOrAbsolute))
         {
             return url;

--- a/src/Playwright/Playwright.cs
+++ b/src/Playwright/Playwright.cs
@@ -40,8 +40,10 @@ public static class Playwright
     /// <returns>A <see cref="Task"/> that completes when the playwright driver is ready to be used.</returns>
     public static async Task<IPlaywright> CreateAsync()
     {
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var transport = new StdIOTransport();
         var connection = new Connection();
+#pragma warning restore CA2000 // Dispose objects before losing scope
         transport.MessageReceived += (_, message) =>
         {
             Connection.TraceMessage("pw:channel:recv", message);

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -7,7 +7,7 @@
     <Summary>The .NET port of Playwright, used to automate Chromium, Firefox and WebKit with a single API.</Summary>
     <Description>Playwright enables reliable end-to-end testing for modern web apps. It is built to enable cross-browser web automation that is ever-green, capable, reliable and fast. Learn more at https://playwright.dev/dotnet/.</Description>
     <PackageIcon>icon.png</PackageIcon>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DocumentationFile>Microsoft.Playwright.xml</DocumentationFile>
     <RunWithWarnings>true</RunWithWarnings>
@@ -25,15 +25,17 @@
   <Import Project="../Common/Dependencies.props" />
   <Import Project="../Common/SignAssembly.props" />
   <Import Project="../Common/SignFiles.props" />
+  <ItemGroup Condition="'$(TargetFramework)'== 'netstandard2.0'">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.10" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Playwright.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100059a04ca5ca77c9b4eb2addd1afe3f8464b20ee6aefe73b8c23c0e6ca278d1a378b33382e7e18d4aa8300dd22d81f146e528d88368f73a288e5b8157da9710fe6f9fa9911fb786193f983408c5ebae0b1ba5d1d00111af2816f5db55871db03d7536f4a7a6c5152d630c1e1886b1a0fb68ba5e7f64a7f24ac372090889be2ffb" />

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -314,105 +314,78 @@ internal class Connection : IDisposable
 
     private ChannelOwner CreateRemoteObject(string parentGuid, ChannelOwnerType type, string guid, JsonElement? initializer)
     {
-        ChannelOwner result = null;
         var parent = string.IsNullOrEmpty(parentGuid) ? _rootObject : Objects[parentGuid];
 
         switch (type)
         {
             case ChannelOwnerType.APIRequestContext:
-                result = new APIRequestContext(parent, guid, initializer?.ToObject<APIRequestContextInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new APIRequestContext(parent, guid, initializer?.ToObject<APIRequestContextInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Artifact:
-                result = new Artifact(parent, guid, initializer?.ToObject<ArtifactInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Artifact(parent, guid, initializer?.ToObject<ArtifactInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.BindingCall:
-                result = new BindingCall(parent, guid, initializer?.ToObject<BindingCallInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new BindingCall(parent, guid, initializer?.ToObject<BindingCallInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Playwright:
-                result = new PlaywrightImpl(parent, guid, initializer?.ToObject<PlaywrightInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new PlaywrightImpl(parent, guid, initializer?.ToObject<PlaywrightInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Browser:
                 var browserInitializer = initializer?.ToObject<BrowserInitializer>(DefaultJsonSerializerOptions);
-                result = new Browser(parent, guid, browserInitializer);
-                break;
+                return new Browser(parent, guid, browserInitializer);
             case ChannelOwnerType.BrowserType:
                 var browserTypeInitializer = initializer?.ToObject<BrowserTypeInitializer>(DefaultJsonSerializerOptions);
-                result = new Core.BrowserType(parent, guid, browserTypeInitializer);
-                break;
+                return new Core.BrowserType(parent, guid, browserTypeInitializer);
             case ChannelOwnerType.BrowserContext:
                 var browserContextInitializer = initializer?.ToObject<BrowserContextInitializer>(DefaultJsonSerializerOptions);
-                result = new BrowserContext(parent, guid, browserContextInitializer);
-                break;
+                return new BrowserContext(parent, guid, browserContextInitializer);
             case ChannelOwnerType.CDPSession:
-                result = new CDPSession(parent, guid);
-                break;
+                return new CDPSession(parent, guid);
             case ChannelOwnerType.Dialog:
-                result = new Dialog(parent, guid, initializer?.ToObject<DialogInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Dialog(parent, guid, initializer?.ToObject<DialogInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.ElementHandle:
-                result = new ElementHandle(parent, guid, initializer?.ToObject<ElementHandleInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new ElementHandle(parent, guid, initializer?.ToObject<ElementHandleInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Frame:
-                result = new Frame(parent, guid, initializer?.ToObject<FrameInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Frame(parent, guid, initializer?.ToObject<FrameInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.JSHandle:
-                result = new JSHandle(parent, guid, initializer?.ToObject<JSHandleInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new JSHandle(parent, guid, initializer?.ToObject<JSHandleInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.JsonPipe:
-                result = new JsonPipe(parent, guid, initializer?.ToObject<JsonPipeInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new JsonPipe(parent, guid, initializer?.ToObject<JsonPipeInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.LocalUtils:
-                result = new LocalUtils(parent, guid, initializer?.ToObject<LocalUtilsInitializer>(DefaultJsonSerializerOptions));
+                var localUtils = new LocalUtils(parent, guid, initializer?.ToObject<LocalUtilsInitializer>(DefaultJsonSerializerOptions));
                 if (LocalUtils == null)
                 {
-                    LocalUtils = result as LocalUtils;
+                    LocalUtils = localUtils;
                 }
-                break;
+                return localUtils;
             case ChannelOwnerType.Page:
-                result = new Page(parent, guid, initializer?.ToObject<PageInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Page(parent, guid, initializer?.ToObject<PageInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Request:
-                result = new Request(parent, guid, initializer?.ToObject<RequestInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Request(parent, guid, initializer?.ToObject<RequestInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Response:
-                result = new Response(parent, guid, initializer?.ToObject<ResponseInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Response(parent, guid, initializer?.ToObject<ResponseInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Route:
-                result = new Route(parent, guid, initializer?.ToObject<RouteInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Route(parent, guid, initializer?.ToObject<RouteInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Worker:
-                result = new Worker(parent, guid, initializer?.ToObject<WorkerInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new Worker(parent, guid, initializer?.ToObject<WorkerInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.WebSocket:
-                result = new WebSocket(parent, guid, initializer?.ToObject<WebSocketInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new WebSocket(parent, guid, initializer?.ToObject<WebSocketInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.WebSocketRoute:
-                result = new WebSocketRoute(parent, guid, initializer?.ToObject<WebSocketRouteInitializer>(DefaultJsonSerializerOptions));
-                break;
+                return new WebSocketRoute(parent, guid, initializer?.ToObject<WebSocketRouteInitializer>(DefaultJsonSerializerOptions));
             case ChannelOwnerType.Selectors:
-                result = new Selectors(parent, guid);
-                break;
+                return new Selectors(parent, guid);
             case ChannelOwnerType.SocksSupport:
-                result = new SocksSupport(parent, guid);
-                break;
+                return new SocksSupport(parent, guid);
             case ChannelOwnerType.Stream:
-                result = new Stream(parent, guid);
-                break;
+                return new Stream(parent, guid);
             case ChannelOwnerType.WritableStream:
-                result = new WritableStream(parent, guid);
-                break;
+                return new WritableStream(parent, guid);
             case ChannelOwnerType.Tracing:
-                result = new Tracing(parent, guid);
-                break;
+                return new Tracing(parent, guid);
             case ChannelOwnerType.Electron:
             case ChannelOwnerType.Android:
-                result = null;
                 break;
             default:
                 Debug.Fail($"Missing Playwright type binding for '{type}'");
                 break;
         }
-        return result;
+        return null;
     }
 
     internal void DoClose(Exception cause = null)
@@ -507,7 +480,11 @@ internal class Connection : IDisposable
                 {
                     apiBoundaryReached = true;
                 }
+#if NET
+                var hasCleanMethodName = !methodName.StartsWith('<');
+#else
                 var hasCleanMethodName = !methodName.StartsWith("<", StringComparison.InvariantCultureIgnoreCase);
+#endif
                 if (hasCleanMethodName)
                 {
                     lastInternalApiName = methodName;

--- a/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
+++ b/src/Playwright/Transport/Converters/EvaluateArgumentValueConverter.cs
@@ -30,7 +30,6 @@ using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Playwright.Core;
@@ -345,7 +344,7 @@ internal static class EvaluateArgumentValueConverter
 
         if (result.TryGetProperty("e", out var error))
         {
-            return new Exception(error.GetProperty("s").ToString());
+            return new PlaywrightException(error.GetProperty("s").ToString());
         }
 
         if (result.TryGetProperty("r", out var regex))
@@ -399,16 +398,25 @@ internal static class EvaluateArgumentValueConverter
         internal VisitorInfo()
         {
             Visited = new Dictionary<long, int>();
-            IDGenerator = new ObjectIDGenerator();
+            ObjectToId = new Dictionary<object, long>();
         }
 
         internal Dictionary<long, int> Visited { get; set; }
 
         internal int LastId { get; set; }
 
-        private ObjectIDGenerator IDGenerator { get; }
+        private Dictionary<object, long> ObjectToId { get; }
 
         internal long Identity(object obj)
-            => IDGenerator.GetId(obj, out _);
+        {
+            if (ObjectToId.TryGetValue(obj, out long id))
+            {
+                return id;
+            }
+
+            id = ObjectToId.Count + 1;
+            ObjectToId.Add(obj, id);
+            return id;
+        }
     }
 }


### PR DESCRIPTION
- add net8.0 target to projects
- fix all compiler warnings introduced by the new targets
- removed unneeded dependencies since they are part of the .NET runtime

Some of these changes make sense regardless of the multi-targeting. Some of the `#if`s could obviously be avoided by ignoring the warning instead. I opted for `#if` almost everywhere for now.

fixes #3033