### PR TITLE
feat: Add possibility to load Playwright settings programmatically in test runners

### DIFF
--- a/src/Playwright.MSTest/WorkerAwareTest.cs
+++ b/src/Playwright.MSTest/WorkerAwareTest.cs
@@ -34,9 +34,26 @@ public class WorkerAwareTest
         return (_currentWorker.Services[name] as T)!;
     }
 
+    protected virtual PlaywrightSettings? PlaywrightSettings()
+    {
+        return null;
+    }
+
+    private void LoadPlaywrightSettings()
+    {
+        var settings = PlaywrightSettings();
+        if (settings != null)
+        {
+            PlaywrightSettingsProvider.Load(settings);
+        }
+    }
+
     [TestInitialize]
     public void WorkerSetup()
     {
+        // Must be run before accessing any static PlaywrightSettingsProvider.* properties
+        LoadPlaywrightSettings();
+
         if (PlaywrightSettingsProvider.ExpectTimeout.HasValue)
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);

--- a/src/Playwright.NUnit/WorkerAwareTest.cs
+++ b/src/Playwright.NUnit/WorkerAwareTest.cs
@@ -58,6 +58,20 @@ public class WorkerAwareTest
         return (_currentWorker.Services[name] as T)!;
     }
 
+    protected virtual PlaywrightSettings? PlaywrightSettings()
+    {
+        return null;
+    }
+
+    private void LoadPlaywrightSettings()
+    {
+        var settings = PlaywrightSettings();
+        if (settings != null)
+        {
+            PlaywrightSettingsProvider.Load(settings);
+        }
+    }
+
     [SetUp]
     public void WorkerSetup()
     {
@@ -66,6 +80,10 @@ public class WorkerAwareTest
             _currentWorker = new();
         }
         WorkerIndex = _currentWorker.WorkerIndex;
+
+        // Must be run before accessing any static PlaywrightSettingsProvider.* properties
+        LoadPlaywrightSettings();
+
         if (PlaywrightSettingsProvider.ExpectTimeout.HasValue)
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);

--- a/src/Playwright.TestAdapter/PlaywrightBrowser.cs
+++ b/src/Playwright.TestAdapter/PlaywrightBrowser.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.Playwright.TestAdapter;
+
+public enum PlaywrightBrowser
+{
+    Chromium,
+    Firefox,
+    WebKit,
+}

--- a/src/Playwright.TestAdapter/PlaywrightSettings.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettings.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Microsoft.Playwright.TestAdapter;
+
+public class PlaywrightSettings
+{
+    public PlaywrightBrowser Browser { get; set; } = PlaywrightBrowser.Chromium;
+    public BrowserTypeLaunchOptions? LaunchOptions { get; set; }
+    public TimeSpan? ExpectTimeout { get; set; }
+}

--- a/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Playwright.TestAdapter;
 public class PlaywrightSettingsProvider : ISettingsProvider
 {
     private static PlaywrightSettingsXml? _settings = null!;
+    private static PlaywrightSettings? _playwrightSettings;
 
     public static void LoadViaEnvIfNeeded()
     {
@@ -56,6 +57,12 @@ public class PlaywrightSettingsProvider : ISettingsProvider
     {
         get
         {
+            if (_playwrightSettings != null)
+            {
+                var browser = _playwrightSettings.Browser.ToString().ToLowerInvariant();
+                ValidateBrowserName(browser, "PlaywrightSettings.Browser property", string.Empty);
+                return browser;
+            }
             var browserFromEnv = Environment.GetEnvironmentVariable("BROWSER")?.ToLowerInvariant();
             // GitHub Codespaces and DevContainers sets the BROWSER environment variable, ignore it if its bogus.
             if (!string.IsNullOrEmpty(browserFromEnv) && !browserFromEnv!.StartsWith("/vscode/"))
@@ -77,15 +84,8 @@ public class PlaywrightSettingsProvider : ISettingsProvider
     {
         get
         {
-            if (_settings == null)
-            {
-                return null;
-            }
-            if (_settings.ExpectTimeout.HasValue)
-            {
-                return _settings.ExpectTimeout.Value;
-            }
-            return null;
+            var expectTimeout = _playwrightSettings?.ExpectTimeout?.TotalMilliseconds;
+            return expectTimeout.HasValue ? Convert.ToSingle(expectTimeout.Value) : _settings?.ExpectTimeout;
         }
     }
 
@@ -93,7 +93,7 @@ public class PlaywrightSettingsProvider : ISettingsProvider
     {
         get
         {
-            var launchOptions = _settings?.LaunchOptions ?? new BrowserTypeLaunchOptions();
+            var launchOptions = _playwrightSettings?.LaunchOptions ?? _settings?.LaunchOptions ?? new BrowserTypeLaunchOptions();
             if (Environment.GetEnvironmentVariable("HEADED") == "1")
             {
                 launchOptions.Headless = false;
@@ -124,5 +124,8 @@ public class PlaywrightSettingsProvider : ISettingsProvider
         _settings = new PlaywrightSettingsXml(reader);
         Environment.SetEnvironmentVariable("PW_INTERNAL_ADAPTER_SETTINGS", JsonSerializer.Serialize(_settings));
     }
+
+    public static void Load(PlaywrightSettings settings)
+        => _playwrightSettings = settings;
 }
 

--- a/src/Playwright.Xunit/WorkerAwareTest.cs
+++ b/src/Playwright.Xunit/WorkerAwareTest.cs
@@ -57,6 +57,20 @@ public class WorkerAwareTest : ExceptionCapturer
         return (_currentWorker.Services[name] as T)!;
     }
 
+    protected virtual PlaywrightSettings? PlaywrightSettings()
+    {
+        return null;
+    }
+
+    private void LoadPlaywrightSettings()
+    {
+        var settings = PlaywrightSettings();
+        if (settings != null)
+        {
+            PlaywrightSettingsProvider.Load(settings);
+        }
+    }
+
     async public override Task InitializeAsync()
     {
         await base.InitializeAsync().ConfigureAwait(false);
@@ -65,6 +79,10 @@ public class WorkerAwareTest : ExceptionCapturer
             _currentWorker = new();
         }
         WorkerIndex = _currentWorker.WorkerIndex;
+
+        // Must be run before accessing any static PlaywrightSettingsProvider.* properties
+        LoadPlaywrightSettings();
+
         if (PlaywrightSettingsProvider.ExpectTimeout.HasValue)
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);


### PR DESCRIPTION
As an alternative to using a .runsettings XML file.

Fixes #3081