### PR TITLE
fix(webSocketRoute): support no trailing slash

### DIFF
--- a/src/Playwright/Core/PageAssertions.cs
+++ b/src/Playwright/Core/PageAssertions.cs
@@ -58,7 +58,7 @@ internal class PageAssertions : AssertionsBase, IPageAssertions
         ExpectImplAsync("to.have.title", ExpectedRegex(titleOrRegExp, new() { NormalizeWhiteSpace = true }), titleOrRegExp, "Page title expected to be", ConvertToFrameExpectOptions(options));
 
     public Task ToHaveURLAsync(string urlOrRegExp, PageAssertionsToHaveURLOptions options = null) =>
-        ExpectImplAsync("to.have.url", new ExpectedTextValue() { String = URLMatch.JoinWithBaseURL(_page.Context.Options.BaseURL, urlOrRegExp), IgnoreCase = options?.IgnoreCase }, urlOrRegExp, "Page URL expected to be", ConvertToFrameExpectOptions(options));
+        ExpectImplAsync("to.have.url", new ExpectedTextValue() { String = URLMatch.ConstructURLBasedOnBaseURL(_page.Context.Options.BaseURL, urlOrRegExp), IgnoreCase = options?.IgnoreCase }, urlOrRegExp, "Page URL expected to be", ConvertToFrameExpectOptions(options));
 
     public Task ToHaveURLAsync(Regex urlOrRegExp, PageAssertionsToHaveURLOptions options = null) =>
         ExpectImplAsync("to.have.url", ExpectedRegex(urlOrRegExp, new() { IgnoreCase = options?.IgnoreCase }), urlOrRegExp, "Page URL expected to match regex", ConvertToFrameExpectOptions(options));


### PR DESCRIPTION
Might affect Java as well.

Relates https://github.com/microsoft/playwright-python/issues/2686.