### PR TITLE
test: isolate test-projects from each-other

### DIFF
--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -9,18 +9,22 @@
   <Import Project="../Common/SignAssembly.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Playwright\Playwright.csproj" />
-    <ProjectReference Include="..\Playwright.MSTest\Playwright.MSTest.csproj" />
-    <ProjectReference Include="..\Playwright.NUnit\Playwright.NUnit.csproj" />
-    <ProjectReference Include="..\Playwright.Xunit\Playwright.Xunit.csproj" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    
+    <!-- MSTest -->
+    <ProjectReference Include="..\Playwright.MSTest\Playwright.MSTest.csproj" Condition="'$(TEST_MODE)' == 'mstest'" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" Condition="'$(TEST_MODE)' == 'mstest'" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" Condition="'$(TEST_MODE)' == 'mstest'" />
+    
+    <!-- NUnit -->
+    <ProjectReference Include="..\Playwright.NUnit\Playwright.NUnit.csproj" Condition="'$(TEST_MODE)' == 'nunit'" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" Condition="'$(TEST_MODE)' == 'nunit'" />
+    
+    <!-- xUnit -->
+    <ProjectReference Include="..\Playwright.Xunit\Playwright.Xunit.csproj" Condition="'$(TEST_MODE)' == 'xunit'" />
+    <PackageReference Include="xunit" Version="2.9.2" Condition="'$(TEST_MODE)' == 'xunit'" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" Condition="'$(TEST_MODE)' == 'xunit'" />
   </ItemGroup>
 </Project>

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -27,4 +27,9 @@
     <PackageReference Include="xunit" Version="2.9.2" Condition="'$(TEST_MODE)' == 'xunit'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" Condition="'$(TEST_MODE)' == 'xunit'" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="**/*.cs" />
+    <Compile Include="$(PWTEST_TEST_DIR)/*.cs" />
+  </ItemGroup>
 </Project>

--- a/src/Playwright.TestingHarnessTest/tests/baseTest.ts
+++ b/src/Playwright.TestingHarnessTest/tests/baseTest.ts
@@ -38,6 +38,7 @@ export const test = base.extend<{
           ...env,
           NODE_OPTIONS: undefined,
           TEST_MODE: testMode,
+          PWTEST_TEST_DIR: testDir,
         },
         stdio: 'pipe',
       });

--- a/src/Playwright.TestingHarnessTest/tests/baseTest.ts
+++ b/src/Playwright.TestingHarnessTest/tests/baseTest.ts
@@ -16,9 +16,11 @@ type RunResult = {
 }
 
 export const test = base.extend<{
+  testMode: 'nunit' | 'mstest' | 'xunit';
   runTest: (files: Record<string, string>, command: string, env?: NodeJS.ProcessEnv) => Promise<RunResult>;
 }>({
-  runTest: async ({ }, use, testInfo) => {
+  testMode: null,
+  runTest: async ({ testMode }, use, testInfo) => {
     const testResults: RunResult[] = [];
     await use(async (files, command, env) => {
       const testDir = testInfo.outputPath();
@@ -34,7 +36,8 @@ export const test = base.extend<{
         env: {
           ...process.env,
           ...env,
-          NODE_OPTIONS: undefined
+          NODE_OPTIONS: undefined,
+          TEST_MODE: testMode,
         },
         stdio: 'pipe',
       });

--- a/src/Playwright.TestingHarnessTest/tests/mstest/basic.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/mstest/basic.spec.ts
@@ -26,6 +26,8 @@ import http from 'http';
 import { test, expect } from '../baseTest';
 import httpProxy from 'http-proxy';
 
+test.use({ testMode: 'mstest' });
+
 test('should be able to forward DEBUG=pw:api env var', async ({ runTest }) => {
   const result = await runTest({
     'ExampleTests.cs': `

--- a/src/Playwright.TestingHarnessTest/tests/nunit/basic.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/nunit/basic.spec.ts
@@ -26,6 +26,8 @@ import http from 'http';
 import { test, expect } from '../baseTest';
 import httpProxy from 'http-proxy';
 
+test.use({ testMode: 'nunit' });
+
 test('should be able to forward DEBUG=pw:api env var', async ({ runTest }) => {
   const result = await runTest({
     'ExampleTests.cs': `

--- a/src/Playwright.TestingHarnessTest/tests/xunit/basic.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/xunit/basic.spec.ts
@@ -26,6 +26,8 @@ import http from 'http';
 import { test, expect } from '../baseTest';
 import httpProxy from 'http-proxy';
 
+test.use({ testMode: 'xunit' });
+
 test('should be able to forward DEBUG=pw:api env var', async ({ runTest }) => {
   const result = await runTest({
     'ExampleTests.cs': `


### PR DESCRIPTION
This has two benefits:

a) that the test-projects don't have other test frameworks loaded
b) helps us to fix namespace clashes between test frameworks (esp. xunit2 vs xunit3)

= 4.6min -> 3.6min