### PR TITLE
When adding content items via targets, provide the NuGetPackageId metadata

### DIFF
--- a/src/Playwright/build/Microsoft.Playwright.targets
+++ b/src/Playwright/build/Microsoft.Playwright.targets
@@ -42,6 +42,7 @@
     </ItemGroup>
     <ItemGroup>
       <Content Include="@(_PlaywrightCopyItems)">
+        <NuGetPackageId>Microsoft.Playwright</NuGetPackageId>
         <Link>.playwright\%(_PlaywrightCopyItems.PlaywrightFolder)%(RecursiveDir)%(FileName)%(Extension)</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <PublishState>Included</PublishState>
@@ -49,6 +50,7 @@
         <Pack>false</Pack>
       </Content>
       <Content Include="$(MSBuildThisFileDirectory)playwright.ps1">
+        <NuGetPackageId>Microsoft.Playwright</NuGetPackageId>
         <Link>playwright.ps1</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <PublishState>Included</PublishState>


### PR DESCRIPTION
This aligns the items with the built-in mechanism in nuget for providing content items, and enables reliable detection of these items in consuming projects.

Fixes #3108