### PR TITLE
chore: migrate from TimeoutAttribute to CancelAfterAttribute

### DIFF
--- a/src/Playwright.Tests/BrowserContextBasicTests.cs
+++ b/src/Playwright.Tests/BrowserContextBasicTests.cs
@@ -235,7 +235,7 @@ public class BrowserContextBasicTests : BrowserTestEx
         CollectionAssert.Contains(context.Pages, second);
     }
 
-    [PlaywrightTest("browsercontext-basic.spec.ts", "BrowserContext.pages()", "should close all belonging pages once closing context")]
+    [PlaywrightTest("browsercontext-basic.spec.ts", "should close all belonging pages once closing context")]
     public async Task ShouldCloseAllBelongingPagesOnceClosingContext()
     {
         await using var context = await Browser.NewContextAsync();

--- a/src/Playwright.Tests/ElementHandleConvenienceTests.cs
+++ b/src/Playwright.Tests/ElementHandleConvenienceTests.cs
@@ -94,7 +94,7 @@ public class ElementHandleConvenienceTests : PageTestEx
         Assert.AreEqual("Text,\nmore text", await Page.TextContentAsync("#outer"));
     }
 
-    [PlaywrightTest("elementhandle-convenience.spec.ts", "Page.dispatchEvent(click)", "innerText should be atomic")]
+    [PlaywrightTest("elementhandle-convenience.spec.ts", "innerText should be atomic")]
     public async Task InnerTextShouldBeAtomic()
     {
         const string createDummySelector = @"({
@@ -120,7 +120,7 @@ public class ElementHandleConvenienceTests : PageTestEx
         Assert.AreEqual("modified", await Page.EvaluateAsync<string>("() => document.querySelector('div').textContent"));
     }
 
-    [PlaywrightTest("elementhandle-convenience.spec.ts", "Page.dispatchEvent(click)", "innerHTML should be atomic")]
+    [PlaywrightTest("elementhandle-convenience.spec.ts", "innerHTML should be atomic")]
     public async Task InnerHtmlShouldBeAtomic()
     {
         const string createDummySelector = @"({
@@ -146,7 +146,7 @@ public class ElementHandleConvenienceTests : PageTestEx
         Assert.AreEqual("modified", await Page.EvaluateAsync<string>("() => document.querySelector('div').textContent"));
     }
 
-    [PlaywrightTest("elementhandle-convenience.spec.ts", "Page.dispatchEvent(click)", "getAttribute should be atomic")]
+    [PlaywrightTest("elementhandle-convenience.spec.ts", "getAttribute should be atomic")]
     public async Task GetAttributeShouldBeAtomic()
     {
         const string createDummySelector = @"({

--- a/src/Playwright.Tests/PageDispatchEventTests.cs
+++ b/src/Playwright.Tests/PageDispatchEventTests.cs
@@ -160,7 +160,7 @@ public class PageDispatchEventTests : PageTestEx
         Assert.True(await Page.EvaluateAsync<bool>("() => window['_clicked']"));
     }
 
-    [PlaywrightTest("page-dispatchevent.spec.ts", "Page.dispatchEvent(drag)", "should dispatch drag drop events")]
+    [PlaywrightTest("page-dispatchevent.spec.ts", "should dispatch drag drop events")]
     [Skip(SkipAttribute.Targets.Webkit)]
     public async Task ShouldDispatchDragDropEvents()
     {
@@ -176,7 +176,7 @@ public class PageDispatchEventTests : PageTestEx
             }", new { source, target }));
     }
 
-    [PlaywrightTest("page-dispatchevent.spec.ts", "Page.dispatchEvent(drag)", "should dispatch drag drop events")]
+    [PlaywrightTest("page-dispatchevent.spec.ts", "should dispatch drag drop events")]
     [Skip(SkipAttribute.Targets.Webkit)]
     public async Task ElementHandleShouldDispatchDragDropEvents()
     {

--- a/src/Playwright.Tests/PageEvaluateTests.cs
+++ b/src/Playwright.Tests/PageEvaluateTests.cs
@@ -709,7 +709,8 @@ public class PageEvaluateTests : PageTestEx
         Test = 1
     }
 
-    [PlaywrightTest(Description = "https://github.com/microsoft/playwright-dotnet/issues/1706")]
+    // See https://github.com/microsoft/playwright-dotnet/issues/1706
+    [PlaywrightTest]
     public async Task ShouldNotReturnDisposedJsonElement()
     {
         var result = await Page.EvaluateAsync<JsonElement?>("()=> [{a:1,b:2},{a:1,b:2}]");

--- a/src/Playwright.Tests/PageNetworkRequestTest.cs
+++ b/src/Playwright.Tests/PageNetworkRequestTest.cs
@@ -232,7 +232,7 @@ public class PageNetworkRequestTest : PageTestEx
         Assert.False(requests["style.css"].IsNavigationRequest);
     }
 
-    [PlaywrightTest("page-network-request.spec.ts", "Request.isNavigationRequest", "should return navigation bit when navigating to image")]
+    [PlaywrightTest("page-network-request.spec.ts", "should return navigation bit when navigating to image")]
     public async Task ShouldReturnNavigationBitWhenNavigatingToImage()
     {
         var requests = new List<IRequest>();

--- a/src/Playwright.Tests/PageWaitForNavigationTests.cs
+++ b/src/Playwright.Tests/PageWaitForNavigationTests.cs
@@ -307,7 +307,7 @@ public class PageWaitForNavigationTests : PageTestEx
     }
 
     [PlaywrightTest]
-    [CancelAfter(45_000)]
+    [CancelAfter(TestConstants.SlowTestTimeout)]
     public async Task ShouldHaveADefaultTimeout()
     {
         await Page.GotoAsync(Server.Prefix + "/frames/one-frame.html");
@@ -315,7 +315,6 @@ public class PageWaitForNavigationTests : PageTestEx
     }
 
     [PlaywrightTest]
-    [CancelAfter(5_000)]
     public async Task ShouldTakeTimeoutIntoAccount()
     {
         await Page.GotoAsync(Server.Prefix + "/frames/one-frame.html");

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -191,7 +191,6 @@ public class ScreencastTests : BrowserTestEx
 
 
     [PlaywrightTest("screencast.spec.ts", "video.path()/saveAs() does not hang immediately after launchPersistentContext and context.close()")]
-    [CancelAfter(30_000)]
     public async Task VideoPathSaveAsDoesNotHangImmediatelyAfterLaunchPersistentContextAndContextClose()
     {
         using var userDirectory = new TempDirectory();

--- a/src/Playwright.Tests/TestConstants.cs
+++ b/src/Playwright.Tests/TestConstants.cs
@@ -25,9 +25,6 @@
 
 using System.Runtime.InteropServices;
 
-[assembly: NUnit.Framework.Timeout(Microsoft.Playwright.Tests.TestConstants.DefaultTestTimeout)]
-[assembly: NUnit.Framework.Parallelizable(NUnit.Framework.ParallelScope.Fixtures)]
-
 namespace Microsoft.Playwright.Tests;
 
 internal static class TestConstants


### PR DESCRIPTION
This only affects our internal tests.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3118