### PR TITLE
chore: use manual TimeoutAttribute instead of CancelAfter attribute

### DIFF
--- a/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
+++ b/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
@@ -36,12 +36,22 @@ namespace Microsoft.Playwright.Tests;
 /// Enables decorating test facts with information about the corresponding test in the upstream repository.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-public class PlaywrightTestAttribute : TestAttribute, IApplyToContext, IApplyToTest, IWrapSetUpTearDown
+public class PlaywrightTestAttribute : TestAttribute, IWrapSetUpTearDown
 {
-    private readonly CancelAfterAttribute _cancelAfterAttribute = new(TestConstants.DefaultTestTimeout);
+    private readonly int? _timeout;
 
     public PlaywrightTestAttribute()
     {
+    }
+
+    public PlaywrightTestAttribute(int timeout) : this()
+    {
+        _timeout = timeout;
+    }
+
+    public PlaywrightTestAttribute(string fileName, string nameOfTest, int timeout) : this(fileName, nameOfTest)
+    {
+        _timeout = timeout;
     }
 
     /// <summary>
@@ -61,11 +71,6 @@ public class PlaywrightTestAttribute : TestAttribute, IApplyToContext, IApplyToT
     public string FileName { get; }
 
     /// <summary>
-    /// Returns the trimmed file name.
-    /// </summary>
-    public string TrimmedName => FileName.Substring(0, FileName.IndexOf('.'));
-
-    /// <summary>
     /// The name of the test, the decorated code is based on.
     /// </summary>
     public string TestName { get; }
@@ -75,22 +80,6 @@ public class PlaywrightTestAttribute : TestAttribute, IApplyToContext, IApplyToT
     /// </summary>
     public string Describe { get; }
 
-    public void ApplyToContext(TestExecutionContext context)
-    {
-        if (context.TestCaseTimeout == 0)
-        {
-            (_cancelAfterAttribute as IApplyToContext).ApplyToContext(context);
-        }
-    }
-
-    public new void ApplyToTest(Test test)
-    {
-        base.ApplyToTest(test);
-        if (TestExecutionContext.CurrentContext.TestCaseTimeout == 0)
-        {
-            _cancelAfterAttribute.ApplyToTest(test);
-        }
-    }
     /// <summary>
     /// Wraps the current test command in a <see cref="UnobservedTaskExceptionCommand"/>.
     /// </summary>
@@ -98,6 +87,7 @@ public class PlaywrightTestAttribute : TestAttribute, IApplyToContext, IApplyToT
     /// <returns>the wrapped test command</returns>
     public TestCommand Wrap(TestCommand command)
     {
+        command = new TimeoutCommand(command, _timeout ?? TestConstants.DefaultTestTimeout);
         if (Environment.GetEnvironmentVariable("CI") != null)
         {
             command = new RetryCommand(command, 3);
@@ -203,6 +193,77 @@ public class PlaywrightTestAttribute : TestAttribute, IApplyToContext, IApplyToT
         private void UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
         {
             _unobservedTaskExceptions.Add(e.Exception);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="TimeoutCommand"/> creates a timer in order to cancel
+    /// a test if it exceeds a specified time and adjusts
+    /// the test result if it did time out.
+    /// </summary>
+    public class TimeoutCommand : BeforeAndAfterTestCommand
+    {
+        private readonly int _timeout;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutCommand"/> class.
+        /// </summary>
+        /// <param name="innerCommand">The inner command</param>
+        /// <param name="timeout">Timeout value</param>
+        /// <param name="debugger">An <see cref="IDebugger" /> instance</param>
+        internal TimeoutCommand(TestCommand innerCommand, int timeout) : base(innerCommand)
+        {
+            _timeout = timeout;
+        }
+
+        /// <summary>
+        /// Runs the test, saving a TestResult in the supplied TestExecutionContext.
+        /// </summary>
+        /// <param name="context">The context in which the test should run.</param>
+        /// <returns>A TestResult</returns>
+        public override TestResult Execute(TestExecutionContext context)
+        {
+            try
+            {
+                using (new TestExecutionContext.IsolatedContext())
+                {
+                    var testExecution = Task.Run(() => innerCommand.Execute(TestExecutionContext.CurrentContext));
+                    var timedOut = Task.WaitAny([testExecution], _timeout) == -1;
+
+                    if (timedOut)
+                    {
+                        context.CurrentResult.SetResult(
+                            ResultState.Failure,
+                            $"Test exceeded Timeout value of {_timeout}ms");
+                        // // When the timeout is reached the TearDown methods are not called. This is a best-effort
+                        // // attempt to call them and close the browser / http server.
+                        // foreach (var method in new string[] { "WorkerTeardown", "BrowserTearDown" })
+                        // {
+                        //     var methodFun = context.CurrentTest.Method.MethodInfo.DeclaringType
+                        //         .GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                        //     if (methodFun != null)
+                        //     {
+                        //         var res = methodFun.Invoke(context.TestObject, null);
+                        //         if (res is Task task)
+                        //         {
+                        //             Console.WriteLine($"Waiting for {method} task to complete");
+                        //             task.GetAwaiter().GetResult();
+                        //         }
+                        //     }
+                        // }
+                    }
+                    else
+                    {
+                        context.CurrentResult = testExecution.GetAwaiter().GetResult();
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                context.CurrentResult.RecordException(exception, FailureSite.Test);
+            }
+
+            return context.CurrentResult;
         }
     }
 }

--- a/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
+++ b/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
@@ -111,7 +111,7 @@ public class PlaywrightTestAttribute : TestAttribute, IWrapSetUpTearDown
                 try
                 {
                     innerCommand.Execute(context);
-                    if (context.CurrentResult.ResultState == ResultState.Success)
+                    if (context.CurrentResult.ResultState == ResultState.Success || context.CurrentResult.ResultState == ResultState.Skipped || context.CurrentResult.ResultState == ResultState.Ignored)
                     {
                         isPassed = true;
                         break;

--- a/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
+++ b/src/Playwright.Tests/Attributes/PlaywrightTestAttribute.cs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+using System.Reflection;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
@@ -235,22 +236,22 @@ public class PlaywrightTestAttribute : TestAttribute, IWrapSetUpTearDown
                         context.CurrentResult.SetResult(
                             ResultState.Failure,
                             $"Test exceeded Timeout value of {_timeout}ms");
-                        // // When the timeout is reached the TearDown methods are not called. This is a best-effort
-                        // // attempt to call them and close the browser / http server.
-                        // foreach (var method in new string[] { "WorkerTeardown", "BrowserTearDown" })
-                        // {
-                        //     var methodFun = context.CurrentTest.Method.MethodInfo.DeclaringType
-                        //         .GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                        //     if (methodFun != null)
-                        //     {
-                        //         var res = methodFun.Invoke(context.TestObject, null);
-                        //         if (res is Task task)
-                        //         {
-                        //             Console.WriteLine($"Waiting for {method} task to complete");
-                        //             task.GetAwaiter().GetResult();
-                        //         }
-                        //     }
-                        // }
+                        // When the timeout is reached the TearDown methods are not called. This is a best-effort
+                        // attempt to call them and close the browser / http server.
+                        foreach (var method in new string[] { "WorkerTeardown", "BrowserTearDown" })
+                        {
+                            var methodFun = context.CurrentTest.Method.MethodInfo.DeclaringType
+                                .GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                            if (methodFun != null)
+                            {
+                                var res = methodFun.Invoke(context.TestObject, null);
+                                if (res is Task task)
+                                {
+                                    Console.WriteLine($"Waiting for {method} task to complete");
+                                    task.GetAwaiter().GetResult();
+                                }
+                            }
+                        }
                     }
                     else
                     {

--- a/src/Playwright.Tests/BaseTests/HttpService.cs
+++ b/src/Playwright.Tests/BaseTests/HttpService.cs
@@ -39,8 +39,8 @@ public class HttpService : IWorkerService
             var assetDir = Path.Combine(TestUtils.FindParentDirectory("Playwright.Tests"), "assets");
             var http = new HttpService
             {
-                Server = SimpleServer.Create(8907 + workerIndex * 2, assetDir),
-                HttpsServer = SimpleServer.CreateHttps(8907 + workerIndex * 2 + 1, assetDir)
+                Server = SimpleServer.Create(8907 + workerIndex * 4, assetDir),
+                HttpsServer = SimpleServer.CreateHttps(8907 + workerIndex * 4 + 1, assetDir)
             };
             await Task.WhenAll(http.Server.StartAsync(TestContext.CurrentContext.CancellationToken), http.HttpsServer.StartAsync(TestContext.CurrentContext.CancellationToken));
             return http;

--- a/src/Playwright.Tests/BrowserTypeConnectTests.cs
+++ b/src/Playwright.Tests/BrowserTypeConnectTests.cs
@@ -451,8 +451,7 @@ public class BrowserTypeConnectTests : PlaywrightTestEx
         }
     }
 
-    [PlaywrightTest("browsertype-connect.spec.ts", "should upload large file")]
-    [CancelAfter(TestConstants.SlowTestTimeout)]
+    [PlaywrightTest("browsertype-connect.spec.ts", "should upload large file", TestConstants.SlowTestTimeout)]
     public async Task ShouldUploadLargeFile()
     {
         var browser = await BrowserType.ConnectAsync(_remoteServer.WSEndpoint);

--- a/src/Playwright.Tests/ClientCertficatesTests.cs
+++ b/src/Playwright.Tests/ClientCertficatesTests.cs
@@ -103,11 +103,6 @@ public class ClientCertificatesTests : BrowserTestEx
         {
             Assert.Ignore("WebKit on macOS doesn't proxy localhost requests");
         }
-        if (TestConstants.IsChromium && TestConstants.IsWindows)
-        {
-            // TODO: Remove after https://github.com/microsoft/playwright/issues/17252 is fixed.
-            Assert.Ignore("Chromium on Windows doesn't proxy localhost requests");
-        }
     }
 
     [PlaywrightTest("", "")]

--- a/src/Playwright.Tests/PageSetInputFilesTests.cs
+++ b/src/Playwright.Tests/PageSetInputFilesTests.cs
@@ -352,8 +352,7 @@ public class PageSetInputFilesTests : PageTestEx
         Assert.True(fileChooser.IsMultiple);
     }
 
-    [PlaywrightTest("page-set-input-files.spec.ts", "should upload large file")]
-    [CancelAfter(TestConstants.SlowTestTimeout)]
+    [PlaywrightTest("page-set-input-files.spec.ts", "should upload large file", TestConstants.SlowTestTimeout)]
     public async Task ShouldUploadLargeFile()
     {
         await Page.GotoAsync(Server.Prefix + "/input/fileupload.html");

--- a/src/Playwright.Tests/PageWaitForNavigationTests.cs
+++ b/src/Playwright.Tests/PageWaitForNavigationTests.cs
@@ -306,8 +306,7 @@ public class PageWaitForNavigationTests : PageTestEx
         StringAssert.Contains("/frames/one-frame.html", Page.Url);
     }
 
-    [PlaywrightTest]
-    [CancelAfter(TestConstants.SlowTestTimeout)]
+    [PlaywrightTest(TestConstants.SlowTestTimeout)]
     public async Task ShouldHaveADefaultTimeout()
     {
         await Page.GotoAsync(Server.Prefix + "/frames/one-frame.html");

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -26,9 +26,9 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
What does it fix?

- When a test was infinitely hanging the test-runner was infinitely waiting as well and the test was not aborted. This ended up in a timeout on GHA.
- When a test was ending in a timeout we didn't retry it on CI. Ideally we retry timeouts. This was caused by the order of Commands, our custom RetryCommand was before the nunit TimeoutCommand.

Notes:

- CancelAfterAttribute [just cancels the CancellationToken](https://docs.nunit.org/articles/nunit/writing-tests/attributes/cancelafter.html) of a test, this is not what we want.
- TimeoutAttribute is [considered deprecated](https://github.com/nunit/nunit/blob/main/src/NUnitFramework/framework/Attributes/TimeoutAttribute.cs) because it does not cancel the thread anymore, it does just instead cancel the task (not underlying) and continues with the test execution. This is not ideal but the better fit for us.
- This PR essentially is a partial revert of https://github.com/microsoft/playwright-dotnet/pull/3119 + manual implementation of the TimeoutAttribute.
- In case of a timeout the worker does get teared down in a best-effort manner. The instance of the class stays the same and just the Worker instance switches, hence we need to call the teardown attributes manually.