### PR TITLE
chore: enable Microsoft.Testing.Platform for internal tests

### DIFF
--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -9,6 +9,9 @@
         <AssemblyName>Microsoft.Playwright.Tests</AssemblyName>
         <RootNamespace>Microsoft.Playwright.Tests</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
+        <OutputType>Exe</OutputType>
+        <EnableNUnitRunner>true</EnableNUnitRunner>
+        <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
     <Import Project="../Common/SignAssembly.props" />
     <ItemGroup>


### PR DESCRIPTION
Interestingly `Command + C` does not work aka. no way of aborting the test run and there is no visible live output when running

    dotnet test -f net8.0 ./src/Playwright.Tests/Playwright.Tests.csproj --logger:"console;verbosity=detailed"

Looks related to `TestingPlatformDotnetTestSupport` when removing this and its using vstest it seems to work.