### PR TITLE
fix: CallLog formatting

### DIFF
--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -99,7 +99,7 @@ internal class Connection : IDisposable
         {
             return string.Empty;
         }
-        return "\nCall log:\n  - " + string.Join("\n  - ", log);
+        return "\nCall log:\n" + string.Join("\n", log);
     }
 
     public void Dispose()


### PR DESCRIPTION
Looks like this was changed [here](https://github.com/microsoft/playwright/commit/2a3d67195dff6ece12bd36aab970a1fc95776998#diff-b6f15e1e595e78791af29171502861070168d93fac02cdd83fd8d99d535e9540L137). Fixes https://github.com/microsoft/playwright-dotnet/issues/3132

Before:

```
➜  Playwright.Examples git:(fix-calllog-formatting) ✗ dotnet run Program.cs
Unhandled exception. System.TimeoutException: Timeout 1000ms exceeded.
Call log:
  -   - waiting for Locator("textarea")
  -     - locator resolved to <textarea disabled></textarea>
  -     - fill("12")
  -   - attempting fill action
  -     2 × waiting for element to be visible, enabled and editable
  -       - element is not enabled
  -     - retrying fill action
  -     - waiting 20ms
  -     2 × waiting for element to be visible, enabled and editable
  -       - element is not enabled
  -     - retrying fill action
  -       - waiting 100ms
  -     2 × waiting for element to be visible, enabled and editable
  -       - element is not enabled
  -     - retrying fill action
  -       - waiting 500ms
   at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Transport/Connection.cs:line 206
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Transport/Connection.cs:line 535
   at Program.<Main>$(String[] args) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Examples/Program.cs:line 31
   at Program.<Main>$(String[] args) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Examples/Program.cs:line 31
   at Program.<Main>(String[] args)
➜  Playwright.Examples git:(main) ✗ 
```

After:

```
➜  Playwright.Examples git:(fix-calllog-formatting) ✗ dotnet run Program.cs
Unhandled exception. System.TimeoutException: Timeout 1000ms exceeded.
Call log:
  - waiting for Locator("textarea")
    - locator resolved to <textarea disabled></textarea>
    - fill("12")
  - attempting fill action
    2 × waiting for element to be visible, enabled and editable
      - element is not enabled
    - retrying fill action
    - waiting 20ms
    2 × waiting for element to be visible, enabled and editable
      - element is not enabled
    - retrying fill action
      - waiting 100ms
    2 × waiting for element to be visible, enabled and editable
      - element is not enabled
    - retrying fill action
      - waiting 500ms
   at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Transport/Connection.cs:line 206
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright/Transport/Connection.cs:line 535
   at Program.<Main>$(String[] args) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Examples/Program.cs:line 31
   at Program.<Main>$(String[] args) in /Users/maxschmitt/Developer/playwright-dotnet/src/Playwright.Examples/Program.cs:line 31
   at Program.<Main>(String[] args)
```
