### PR TITLE
fix: CookiesAsync regression accepting null

### DIFF
--- a/src/Playwright.Tests/BrowserContextCookiesTests.cs
+++ b/src/Playwright.Tests/BrowserContextCookiesTests.cs
@@ -199,4 +199,37 @@ public class BrowserContextCookiesTests : PageTestEx
         Assert.IsTrue(cookie.Secure);
         Assert.AreEqual(DefaultSameSiteCookieValue, cookie.SameSite);
     }
+
+    [PlaywrightTest("browsercontext-cookies.spec.ts", "should get cookies from single urls")]
+    public async Task ShouldGetCookiesFromSingleUrl()
+    {
+        await Context.AddCookiesAsync(
+        [
+                new Cookie
+                {
+                    Url = "https://foo.com",
+                    Name = "doggo",
+                    Value = "woofs"
+                },
+            ]);
+
+        void ValidateCookies(IReadOnlyList<BrowserContextCookiesResult> cookies)
+        {
+            Assert.AreEqual(1, cookies.Count);
+            var cookie = cookies[0];
+            Assert.AreEqual("doggo", cookie.Name);
+            Assert.AreEqual("woofs", cookie.Value);
+            Assert.AreEqual("foo.com", cookie.Domain);
+            Assert.AreEqual("/", cookie.Path);
+            Assert.AreEqual(cookie.Expires, -1);
+            Assert.IsFalse(cookie.HttpOnly);
+            Assert.IsTrue(cookie.Secure);
+            Assert.AreEqual(DefaultSameSiteCookieValue, cookie.SameSite);
+        }
+
+        ValidateCookies(await Context.CookiesAsync("https://foo.com"));
+        ValidateCookies(await Context.CookiesAsync(null as string));
+        ValidateCookies(await Context.CookiesAsync(null as string[]));
+        ValidateCookies(await Context.CookiesAsync([]));
+    }
 }

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -379,14 +379,14 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     public Task<IReadOnlyList<BrowserContextCookiesResult>> CookiesAsync() => CookiesAsync(Array.Empty<string>());
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public Task<IReadOnlyList<BrowserContextCookiesResult>> CookiesAsync(string url) => CookiesAsync(new string[] { url });
+    public Task<IReadOnlyList<BrowserContextCookiesResult>> CookiesAsync(string url) => CookiesAsync(string.IsNullOrEmpty(url) ? null : [url]);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<BrowserContextCookiesResult>> CookiesAsync(IEnumerable<string> urls) => (await SendMessageToServerAsync(
             "cookies",
             new Dictionary<string, object>
             {
-                ["urls"] = urls.ToArray(),
+                ["urls"] = urls ?? [],
             }).ConfigureAwait(false))?.GetProperty("cookies").ToObject<IReadOnlyList<BrowserContextCookiesResult>>();
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
We used to accept `null` before https://github.com/microsoft/playwright-dotnet/pull/3145 - this was also aligned with which types we accepted. A `string` can be null or a `string[]` can be null. This PR adds back the null checks / falls back to an empty array so it doesn't crash.

https://github.com/microsoft/playwright-dotnet/issues/3161