### PR TITLE
chore: re-render transport types

### DIFF
--- a/src/Playwright/Transport/Protocol/Generated/APIRequestContextInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/APIRequestContextInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class APIRequestContextInitializer
 {
     [JsonPropertyName("tracing")]
-    public Core.Tracing Tracing { get; set; }
+    public Core.Tracing Tracing { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/APIResponse.cs
+++ b/src/Playwright/Transport/Protocol/Generated/APIResponse.cs
@@ -30,17 +30,17 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class APIResponse
 {
     [JsonPropertyName("fetchUid")]
-    public string FetchUid { get; set; }
+    public string FetchUid { get; set; } = null!;
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     [JsonPropertyName("status")]
     public int Status { get; set; }
 
     [JsonPropertyName("statusText")]
-    public string StatusText { get; set; }
+    public string StatusText { get; set; } = null!;
 
     [JsonPropertyName("headers")]
-    public List<NameValue> Headers { get; set; }
+    public List<NameValue> Headers { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidDeviceInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidDeviceInitializer.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class AndroidDeviceInitializer : EventTargetInitializer
 {
     [JsonPropertyName("model")]
-    public string Model { get; set; }
+    public string Model { get; set; } = null!;
 
     [JsonPropertyName("serial")]
-    public string Serial { get; set; }
+    public string Serial { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidElementInfo.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidElementInfo.cs
@@ -30,25 +30,25 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class AndroidElementInfo
 {
     [JsonPropertyName("children")]
-    public List<AndroidElementInfo> Children { get; set; }
+    public List<AndroidElementInfo> Children { get; set; } = null!;
 
     [JsonPropertyName("clazz")]
-    public string Clazz { get; set; }
+    public string Clazz { get; set; } = null!;
 
     [JsonPropertyName("desc")]
-    public string Desc { get; set; }
+    public string Desc { get; set; } = null!;
 
     [JsonPropertyName("res")]
-    public string Res { get; set; }
+    public string Res { get; set; } = null!;
 
     [JsonPropertyName("pkg")]
-    public string Pkg { get; set; }
+    public string Pkg { get; set; } = null!;
 
     [JsonPropertyName("text")]
-    public string Text { get; set; }
+    public string Text { get; set; } = null!;
 
     [JsonPropertyName("bounds")]
-    public Rect Bounds { get; set; }
+    public Rect Bounds { get; set; } = null!;
 
     [JsonPropertyName("checkable")]
     public bool Checkable { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidSelector.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidSelector.cs
@@ -35,7 +35,7 @@ internal class AndroidSelector
     public bool? Checked { get; set; }
 
     [JsonPropertyName("clazz")]
-    public string Clazz { get; set; }
+    public string Clazz { get; set; } = null!;
 
     [JsonPropertyName("clickable")]
     public bool? Clickable { get; set; }
@@ -44,7 +44,7 @@ internal class AndroidSelector
     public int? Depth { get; set; }
 
     [JsonPropertyName("desc")]
-    public string Desc { get; set; }
+    public string Desc { get; set; } = null!;
 
     [JsonPropertyName("enabled")]
     public bool? Enabled { get; set; }
@@ -56,19 +56,19 @@ internal class AndroidSelector
     public bool? Focused { get; set; }
 
     [JsonPropertyName("hasChild")]
-    public AndroidSelectorHasChild HasChild { get; set; }
+    public AndroidSelectorHasChild HasChild { get; set; } = null!;
 
     [JsonPropertyName("hasDescendant")]
-    public AndroidSelectorHasDescendant HasDescendant { get; set; }
+    public AndroidSelectorHasDescendant HasDescendant { get; set; } = null!;
 
     [JsonPropertyName("longClickable")]
     public bool? LongClickable { get; set; }
 
     [JsonPropertyName("pkg")]
-    public string Pkg { get; set; }
+    public string Pkg { get; set; } = null!;
 
     [JsonPropertyName("res")]
-    public string Res { get; set; }
+    public string Res { get; set; } = null!;
 
     [JsonPropertyName("scrollable")]
     public bool? Scrollable { get; set; }
@@ -77,5 +77,5 @@ internal class AndroidSelector
     public bool? Selected { get; set; }
 
     [JsonPropertyName("text")]
-    public string Text { get; set; }
+    public string Text { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidSelectorHasChild.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidSelectorHasChild.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class AndroidSelectorHasChild
 {
     [JsonPropertyName("selector")]
-    public AndroidSelector Selector { get; set; }
+    public AndroidSelector Selector { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidSelectorHasDescendant.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidSelectorHasDescendant.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class AndroidSelectorHasDescendant
 {
     [JsonPropertyName("selector")]
-    public AndroidSelector Selector { get; set; }
+    public AndroidSelector Selector { get; set; } = null!;
 
     [JsonPropertyName("maxDepth")]
     public int? MaxDepth { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidWebView.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidWebView.cs
@@ -32,8 +32,8 @@ internal class AndroidWebView
     public int Pid { get; set; }
 
     [JsonPropertyName("pkg")]
-    public string Pkg { get; set; }
+    public string Pkg { get; set; } = null!;
 
     [JsonPropertyName("socketName")]
-    public string SocketName { get; set; }
+    public string SocketName { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/ArtifactInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ArtifactInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class ArtifactInitializer
 {
     [JsonPropertyName("absolutePath")]
-    public string AbsolutePath { get; set; }
+    public string AbsolutePath { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/BindingCallInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BindingCallInitializer.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class BindingCallInitializer
 {
     [JsonPropertyName("frame")]
-    public Core.Frame Frame { get; set; }
+    public Core.Frame Frame { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("args")]
-    public List<System.Text.Json.JsonElement> Args { get; set; }
+    public List<System.Text.Json.JsonElement> Args { get; set; } = null!;
 
     [JsonPropertyName("handle")]
-    public Core.JSHandle Handle { get; set; }
+    public Core.JSHandle Handle { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/BrowserContextInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BrowserContextInitializer.cs
@@ -32,8 +32,8 @@ internal class BrowserContextInitializer : EventTargetInitializer
     public bool IsChromium { get; set; }
 
     [JsonPropertyName("requestContext")]
-    public Core.APIRequestContext RequestContext { get; set; }
+    public Core.APIRequestContext RequestContext { get; set; } = null!;
 
     [JsonPropertyName("tracing")]
-    public Core.Tracing Tracing { get; set; }
+    public Core.Tracing Tracing { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/BrowserInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BrowserInitializer.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class BrowserInitializer
 {
     [JsonPropertyName("version")]
-    public string Version { get; set; }
+    public string Version { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/BrowserTypeInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BrowserTypeInitializer.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class BrowserTypeInitializer
 {
     [JsonPropertyName("executablePath")]
-    public string ExecutablePath { get; set; }
+    public string ExecutablePath { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/ClientSideCallMetadata.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ClientSideCallMetadata.cs
@@ -33,5 +33,5 @@ internal class ClientSideCallMetadata
     public int Id { get; set; }
 
     [JsonPropertyName("stack")]
-    public List<StackFrame> Stack { get; set; }
+    public List<StackFrame> Stack { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/DialogInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/DialogInitializer.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class DialogInitializer
 {
     [JsonPropertyName("page")]
-    public Core.Page Page { get; set; }
+    public Core.Page Page { get; set; } = null!;
 
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 
     [JsonPropertyName("message")]
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 
     [JsonPropertyName("defaultValue")]
-    public string DefaultValue { get; set; }
+    public string DefaultValue { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/ElectronApplicationInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ElectronApplicationInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class ElectronApplicationInitializer : EventTargetInitializer
 {
     [JsonPropertyName("context")]
-    public Core.BrowserContext Context { get; set; }
+    public Core.BrowserContext Context { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/ExpectedTextValue.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ExpectedTextValue.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class ExpectedTextValue
 {
     [JsonPropertyName("string")]
-    public string String { get; set; }
+    public string String { get; set; } = null!;
 
     [JsonPropertyName("regexSource")]
-    public string RegexSource { get; set; }
+    public string RegexSource { get; set; } = null!;
 
     [JsonPropertyName("regexFlags")]
-    public string RegexFlags { get; set; }
+    public string RegexFlags { get; set; } = null!;
 
     [JsonPropertyName("matchSubstring")]
     public bool? MatchSubstring { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/FormField.cs
+++ b/src/Playwright/Transport/Protocol/Generated/FormField.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class FormField
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("value")]
-    public string Value { get; set; }
+    public string Value { get; set; } = null!;
 
     [JsonPropertyName("file")]
-    public FormFieldFile File { get; set; }
+    public FormFieldFile File { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/FormFieldFile.cs
+++ b/src/Playwright/Transport/Protocol/Generated/FormFieldFile.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class FormFieldFile
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("mimeType")]
-    public string MimeType { get; set; }
+    public string MimeType { get; set; } = null!;
 
     [JsonPropertyName("buffer")]
-    public byte[] Buffer { get; set; }
+    public byte[] Buffer { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/FrameInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/FrameInitializer.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class FrameInitializer
 {
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("parentFrame")]
-    public Core.Frame ParentFrame { get; set; }
+    public Core.Frame ParentFrame { get; set; } = null!;
 
     [JsonPropertyName("loadStates")]
-    public List<WaitUntilState> LoadStates { get; set; }
+    public List<WaitUntilState> LoadStates { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/JSHandleInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/JSHandleInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class JSHandleInitializer
 {
     [JsonPropertyName("preview")]
-    public string Preview { get; set; }
+    public string Preview { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/LocalUtilsInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/LocalUtilsInitializer.cs
@@ -30,5 +30,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class LocalUtilsInitializer
 {
     [JsonPropertyName("deviceDescriptors")]
-    public List<DeviceDescriptorEntry> DeviceDescriptors { get; set; }
+    public List<DeviceDescriptorEntry> DeviceDescriptors { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/Metadata.cs
+++ b/src/Playwright/Transport/Protocol/Generated/Metadata.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class Metadata
 {
     [JsonPropertyName("location")]
-    public MetadataLocation Location { get; set; }
+    public MetadataLocation Location { get; set; } = null!;
 
     [JsonPropertyName("apiName")]
-    public string ApiName { get; set; }
+    public string ApiName { get; set; } = null!;
 
     [JsonPropertyName("internal")]
     public bool? Internal { get; set; }
 
     [JsonPropertyName("stepId")]
-    public string StepId { get; set; }
+    public string StepId { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/MetadataLocation.cs
+++ b/src/Playwright/Transport/Protocol/Generated/MetadataLocation.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class MetadataLocation
 {
     [JsonPropertyName("file")]
-    public string File { get; set; }
+    public string File { get; set; } = null!;
 
     [JsonPropertyName("line")]
     public int? Line { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/NameValue.cs
+++ b/src/Playwright/Transport/Protocol/Generated/NameValue.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class NameValue
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("value")]
-    public string Value { get; set; }
+    public string Value { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/PageInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/PageInitializer.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class PageInitializer : EventTargetInitializer
 {
     [JsonPropertyName("mainFrame")]
-    public Core.Frame MainFrame { get; set; }
+    public Core.Frame MainFrame { get; set; } = null!;
 
     [JsonPropertyName("viewportSize")]
-    public ViewportSize ViewportSize { get; set; }
+    public ViewportSize ViewportSize { get; set; } = null!;
 
     [JsonPropertyName("isClosed")]
     public bool IsClosed { get; set; }
 
     [JsonPropertyName("opener")]
-    public Core.Page Opener { get; set; }
+    public Core.Page Opener { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/PlaywrightInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/PlaywrightInitializer.cs
@@ -29,32 +29,32 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class PlaywrightInitializer
 {
     [JsonPropertyName("chromium")]
-    public Core.BrowserType Chromium { get; set; }
+    public Core.BrowserType Chromium { get; set; } = null!;
 
     [JsonPropertyName("firefox")]
-    public Core.BrowserType Firefox { get; set; }
+    public Core.BrowserType Firefox { get; set; } = null!;
 
     [JsonPropertyName("webkit")]
-    public Core.BrowserType Webkit { get; set; }
+    public Core.BrowserType Webkit { get; set; } = null!;
 
     [JsonPropertyName("bidiChromium")]
-    public Core.BrowserType BidiChromium { get; set; }
+    public Core.BrowserType BidiChromium { get; set; } = null!;
 
     [JsonPropertyName("bidiFirefox")]
-    public Core.BrowserType BidiFirefox { get; set; }
+    public Core.BrowserType BidiFirefox { get; set; } = null!;
 
     [JsonPropertyName("utils")]
-    public Core.LocalUtils Utils { get; set; }
+    public Core.LocalUtils Utils { get; set; } = null!;
 
     [JsonPropertyName("selectors")]
-    public Core.Selectors Selectors { get; set; }
+    public Core.Selectors Selectors { get; set; } = null!;
 
     [JsonPropertyName("preLaunchedBrowser")]
-    public Core.Browser PreLaunchedBrowser { get; set; }
+    public Core.Browser PreLaunchedBrowser { get; set; } = null!;
 
     [JsonPropertyName("preConnectedAndroidDevice")]
-    public Core.AndroidDevice PreConnectedAndroidDevice { get; set; }
+    public Core.AndroidDevice PreConnectedAndroidDevice { get; set; } = null!;
 
     [JsonPropertyName("socksSupport")]
-    public Core.SocksSupport SocksSupport { get; set; }
+    public Core.SocksSupport SocksSupport { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/RecordHarOptions.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RecordHarOptions.cs
@@ -29,20 +29,20 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class RecordHarOptions
 {
     [JsonPropertyName("path")]
-    public string Path { get; set; }
+    public string Path { get; set; } = null!;
 
     [JsonPropertyName("content")]
-    public string Content { get; set; }
+    public string Content { get; set; } = null!;
 
     [JsonPropertyName("mode")]
-    public string Mode { get; set; }
+    public string Mode { get; set; } = null!;
 
     [JsonPropertyName("urlGlob")]
-    public string UrlGlob { get; set; }
+    public string UrlGlob { get; set; } = null!;
 
     [JsonPropertyName("urlRegexSource")]
-    public string UrlRegexSource { get; set; }
+    public string UrlRegexSource { get; set; } = null!;
 
     [JsonPropertyName("urlRegexFlags")]
-    public string UrlRegexFlags { get; set; }
+    public string UrlRegexFlags { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/RecorderSource.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RecorderSource.cs
@@ -33,23 +33,23 @@ internal class RecorderSource
     public bool IsRecorded { get; set; }
 
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     [JsonPropertyName("label")]
-    public string Label { get; set; }
+    public string Label { get; set; } = null!;
 
     [JsonPropertyName("text")]
-    public string Text { get; set; }
+    public string Text { get; set; } = null!;
 
     [JsonPropertyName("language")]
-    public string Language { get; set; }
+    public string Language { get; set; } = null!;
 
     [JsonPropertyName("highlight")]
-    public List<RecorderSourceHighlight> Highlight { get; set; }
+    public List<RecorderSourceHighlight> Highlight { get; set; } = null!;
 
     [JsonPropertyName("revealLine")]
     public int? RevealLine { get; set; }
 
     [JsonPropertyName("group")]
-    public string Group { get; set; }
+    public string Group { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/RecorderSourceHighlight.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RecorderSourceHighlight.cs
@@ -32,5 +32,5 @@ internal class RecorderSourceHighlight
     public int Line { get; set; }
 
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/RemoteAddr.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RemoteAddr.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class RemoteAddr
 {
     [JsonPropertyName("ipAddress")]
-    public string IpAddress { get; set; }
+    public string IpAddress { get; set; } = null!;
 
     [JsonPropertyName("port")]
     public int Port { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RequestInitializer.cs
@@ -30,29 +30,29 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class RequestInitializer
 {
     [JsonPropertyName("frame")]
-    public Core.Frame Frame { get; set; }
+    public Core.Frame Frame { get; set; } = null!;
 
     [JsonPropertyName("serviceWorker")]
-    public Core.Worker ServiceWorker { get; set; }
+    public Core.Worker ServiceWorker { get; set; } = null!;
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     [JsonPropertyName("resourceType")]
-    public string ResourceType { get; set; }
+    public string ResourceType { get; set; } = null!;
 
     [JsonPropertyName("method")]
-    public string Method { get; set; }
+    public string Method { get; set; } = null!;
 
     [JsonPropertyName("postData")]
-    public byte[] PostData { get; set; }
+    public byte[] PostData { get; set; } = null!;
 
     [JsonPropertyName("headers")]
-    public List<NameValue> Headers { get; set; }
+    public List<NameValue> Headers { get; set; } = null!;
 
     [JsonPropertyName("isNavigationRequest")]
     public bool IsNavigationRequest { get; set; }
 
     [JsonPropertyName("redirectedFrom")]
-    public Core.Request RedirectedFrom { get; set; }
+    public Core.Request RedirectedFrom { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/ResponseInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ResponseInitializer.cs
@@ -30,22 +30,22 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class ResponseInitializer
 {
     [JsonPropertyName("request")]
-    public Core.Request Request { get; set; }
+    public Core.Request Request { get; set; } = null!;
 
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 
     [JsonPropertyName("status")]
     public int Status { get; set; }
 
     [JsonPropertyName("statusText")]
-    public string StatusText { get; set; }
+    public string StatusText { get; set; } = null!;
 
     [JsonPropertyName("headers")]
-    public List<NameValue> Headers { get; set; }
+    public List<NameValue> Headers { get; set; } = null!;
 
     [JsonPropertyName("timing")]
-    public RequestTimingResult Timing { get; set; }
+    public RequestTimingResult Timing { get; set; } = null!;
 
     [JsonPropertyName("fromServiceWorker")]
     public bool FromServiceWorker { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/RouteInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RouteInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class RouteInitializer
 {
     [JsonPropertyName("request")]
-    public Core.Request Request { get; set; }
+    public Core.Request Request { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/SecurityDetails.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SecurityDetails.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SecurityDetails
 {
     [JsonPropertyName("issuer")]
-    public string Issuer { get; set; }
+    public string Issuer { get; set; } = null!;
 
     [JsonPropertyName("protocol")]
-    public string Protocol { get; set; }
+    public string Protocol { get; set; } = null!;
 
     [JsonPropertyName("subjectName")]
-    public string SubjectName { get; set; }
+    public string SubjectName { get; set; } = null!;
 
     [JsonPropertyName("validFrom")]
     public int? ValidFrom { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedError.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedError.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedError
 {
     [JsonPropertyName("error")]
-    public SerializedErrorError Error { get; set; }
+    public SerializedErrorError Error { get; set; } = null!;
 
     [JsonPropertyName("value")]
     public System.Text.Json.JsonElement Value { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedErrorError.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedErrorError.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedErrorError
 {
     [JsonPropertyName("message")]
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [JsonPropertyName("stack")]
-    public string Stack { get; set; }
+    public string Stack { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValue.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValue.cs
@@ -36,34 +36,34 @@ internal class SerializedValue
     public bool? B { get; set; }
 
     [JsonPropertyName("s")]
-    public string S { get; set; }
+    public string S { get; set; } = null!;
 
     [JsonPropertyName("v")]
-    public string V { get; set; }
+    public string V { get; set; } = null!;
 
     [JsonPropertyName("d")]
-    public string D { get; set; }
+    public string D { get; set; } = null!;
 
     [JsonPropertyName("u")]
-    public string U { get; set; }
+    public string U { get; set; } = null!;
 
     [JsonPropertyName("bi")]
-    public string Bi { get; set; }
+    public string Bi { get; set; } = null!;
 
     [JsonPropertyName("ta")]
-    public SerializedValueTa Ta { get; set; }
+    public SerializedValueTa Ta { get; set; } = null!;
 
     [JsonPropertyName("e")]
-    public SerializedValueE E { get; set; }
+    public SerializedValueE E { get; set; } = null!;
 
     [JsonPropertyName("r")]
-    public SerializedValueR R { get; set; }
+    public SerializedValueR R { get; set; } = null!;
 
     [JsonPropertyName("a")]
-    public List<System.Text.Json.JsonElement> A { get; set; }
+    public List<System.Text.Json.JsonElement> A { get; set; } = null!;
 
     [JsonPropertyName("o")]
-    public List<SerializedValueO> O { get; set; }
+    public List<SerializedValueO> O { get; set; } = null!;
 
     [JsonPropertyName("h")]
     public int? H { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValueE.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValueE.cs
@@ -29,11 +29,11 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedValueE
 {
     [JsonPropertyName("m")]
-    public string M { get; set; }
+    public string M { get; set; } = null!;
 
     [JsonPropertyName("n")]
-    public string N { get; set; }
+    public string N { get; set; } = null!;
 
     [JsonPropertyName("s")]
-    public string S { get; set; }
+    public string S { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValueO.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValueO.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedValueO
 {
     [JsonPropertyName("k")]
-    public string K { get; set; }
+    public string K { get; set; } = null!;
 
     [JsonPropertyName("v")]
     public System.Text.Json.JsonElement V { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValueR.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValueR.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedValueR
 {
     [JsonPropertyName("p")]
-    public string P { get; set; }
+    public string P { get; set; } = null!;
 
     [JsonPropertyName("f")]
-    public string F { get; set; }
+    public string F { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValueTa.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValueTa.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class SerializedValueTa
 {
     [JsonPropertyName("b")]
-    public byte[] B { get; set; }
+    public byte[] B { get; set; } = null!;
 
     [JsonPropertyName("k")]
-    public string K { get; set; }
+    public string K { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/StackFrame.cs
+++ b/src/Playwright/Transport/Protocol/Generated/StackFrame.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class StackFrame
 {
     [JsonPropertyName("file")]
-    public string File { get; set; }
+    public string File { get; set; } = null!;
 
     [JsonPropertyName("line")]
     public int Line { get; set; }
@@ -38,5 +38,5 @@ internal class StackFrame
     public int Column { get; set; }
 
     [JsonPropertyName("function")]
-    public string Function { get; set; }
+    public string Function { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WebSocketInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WebSocketInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class WebSocketInitializer : EventTargetInitializer
 {
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WebSocketRouteInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WebSocketRouteInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class WebSocketRouteInitializer
 {
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WorkerInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WorkerInitializer.cs
@@ -29,5 +29,5 @@ namespace Microsoft.Playwright.Transport.Protocol;
 internal class WorkerInitializer
 {
     [JsonPropertyName("url")]
-    public string Url { get; set; }
+    public string Url { get; set; } = null!;
 }


### PR DESCRIPTION
This re-renders the transport types based on https://github.com/microsoft/playwright/pull/36114.

Relates https://github.com/microsoft/playwright-dotnet/issues/3163.