### PR TITLE
Automatically install required browser files for Playwright

### DIFF
--- a/src/Playwright.MSTest/WorkerAwareTest.cs
+++ b/src/Playwright.MSTest/WorkerAwareTest.cs
@@ -46,6 +46,12 @@ public class WorkerAwareTest
         {
             _currentWorker = new();
         }
+
+        var result = new Program().RunWithResult(["install", "--with-deps", PlaywrightSettingsProvider.BrowserName]);
+        if (result.ExitCode != 0)
+        {
+            throw new PlaywrightException($"Running \"playwright install --with-deps {PlaywrightSettingsProvider.BrowserName}\" failed ({result.ExitCode})\n{result.StandardOutput}\n{result.StandardError}");
+        }
     }
 
     [TestCleanup]

--- a/src/Playwright.NUnit/WorkerAwareTest.cs
+++ b/src/Playwright.NUnit/WorkerAwareTest.cs
@@ -70,6 +70,12 @@ public class WorkerAwareTest
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);
         }
+
+        var result = new Program().RunWithResult(["install", "--with-deps", PlaywrightSettingsProvider.BrowserName]);
+        if (result.ExitCode != 0)
+        {
+            throw new PlaywrightException($"Running \"playwright install --with-deps {PlaywrightSettingsProvider.BrowserName}\" failed ({result.ExitCode})\n{result.StandardOutput}\n{result.StandardError}");
+        }
     }
 
     [TearDown]

--- a/src/Playwright.Xunit/WorkerAwareTest.cs
+++ b/src/Playwright.Xunit/WorkerAwareTest.cs
@@ -69,6 +69,12 @@ public class WorkerAwareTest : ExceptionCapturer
         {
             AssertionsBase.SetDefaultTimeout(PlaywrightSettingsProvider.ExpectTimeout.Value);
         }
+
+        var result = new Program().RunWithResult(["install", "--with-deps", PlaywrightSettingsProvider.BrowserName]);
+        if (result.ExitCode != 0)
+        {
+            throw new PlaywrightException($"Running \"playwright install --with-deps {PlaywrightSettingsProvider.BrowserName}\" failed ({result.ExitCode})\n{result.StandardOutput}\n{result.StandardError}");
+        }
     }
 
     public async override Task DisposeAsync()


### PR DESCRIPTION
This will prevent this exception when `Playwright.MSTest`, `Playwright.NUnit` or `Playwright.Xunit` is used:

```
Microsoft.Playwright.PlaywrightException
Executable doesn't exist at ~/Library/Caches/ms-playwright/chromium-1148/chrome-mac/Chromium.app/Contents/MacOS/Chromium
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
   at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 206
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal) in /_/src/Playwright/Transport/Connection.cs:line 535
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType) in /_/src/Playwright.Xunit/BrowserService.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 46
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
```

This helps with #2286.

~~Aslo note that this pull request is stacked on top of #3140.~~ (not anymore)