### PR TITLE
feat(mstest): Mark TestContext as virtual

### DIFF
--- a/src/Playwright.MSTest/WorkerAwareTest.cs
+++ b/src/Playwright.MSTest/WorkerAwareTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Playwright.MSTest;
 
 public class WorkerAwareTest
 {
-    public TestContext TestContext { get; set; } = null!;
+    public virtual TestContext TestContext { get; set; } = null!;
 
     private static readonly ConcurrentStack<Worker> _allWorkers = new();
     private Worker _currentWorker = null!;


### PR DESCRIPTION
`WorkerAwareTest` is designed to be inherited for testing. As such, the TestContext property, which is injected by the test framework, should be marked `virtual` so that inheritors can override behavior as necessary.

Fixes #3209.