### PR TITLE
chore: mark v1.55.0-beta-3

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AssemblyVersion>1.55.0</AssemblyVersion>
-    <PackageVersion>$(AssemblyVersion)-beta-3</PackageVersion>
+    <PackageVersion>$(AssemblyVersion)-beta-4</PackageVersion>
     <DriverVersion>1.54.1</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>


### PR DESCRIPTION
The last build was only published half because the API key only had permissions to publish to existing packages, not create new ones.