### PR TITLE
chore: update Playwright.NET to v1.56.1

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.55.0</AssemblyVersion>
+    <AssemblyVersion>1.56.1</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <DriverVersion>1.56.1</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>


### PR DESCRIPTION
This PR updates Playwright.NET to version 1.56.1, a maintenance release that follows 1.56.0.

## Changes
- Bump `AssemblyVersion` from 1.55.0 to 1.56.1
- Maintain `DriverVersion` at 1.56.1 (already rolled in #3250)
- Docker images will be built with Playwright 1.56.1 drivers

## Playwright 1.56.1 Highlights
This is a maintenance release with bug fixes and improvements:
- Fix for local-network-access permission in Chromium
- Improvements to agents (workspaceFolder ref removal from vscode mcp)
- Rename agents to test agents
- Various MCP-related fixes

## Related Links
- Playwright 1.56.1 release: https://github.com/microsoft/playwright/releases/tag/v1.56.1
- Playwright 1.56.0 release: https://github.com/microsoft/playwright/releases/tag/v1.56.0
- Driver rolled to 1.56.1: #3250
- v1.56.0 PR: #3252

## Testing
- Docker builds will be validated via CI
- All existing tests should pass with the updated driver version

cc @microsoft/playwright-dotnet-maintainers