### PR TITLE
chore: bump version to 1.59.0

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.58.0</AssemblyVersion>
+    <AssemblyVersion>1.59.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <DriverVersion>1.59.1</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>


### PR DESCRIPTION
## Summary
- Bump AssemblyVersion from 1.58.0 to 1.59.0 for the 1.59 release.