### PR TITLE
fix(screencast): correct overlay/chapter channels

### DIFF
--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -281,4 +281,45 @@ public class ScreencastTests : BrowserTestEx
         }
         await context.CloseAsync();
     }
+
+    [PlaywrightTest()]
+    public async Task ShowOverlayAsync_ReturnsDisposableThatCompletesOnDispose()
+    {
+        var context = await Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await using (var overlay = await page.Screencast.ShowOverlayAsync("<div>overlay</div>"))
+        {
+            Assert.IsNotNull(overlay);
+        }
+
+        await context.CloseAsync();
+    }
+
+    [PlaywrightTest()]
+    public async Task ShowChapterAsync_CompletesWithTitleAndOptions()
+    {
+        var context = await Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.Screencast.ShowChapterAsync("Chapter title", new()
+        {
+            Description = "Chapter description",
+            Duration = 500f,
+        });
+
+        await context.CloseAsync();
+    }
+
+    [PlaywrightTest()]
+    public async Task ShowOverlaysAsync_AndHideOverlaysAsync_Complete()
+    {
+        var context = await Browser.NewContextAsync();
+        var page = await context.NewPageAsync();
+
+        await page.Screencast.HideOverlaysAsync();
+        await page.Screencast.ShowOverlaysAsync();
+
+        await context.CloseAsync();
+    }
 }

--- a/src/Playwright/Core/Screencast.cs
+++ b/src/Playwright/Core/Screencast.cs
@@ -96,17 +96,17 @@ internal class Screencast : IScreencast
 
     public async Task<IAsyncDisposable> ShowOverlayAsync(string html, ScreencastShowOverlayOptions? options = default)
     {
-        var result = await _page.SendMessageToServerAsync("overlayShow", new Dictionary<string, object?>
+        var result = await _page.SendMessageToServerAsync("screencastShowOverlay", new Dictionary<string, object?>
         {
             ["html"] = html,
             ["duration"] = options?.Duration,
         }).ConfigureAwait(false);
         var id = result!.Value.GetProperty("id").GetString();
-        return new DisposableStub(() => _page.SendMessageToServerAsync("overlayRemove", new Dictionary<string, object?> { ["id"] = id }));
+        return new DisposableStub(() => _page.SendMessageToServerAsync("screencastRemoveOverlay", new Dictionary<string, object?> { ["id"] = id }));
     }
 
     public Task ShowChapterAsync(string title, ScreencastShowChapterOptions? options = default)
-        => _page.SendMessageToServerAsync("overlayChapter", new Dictionary<string, object?>
+        => _page.SendMessageToServerAsync("screencastChapter", new Dictionary<string, object?>
         {
             ["title"] = title,
             ["description"] = options?.Description,
@@ -128,8 +128,8 @@ internal class Screencast : IScreencast
         => _page.SendMessageToServerAsync("screencastHideActions");
 
     public Task ShowOverlaysAsync()
-        => _page.SendMessageToServerAsync("overlaySetVisible", new Dictionary<string, object?> { ["visible"] = true });
+        => _page.SendMessageToServerAsync("screencastSetOverlayVisible", new Dictionary<string, object?> { ["visible"] = true });
 
     public Task HideOverlaysAsync()
-        => _page.SendMessageToServerAsync("overlaySetVisible", new Dictionary<string, object?> { ["visible"] = false });
+        => _page.SendMessageToServerAsync("screencastSetOverlayVisible", new Dictionary<string, object?> { ["visible"] = false });
 }


### PR DESCRIPTION
- Fix screencast overlay/chapter/visibility APIs to call the `screencast*` channel methods expected by the driver.
- Add regression coverage for overlay and chapter APIs.

Fixes #3302