### PR TITLE
feat(xunit.v3): add LaunchOptionsAsync override

### DIFF
--- a/src/Playwright.TestingHarnessTest/tests/xunit.v3.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/xunit.v3.spec.ts
@@ -572,3 +572,47 @@ test.describe('ConnectOptions', () => {
     expect(result.total).toBe(1);
   });
 });
+
+test.describe('LaunchOptions', () => {
+  test('should be able to override launch options via LaunchOptionsAsync', async ({ runTest }) => {
+    const result = await runTest({
+      'ExampleTests.cs': `
+        using System;
+        using System.Threading.Tasks;
+        using Microsoft.Playwright;
+        using Microsoft.Playwright.Xunit.v3;
+        using Xunit;
+
+        namespace Playwright.TestingHarnessTest.Xunit;
+
+        public class <class-name> : PageTest
+        {
+            private readonly ITestOutputHelper output;
+
+            public <class-name>(ITestOutputHelper output)
+            {
+                this.output = output;
+            }
+
+            [Fact]
+            public async Task Test()
+            {
+                await Page.GotoAsync("about:blank");
+                output.WriteLine("User-Agent: " + await Page.EvaluateAsync<string>("() => navigator.userAgent"));
+            }
+
+            public override Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync()
+            {
+                return Task.FromResult<BrowserTypeLaunchOptions?>(new BrowserTypeLaunchOptions
+                {
+                    Args = new[] { "--user-agent=hello" },
+                });
+            }
+        }`,
+    }, 'dotnet test');
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.total).toBe(1);
+    expect(result.stdout).toContain("User-Agent: hello");
+  });
+});

--- a/src/Playwright.Xunit.v3/BrowserService.cs
+++ b/src/Playwright.Xunit.v3/BrowserService.cs
@@ -42,12 +42,12 @@ internal class BrowserService : IWorkerService
         Browser = browser;
     }
 
-    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions)
+    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
-        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions).ConfigureAwait(false)));
+        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions, launchOptions).ConfigureAwait(false)));
     }
 
-    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions)
+    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
         if (connectOptions.HasValue && connectOptions.Value.WSEndpoint != null)
         {
@@ -63,7 +63,7 @@ internal class BrowserService : IWorkerService
         {
             return legacyBrowser;
         }
-        return await browserType.LaunchAsync(PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
+        return await browserType.LaunchAsync(launchOptions ?? PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
     }
 
     // TODO: Remove at some point

--- a/src/Playwright.Xunit.v3/BrowserTest.cs
+++ b/src/Playwright.Xunit.v3/BrowserTest.cs
@@ -42,7 +42,7 @@ public class BrowserTest : PlaywrightTest
     public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync().ConfigureAwait(false);
-        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync()).ConfigureAwait(false);
+        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync(), await LaunchOptionsAsync()).ConfigureAwait(false);
         Browser = service.Browser;
     }
 
@@ -61,4 +61,6 @@ public class BrowserTest : PlaywrightTest
     }
 
     public virtual Task<(string, BrowserTypeConnectOptions?)?> ConnectOptionsAsync() => Task.FromResult<(string, BrowserTypeConnectOptions?)?>(null);
+
+    public virtual Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync() => Task.FromResult<BrowserTypeLaunchOptions?>(null);
 }


### PR DESCRIPTION
## Summary
- Adds a virtual `LaunchOptionsAsync()` to `Microsoft.Playwright.Xunit.v3.BrowserTest`, mirroring the existing `ConnectOptionsAsync()` pattern, so tests can override `BrowserTypeLaunchOptions` programmatically without `.runsettings`.
- When the override returns non-null, it replaces `PlaywrightSettingsProvider.LaunchOptions`; when it returns null, the runsettings-derived options are used as before.
- Adds a harness test in `xunit.v3.spec.ts` exercising the override path.

Closes https://github.com/microsoft/playwright-dotnet/issues/3249
Supersedes #3248