### PR TITLE
feat(page): make IPage implement IAsyncDisposable

### DIFF
--- a/src/Playwright.Tests/PageCloseTests.cs
+++ b/src/Playwright.Tests/PageCloseTests.cs
@@ -26,4 +26,15 @@ namespace Microsoft.Playwright.Tests;
 
 public class PageCloseTests : PageTestEx
 {
+    [PlaywrightTest("page-close.spec.ts", "should close the page using await using")]
+    public async Task ShouldClosePageWithAwaitUsing()
+    {
+        IPage closedPage;
+        await using (var page = await Context.NewPageAsync())
+        {
+            closedPage = page;
+            Assert.False(page.IsClosed);
+        }
+        Assert.True(closedPage.IsClosed);
+    }
 }

--- a/src/Playwright/API/Supplements/IPage.cs
+++ b/src/Playwright/API/Supplements/IPage.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Playwright;
 
-public partial interface IPage
+public partial interface IPage : IAsyncDisposable
 {
     Task<JsonElement?> EvaluateAsync(string expression, object? arg = default);
 

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -501,6 +501,9 @@ internal class Page : ChannelOwner, IPage
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public ValueTask DisposeAsync() => new(CloseAsync());
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task CloseAsync(PageCloseOptions? options = default)
     {
         _closeReason = options?.Reason;


### PR DESCRIPTION
## Summary
- `IPage` now implements `IAsyncDisposable`, so `await using var page = await context.NewPageAsync();` works the same way it does for `IBrowser` and `IBrowserContext`.
- `Page.DisposeAsync` simply forwards to `CloseAsync`, matching the one-liner already used in `Browser` and `BrowserContext`.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3243