### PR TITLE
fix(transport): dispose StdIOTransport and break event cycles on shutdown

### DIFF
--- a/src/Playwright/Playwright.cs
+++ b/src/Playwright/Playwright.cs
@@ -41,25 +41,41 @@ public static class Playwright
     {
         var transport = new StdIOTransport();
         var connection = new Connection();
-        transport.MessageReceived += (_, message) =>
+
+        EventHandler<byte[]> onMessageReceived = (_, message) =>
         {
             Connection.TraceMessage("pw:channel:recv", message);
             connection.Dispatch(JsonSerializer.Deserialize<PlaywrightServerMessage>(message, JsonExtensions.DefaultJsonSerializerOptions)!);
         };
-        transport.LogReceived += (_, log) =>
+        EventHandler<string> onLogReceived = (_, log) =>
         {
             // workaround for https://github.com/nunit/nunit/issues/4144
             var writer = Environment.GetEnvironmentVariable("PWAPI_TO_STDOUT") != null ? Console.Out : Console.Error;
             writer.WriteLine(log);
         };
-        transport.TransportClosed += (_, reason) => connection.DoClose(reason);
+        EventHandler<Exception> onTransportClosed = (_, reason) => connection.DoClose(reason);
+
+        transport.MessageReceived += onMessageReceived;
+        transport.LogReceived += onLogReceived;
+        transport.TransportClosed += onTransportClosed;
         connection.OnMessage = (message, keepNulls) =>
         {
             var rawMessage = JsonSerializer.SerializeToUtf8Bytes(message, keepNulls ? connection.DefaultJsonSerializerOptionsKeepNulls : connection.DefaultJsonSerializerOptions);
             Connection.TraceMessage("pw:channel:send", rawMessage);
             return transport.SendAsync(rawMessage);
         };
-        connection.Close += (_, reason) => transport.Close(reason);
+        connection.Close += (_, reason) =>
+        {
+            // Break Connection<->Transport closure cycles and release the underlying
+            // process / token / reader task, so that callers who call `Dispose` on a
+            // short-lived Playwright don't accumulate orphaned graphs.
+            transport.MessageReceived -= onMessageReceived;
+            transport.LogReceived -= onLogReceived;
+            transport.TransportClosed -= onTransportClosed;
+            connection.OnMessage = null!;
+            transport.Close(reason);
+            transport.Dispose();
+        };
         return await connection.InitializePlaywrightAsync().ConfigureAwait(false);
     }
 }

--- a/src/Playwright/Transport/StdIOTransport.cs
+++ b/src/Playwright/Transport/StdIOTransport.cs
@@ -44,14 +44,8 @@ internal class StdIOTransport : IDisposable
     {
         _process = GetProcess("run-driver");
         StartProcessWithUTF8IOEncoding(_process);
-        _process.Exited += (_, _) => Close(new TargetClosedException("Process exited"));
-        _process.ErrorDataReceived += (_, error) =>
-        {
-            if (error.Data != null)
-            {
-                LogReceived?.Invoke(this, error.Data);
-            }
-        };
+        _process.Exited += OnProcessExited;
+        _process.ErrorDataReceived += OnProcessErrorDataReceived;
         _process.BeginErrorReadLine();
 
         _getResponseTask = ScheduleTransportTaskAsync(GetResponseAsync, _readerCancellationSource.Token);
@@ -195,9 +189,25 @@ internal class StdIOTransport : IDisposable
             return;
         }
 
+        if (_process != null)
+        {
+            _process.Exited -= OnProcessExited;
+            _process.ErrorDataReceived -= OnProcessErrorDataReceived;
+            _process.Dispose();
+        }
         _readerCancellationSource?.Dispose();
-        _process?.Dispose();
         _getResponseTask?.Dispose();
+    }
+
+    private void OnProcessExited(object? sender, EventArgs e)
+        => Close(new TargetClosedException("Process exited"));
+
+    private void OnProcessErrorDataReceived(object? sender, DataReceivedEventArgs e)
+    {
+        if (e.Data != null)
+        {
+            LogReceived?.Invoke(this, e.Data);
+        }
     }
 
     private async Task GetResponseAsync(CancellationToken token)


### PR DESCRIPTION
## Summary
- `StdIOTransport.Dispose()` was never invoked from anywhere — only `Close()` was. Each call to `Playwright.CreateAsync()` followed by disposal therefore leaked the underlying `Process`, `CancellationTokenSource`, and reader `Task`. The finalizer was a no-op (`Dispose(false)` returns immediately).
- `Playwright.CreateAsync()` now stores the four `transport`/`connection` event subscriptions as named locals; the `connection.Close` handler unsubscribes them, clears `connection.OnMessage`, calls `transport.Close(reason)`, and finally `transport.Dispose()`. This breaks the `Connection`<->`Transport` closure cycle eagerly and releases the underlying resources.
- `StdIOTransport`'s `Process.Exited` / `ErrorDataReceived` lambdas are converted to named methods so `Dispose(true)` can unsubscribe them and break the `Process`<->`Transport` cycle.

References https://github.com/microsoft/playwright-dotnet/issues/2962