### PR TITLE
chore: roll driver to 1.60.0

### DIFF
--- a/.claude/skills/playwright-roll/SKILL.md
+++ b/.claude/skills/playwright-roll/SKILL.md
@@ -16,34 +16,91 @@ Now, with the driver version known, always start with running the roll script to
 ./build.sh --roll <driver-version>
 ```
 
-Afterwards, work through the list of changes that need to be backported.
-You can find a list of pull requests that might need to be taking into account in the issue titled "Backport changes". Ignore the items that are already checked off.
+Afterwards, walk through the upstream changes that affect the Java client and port the relevant ones.
 
-Some items may be irrelevant to the .NET implementation - feel free to check with the upstream.
+## Determining what to port
 
-Some items may be connected, for example when the API has changed multiple times. In this case, handle them alltogether, aligning with the latest change. Check upstream to see the latest implementation.
+List the upstream commits that touched a client-relevant path since the last release. The paths cover everything that can change the public Java surface or the wire protocol:
 
-Otherwise, work through items one-by-one.
+- `docs/src/api/` — the source of truth for `api.json`. Method/option additions, removals, and `langs:` filter changes flow from here.
+- `packages/playwright-core/src/client/` — the JS client implementation that the Java client mirrors.
+- `packages/isomorphic/` — selector engines, locator generation/parsing, and aria-snapshot logic shared between client and server. Changes here can affect client-side helpers like `getByRoleSelector`.
+- `packages/playwright/src/matchers/matchers.ts` — assertion-method definitions. Changes here usually correspond to new options on `LocatorAssertions` / `PageAssertions`.
+- `packages/protocol/src/protocol.yml` and `packages/protocol/spec/**.yml` — the wire protocol schema. Method/event additions, parameter renames, and result-shape changes affect what the .NET implementation classes need to send/receive.
 
-Rolling includes:
-- updating client implementation to match changes in the upstream JS implementation (see ../playwright/packages/playwright-core/src/client)
-- adding a couple of new tests to verify new/changed functionality
+```bash
+cd ~/playwright
+PREV_TAG=$(git tag | grep -E '^v1\.[0-9]+\.[0-9]+$' | sort -V | tail -1)  # e.g. v1.59.1
+git log "$PREV_TAG"..HEAD --oneline -- \
+  'docs/src/api/' \
+  'packages/playwright-core/src/client/' \
+  'packages/isomorphic/' \
+  'packages/playwright/src/matchers/matchers.ts' \
+  'packages/protocol/src/protocol.yml' \
+  'packages/protocol/spec/'
+```
+
+Walk that list top-to-bottom (oldest-first is easier — newest is at top, so reverse). For each commit:
+1. Read the commit (`git show <sha>`) to see what client/protocol/docs changed.
+2. If it's JS-internal (bundling, dispatcher conventions, electron, mcp, dashboard, trace-viewer, test-runner) — skip.
+3. If it touches `docs/src/api/` or types, check `langs:` annotations — features marked with languages other than "csharp" do not apply.
+4. If it adds/changes a public API method or option that applies to .NET, port it. The 'build.sh --roll' already regenerated the types/options, so we usually only need to update the implementation.
+5. Watch for follow-up reverts — a "feat: X" commit might be undone by a later "Revert X". Check whether the change still exists in HEAD before porting.
+6. Maintain a running notes file (e.g. `/tmp/roll-notes.md`) listing each upstream PR as ported / skipped / verified-already-supported, with a one-line reason. This file becomes the body of the eventual PR.
+7. Do not forget to port tests that cover .NET-relevant changes. At least one test per every API method/option to excercise the new code paths. Some server-side implementation tests are not needed in this port.
+
+## Mimicking the JavaScript implementation
+
+The .NET client is a port of the JS client in `../playwright/packages/playwright-core/src/client/`. When implementing a new or changed method, always read the corresponding JS file first and mirror its logic:
+
+```
+../playwright/packages/playwright-core/src/client/browserContext.ts
+../playwright/packages/playwright-core/src/client/page.ts
+...
+```
+
+**Read the final state at the release tag, not just the introducing PR diff.** When a feature evolves across multiple PRs (e.g. a method was introduced in one PR, then some options were added in follow-ups, then some logic was changed), the original PR's diff is a misleading reference — the final shape lives in `git show v1.X.0:packages/playwright-core/src/client/foo.ts`. Always read the v1.X.0 file before porting non-trivial logic.
+
+Key translation rules:
+
+**Protocol calls** — `await this._channel.methodName(params)` → `SendMessageToServerAsync("methodName", paramsDictionary)`
+
+**Extracting a returned channel object from a result** — JS uses `SomeClass.from(result.foo)` which resolves the JS-side object for a channel reference. In .NET, extract it from the connection: `.GetObject<Foo>("foo", _connection)`
+
+**Watch for channel migrations.** A method that lived on `BrowserContext` may move to `Tracing` (and vice-versa) without notice — the protocol spec is the source of truth. If a `SendMessageToServerAsync("foo", ...)` call suddenly fails, grep `packages/protocol/spec/*.yml` to find which channel actually owns `foo` now.
+
+**Wire format changes can be subtle.** A method's result shape can change without renaming anything. These are easy to miss when walking client.ts because the JS code just adapts; the regression only surfaces when an existing test's deserialization breaks. Always diff `packages/protocol/spec/*.yml` for each commit on the walk list, not just the client code.
+
+**Update tests similarly to upstream.** When upstream removes or modifies a test, apply similar changes.
 
 ## Renaming generated types
 
 When the API generator produces an unhelpful name for a return type (e.g. `Bind` instead of `BrowserBindResult`), you can control it by adding a struct alias in the upstream docs.
 
-In the docs markdown file (e.g. `docs/src/api/class-browser.md`), change the return type from `<[Object]>` to `<[Object=DesiredName]>`:
+In the docs markdown file (e.g. `docs/src/api/class-browser.md`), add `alias` (applies to all languages) or `alias-csharp` (overrides for .NET only) to the `<[Object]>` type:
 
 ```diff
 -- returns: <[Object]>
-+- returns: <[Object=BrowserBindResult]>
-   - `endpoint` <[string]>
++- returns: <[Object]>
++  - alias-csharp: BrowserBindResult
 ```
 
-The `=Name` syntax sets `structName` on the parsed type, which the .NET generator uses directly as the class name. After making this change, re-run `./build.sh --roll <version>` to regenerate, then update any hand-written implementation code to use the new type name.
+Use `alias-csharp` (in addition to bare `alias`) when upstream already declared a different `alias` for other languages and you only want to override .NET's name — typically to preserve a name we've already shipped and don't want to break. After making this change, re-run `./build.sh --roll <version>` to regenerate, then update any hand-written implementation code to use the new type name. The upstream docs change must also land in `microsoft/playwright` via a separate PR or it will revert on the next roll.
+
+## Running the full test suite
+
+After porting, run the chromium suite end-to-end before opening the PR — many regressions only surface in older tests that depended on now-changed behavior. Tests take ~8–10 minutes:
+
+```bash
+BROWSER=chromium dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj \
+  -c Debug -f net8.0 --logger:"console;verbosity=detailed" > /tmp/test-results.txt 2>&1
+grep "^  Failed " /tmp/test-results.txt        # list failures
+tail -5 /tmp/test-results.txt                  # summary
+```
+
+Run as a background task — don't block the conversation on it. For each failure: check whether it's a flake (port collision, browser timing) by running the single test in isolation, then investigate whether your roll introduced it or it's pre-existing.
 
 ## Tips & Tricks
 - Project checkouts are in the parent directory (`../`).
-- When updating checkboxes, store the issue content into /tmp and edit it there, then update the issue based on the file.
 - Use the "gh" cli to interact with GitHub.
+- When running git commands against an upstream repo, always use `git -C /path/to/repo <subcommand>` instead of `cd /path/to/repo && git <subcommand>`.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->147.0.7727.15<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->148.0.7778.96<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->148.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->150.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 Playwright for .NET is the official language port of [Playwright](https://playwright.dev), the library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.59.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.59.1</DriverVersion>
+    <DriverVersion>1.60.0</DriverVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -7,19 +7,19 @@
     "": {
       "name": "playwright.testingharnesstest",
       "devDependencies": {
-        "@playwright/test": "1.59.1",
+        "@playwright/test": "1.60.0",
         "@types/node": "^22.12.0",
         "fast-xml-parser": "^4.5.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -77,13 +77,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -124,12 +124,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "requires": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       }
     },
     "@types/node": {
@@ -158,19 +158,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       }
     },
     "playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.60.0",
     "@types/node": "^22.12.0",
     "fast-xml-parser": "^4.5.0"
   }

--- a/src/Playwright.TestingHarnessTest/tests/baseTest.ts
+++ b/src/Playwright.TestingHarnessTest/tests/baseTest.ts
@@ -40,7 +40,7 @@ export const test = base.extend<{
   launchServer: async ({ playwright }, use) => {
     const servers: BrowserServer[] = [];
     await use(async ({port}: {port: number}) => {
-      servers.push(await playwright.chromium.launchServer({ port }));
+      servers.push(await playwright.chromium.launchServer({ host: '127.0.0.1', port }));
     });
     for (const server of servers)
       await server.close();

--- a/src/Playwright.Tests/Assertions/PageAssertionsTests.cs
+++ b/src/Playwright.Tests/Assertions/PageAssertionsTests.cs
@@ -90,4 +90,28 @@ public class PageAssertionsTests : PageTestEx
         await Expect(Page).ToHaveURLAsync("DATA:teXT/HTml,<div>a</div>", new() { IgnoreCase = true });
         await Expect(Page).ToHaveURLAsync(new Regex("DATA:teXT/HTml,<div>a</div>"), new() { IgnoreCase = true });
     }
+
+    [PlaywrightTest("playwright-test/playwright.expect.misc.spec.ts", "should support toMatchAriaSnapshot on page")]
+    public async Task ShouldSupportToMatchAriaSnapshotOnPage()
+    {
+        await Page.SetContentAsync("<h1>title</h1><button>click me</button>");
+        await Expect(Page).ToMatchAriaSnapshotAsync(@"
+            - heading ""title""
+            - button ""click me""
+        ");
+
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Expect(Page).ToMatchAriaSnapshotAsync(@"
+            - heading ""missing""
+        ", new() { Timeout = 100 }));
+        StringAssert.Contains("Page expected to match Aria snapshot", exception.Message);
+    }
+
+    [PlaywrightTest("playwright-test/playwright.expect.misc.spec.ts", "should include aria snapshot in failure message")]
+    public async Task ShouldIncludeAriaSnapshotInFailureMessage()
+    {
+        await Page.SetContentAsync("<h1>actual title</h1>");
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Expect(Page.Locator("h1")).ToHaveTextAsync("wrong", new() { Timeout = 100 }));
+        StringAssert.Contains("Aria snapshot", exception.Message);
+        StringAssert.Contains("heading", exception.Message);
+    }
 }

--- a/src/Playwright.Tests/BrowserContextEventsTests.cs
+++ b/src/Playwright.Tests/BrowserContextEventsTests.cs
@@ -216,4 +216,62 @@ public class BrowserContextEventsTests : PageTestEx
         Assert.AreEqual(Page, webError.Page);
         StringAssert.Contains("boom", webError.Error);
     }
+
+    [PlaywrightTest("browsercontext-events.spec.ts", "weberror event should include location")]
+    public async Task WebErrorEventShouldIncludeLocation()
+    {
+        var tsc = new TaskCompletionSource<IWebError>();
+        Context.WebError += (sender, e) => tsc.TrySetResult(e);
+        await Page.SetContentAsync(@"<script>throw new Error(""boom"")</script>");
+        var webError = await tsc.Task;
+        Assert.IsNotNull(webError.Location);
+        StringAssert.Contains("boom", webError.Error);
+    }
+
+    [PlaywrightTest("browsercontext-events.spec.ts", "should fire pageLoad")]
+    public async Task ShouldFirePageLoad()
+    {
+        var tcs = new TaskCompletionSource<IPage>();
+        Context.PageLoad += (_, p) => tcs.TrySetResult(p);
+        var page = await Context.NewPageAsync();
+        await page.GotoAsync(Server.EmptyPage);
+        var loaded = await tcs.Task;
+        Assert.AreSame(page, loaded);
+    }
+
+    [PlaywrightTest("browsercontext-events.spec.ts", "should fire pageClose")]
+    public async Task ShouldFirePageClose()
+    {
+        var tcs = new TaskCompletionSource<IPage>();
+        Context.PageClose += (_, p) => tcs.TrySetResult(p);
+        var page = await Context.NewPageAsync();
+        await page.CloseAsync();
+        var closed = await tcs.Task;
+        Assert.AreSame(page, closed);
+    }
+
+    [PlaywrightTest("browsercontext-events.spec.ts", "should fire frameAttached and frameNavigated")]
+    public async Task ShouldFireFrameAttachedAndFrameNavigated()
+    {
+        var attachedTcs = new TaskCompletionSource<IFrame>();
+        var navigatedTcs = new TaskCompletionSource<IFrame>();
+        Context.FrameAttached += (_, f) =>
+        {
+            if (f.ParentFrame != null)
+            {
+                attachedTcs.TrySetResult(f);
+            }
+        };
+        Context.FrameNavigated += (_, f) =>
+        {
+            if (f.ParentFrame != null)
+            {
+                navigatedTcs.TrySetResult(f);
+            }
+        };
+        var page = await Context.NewPageAsync();
+        await page.GotoAsync(Server.Prefix + "/frames/one-frame.html");
+        await attachedTcs.Task;
+        await navigatedTcs.Task;
+    }
 }

--- a/src/Playwright.Tests/BrowserContextExposeFunctionTests.cs
+++ b/src/Playwright.Tests/BrowserContextExposeFunctionTests.cs
@@ -103,43 +103,4 @@ public class BrowserContextExposeFunctionTests : ContextTestEx
         CollectionAssert.Contains(args, "page");
     }
 
-    [PlaywrightTest("browsercontext-expose-function.spec.ts", "exposeBindingHandle should work")]
-    public async Task ExposeBindingHandleShouldWork()
-    {
-        IJSHandle target = null;
-        await Context.ExposeBindingAsync(
-            "logme",
-            (BindingSource _, IJSHandle t) =>
-            {
-                target = t;
-                return 17;
-            });
-
-        var page = await Context.NewPageAsync();
-        int result = await page.EvaluateAsync<int>(@"async function() {
-                return window['logme']({ foo: 42 });
-            }");
-
-        Assert.AreEqual(42, await target.EvaluateAsync<int>("x => x.foo"));
-        Assert.AreEqual(17, result);
-    }
-
-    public async Task ExposeBindingHandleLikeInDocumentation()
-    {
-        var result = new TaskCompletionSource<string>();
-        var page = await Context.NewPageAsync();
-        await Context.ExposeBindingAsync("clicked", async (BindingSource _, IJSHandle t) =>
-        {
-            return result.TrySetResult(await t.AsElement().TextContentAsync());
-        });
-
-        await page.SetContentAsync("<script>\n" +
-         "  document.addEventListener('click', event => window.clicked(event.target));\n" +
-         "</script>\n" +
-         "<div>Click me</div>\n" +
-         "<div>Or click me</div>\n");
-
-        await page.ClickAsync("div");
-        Assert.AreEqual("Click me", await result.Task);
-    }
 }

--- a/src/Playwright.Tests/BrowserTests.cs
+++ b/src/Playwright.Tests/BrowserTests.cs
@@ -76,4 +76,22 @@ public class BrowserTests : BrowserTestEx
             Assert.That(version, Does.Match("\\d+\\.\\d+"));
         }
     }
+
+    [PlaywrightTest("browser.spec.ts", "should fire Context event when a context is created")]
+    public async Task ShouldFireContextEvent()
+    {
+        var tcs = new TaskCompletionSource<IBrowserContext>();
+        EventHandler<IBrowserContext> handler = (_, c) => tcs.TrySetResult(c);
+        Browser.Context += handler;
+        try
+        {
+            await using var context = await Browser.NewContextAsync();
+            var emitted = await tcs.Task;
+            Assert.AreSame(context, emitted);
+        }
+        finally
+        {
+            Browser.Context -= handler;
+        }
+    }
 }

--- a/src/Playwright.Tests/Locator/LocatorHighlightTests.cs
+++ b/src/Playwright.Tests/Locator/LocatorHighlightTests.cs
@@ -34,4 +34,38 @@ public class LocatorHighlightTests : PageTestEx
         await Page.Locator(".box").Nth(3).HighlightAsync();
         Assert.AreEqual(await Page.Locator("x-pw-glass").IsVisibleAsync(), true);
     }
+
+    [PlaywrightTest("locator-highlight.spec.ts", "highlight should accept a CSS string style")]
+    public async Task HighlightShouldAcceptCssStringStyle()
+    {
+        await Page.GotoAsync(Server.Prefix + "/grid.html");
+        await Page.Locator(".box").Nth(3).HighlightAsync(new() { Style = "outline: 3px solid rgb(255, 0, 0)" });
+        Assert.AreEqual(await Page.Locator("x-pw-glass").IsVisibleAsync(), true);
+    }
+
+    [PlaywrightTest("locator-highlight.spec.ts", "hideHighlight should not throw")]
+    public async Task HideHighlightShouldNotThrow()
+    {
+        await Page.GotoAsync(Server.Prefix + "/grid.html");
+        var locator = Page.Locator(".box").Nth(3);
+        await locator.HighlightAsync();
+        await locator.HideHighlightAsync();
+    }
+
+    [PlaywrightTest("locator-highlight.spec.ts", "page.hideHighlight should work")]
+    public async Task PageHideHighlightShouldWork()
+    {
+        await Page.GotoAsync(Server.Prefix + "/grid.html");
+        await Page.Locator(".box").Nth(3).HighlightAsync();
+        await Page.HideHighlightAsync();
+    }
+
+    [PlaywrightTest("locator-highlight.spec.ts", "highlight returns disposable")]
+    public async Task HighlightReturnsDisposable()
+    {
+        await Page.GotoAsync(Server.Prefix + "/grid.html");
+        var locator = Page.Locator(".box").Nth(3);
+        await using var disposable = await locator.HighlightAsync();
+        Assert.IsNotNull(disposable);
+    }
 }

--- a/src/Playwright.Tests/PageDropTests.cs
+++ b/src/Playwright.Tests/PageDropTests.cs
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Text;
+
+namespace Microsoft.Playwright.Tests;
+
+public class PageDropTests : PageTestEx
+{
+    private const string DropzoneSetup = @"
+        <style>#dropzone { width: 300px; height: 200px; border: 2px dashed #888; }</style>
+        <div id='dropzone'></div>
+        <script>
+          window.__dropInfo = null;
+          const zone = document.getElementById('dropzone');
+          zone.addEventListener('dragenter', e => e.preventDefault());
+          zone.addEventListener('dragover', e => e.preventDefault());
+          zone.addEventListener('drop', async e => {
+            e.preventDefault();
+            const files = [];
+            for (const file of e.dataTransfer.files)
+              files.push({ name: file.name, type: file.type, size: file.size, text: await file.text() });
+            const data = {};
+            for (const t of e.dataTransfer.types) {
+              if (t !== 'Files')
+                data[t] = e.dataTransfer.getData(t);
+            }
+            window.__dropInfo = { files, data };
+          });
+        </script>";
+
+    [PlaywrightTest("page-drop.spec.ts", "should drop a file payload")]
+    public async Task ShouldDropFilePayload()
+    {
+        await Page.SetContentAsync(DropzoneSetup);
+        await Page.Locator("#dropzone").DropAsync(new()
+        {
+            Files = new[]
+            {
+                new FilePayload { Name = "note.txt", MimeType = "text/plain", Buffer = Encoding.UTF8.GetBytes("hello") },
+            },
+        });
+        var info = await Page.EvaluateAsync<DropInfo>("() => window.__dropInfo");
+        Assert.AreEqual(1, info.Files.Length);
+        Assert.AreEqual("note.txt", info.Files[0].Name);
+        Assert.AreEqual("text/plain", info.Files[0].Type);
+        Assert.AreEqual("hello", info.Files[0].Text);
+    }
+
+    [PlaywrightTest("page-drop.spec.ts", "should drop clipboard-like data")]
+    public async Task ShouldDropClipboardLikeData()
+    {
+        await Page.SetContentAsync(DropzoneSetup);
+        await Page.Locator("#dropzone").DropAsync(new()
+        {
+            Data = new Dictionary<string, string>
+            {
+                ["text/plain"] = "hello world",
+                ["text/uri-list"] = "https://example.com",
+            },
+        });
+        var hasData = await Page.EvaluateAsync<bool>("() => !!window.__dropInfo");
+        Assert.IsTrue(hasData);
+    }
+
+    [PlaywrightTest("page-drop.spec.ts", "should throw when target does not accept drop")]
+    public async Task ShouldThrowWhenTargetRejects()
+    {
+        await Page.SetContentAsync("<div id='dropzone' style='width: 200px; height: 100px;'></div>");
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.Locator("#dropzone").DropAsync(new()
+        {
+            Data = new Dictionary<string, string> { ["text/plain"] = "nope" },
+        }));
+        StringAssert.Contains("drop target did not accept the drop", exception.Message.ToLowerInvariant());
+    }
+
+    public class DropInfo
+    {
+        public DropFile[] Files { get; set; } = System.Array.Empty<DropFile>();
+        public Dictionary<string, string> Data { get; set; } = new();
+    }
+
+    public class DropFile
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public int Size { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/src/Playwright.Tests/PageExposeFunctionTests.cs
+++ b/src/Playwright.Tests/PageExposeFunctionTests.cs
@@ -194,46 +194,6 @@ public class PageExposeFunctionTests : PageTestEx
         Assert.AreEqual(7, result.x);
     }
 
-    [PlaywrightTest("page-expose-function.spec.ts", "exposeBindingHandle should work")]
-    public async Task ExposeBindingHandleShouldWork()
-    {
-        IJSHandle target = null;
-        await Page.ExposeBindingAsync(
-            "logme",
-            (_, t) =>
-            {
-                target = t;
-                return 17;
-            });
-
-        int result = await Page.EvaluateAsync<int>(@"async function() {
-                return window['logme']({ foo: 42 });
-            }");
-
-        Assert.AreEqual(42, await target.EvaluateAsync<int>("x => x.foo"));
-        Assert.AreEqual(17, result);
-    }
-
-    [PlaywrightTest("page-expose-function.spec.ts", "exposeBindingHandle should not throw during navigation")]
-    public async Task ExposeBindingHandleShouldNotThrowDuringNavigation()
-    {
-        IJSHandle target = null;
-        await Page.ExposeBindingAsync(
-            "logme",
-            (_, t) =>
-            {
-                target = t;
-                return 17;
-            });
-
-        await TaskUtils.WhenAll(
-            Page.WaitForNavigationAsync(new() { WaitUntil = WaitUntilState.Load }),
-            Page.EvaluateAsync(@"async url => {
-                    window['logme']({ foo: 42 });
-                    window.location.href = url;
-                }", Server.Prefix + "/one-style.html"));
-    }
-
     [PlaywrightTest("browsercontext-expose-function.spec.ts", "should throw for duplicate registrations")]
     public async Task ShouldThrowForDuplicateRegistrations()
     {

--- a/src/Playwright.Tests/PageRouteWebSocketTests.cs
+++ b/src/Playwright.Tests/PageRouteWebSocketTests.cs
@@ -32,7 +32,7 @@ public class PageRouteWebSocketTests : PageTestEx
 
     private async Task SetupWS(IFrame target, int port, string path)
     {
-        await target.GotoAsync("about:blank");
+        await target.GotoAsync(Server.EmptyPage);
         await target.EvaluateAsync(@"({ port, binaryType }) => {
             window.log = [];
             window.ws = new WebSocket('ws://localhost:' + port + '/ws');
@@ -118,7 +118,7 @@ public class PageRouteWebSocketTests : PageTestEx
 
         var wsPromise = Server.WaitForWebSocketAsync();
 
-        await Page.GotoAsync("about:blank");
+        await Page.GotoAsync(Server.EmptyPage);
         await Page.EvaluateAsync(@"async ({ port }) => {
             window.log = [];
             window.ws1 = new WebSocket('ws://localhost:' + port + '/ws');
@@ -328,7 +328,7 @@ public class PageRouteWebSocketTests : PageTestEx
             });
         });
 
-        await Page.GotoAsync("about:blank");
+        await Page.GotoAsync(Server.EmptyPage);
         await Page.EvaluateAsync(@"({ port }) => {
             window.log = [];
             // No trailing slash in WebSocket URL
@@ -347,5 +347,29 @@ public class PageRouteWebSocketTests : PageTestEx
         await AssertAreEqualWithRetriesAsync(
             () => Page.EvaluateAsync<string[]>("() => window.log"),
             ["response"]);
+    }
+
+    [PlaywrightTest("page-route-web-socket.spec.ts", "should expose protocols to the route handler")]
+    public async Task ShouldExposeProtocolsToRouteHandler()
+    {
+        var routes = new List<IWebSocketRoute>();
+        await Page.RouteWebSocketAsync(new Regex(".*"), ws =>
+        {
+            routes.Add(ws);
+        });
+
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.EvaluateAsync(@"({ port }) => {
+            window.wsNone = new WebSocket('ws://localhost:' + port + '/ws-none');
+            window.wsString = new WebSocket('ws://localhost:' + port + '/ws-string', 'chat.v1');
+            window.wsArray = new WebSocket('ws://localhost:' + port + '/ws-array', ['chat.v2', 'chat.v1']);
+        }", new Dictionary<string, object> { ["port"] = Server.Port });
+
+        await AssertAreEqualWithRetriesAsync(() => Task.FromResult(new[] { routes.Count.ToString(System.Globalization.CultureInfo.InvariantCulture) }), new[] { "3" });
+
+        var byPath = routes.ToDictionary(r => new Uri(r.Url).AbsolutePath, r => r.Protocols);
+        CollectionAssert.AreEqual(System.Array.Empty<string>(), byPath["/ws-none"]);
+        CollectionAssert.AreEqual(new[] { "chat.v1" }, byPath["/ws-string"]);
+        CollectionAssert.AreEqual(new[] { "chat.v2", "chat.v1" }, byPath["/ws-array"]);
     }
 }

--- a/src/Playwright.Tests/SelectorsRoleTests.cs
+++ b/src/Playwright.Tests/SelectorsRoleTests.cs
@@ -274,7 +274,7 @@ public class SelectorsRoleTests : PageTestEx
         StringAssert.Contains("Role must not be empty", exception0.Message);
 
         var exception1 = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.QuerySelectorAsync("role=foo[sElected]"));
-        StringAssert.Contains("Unknown attribute \"sElected\", must be one of \"checked\", \"disabled\", \"expanded\", \"include-hidden\", \"level\", \"name\", \"pressed\", \"selected\"", exception1.Message);
+        StringAssert.Contains("Unknown attribute \"sElected\", must be one of \"checked\", \"description\", \"disabled\", \"expanded\", \"include-hidden\", \"level\", \"name\", \"pressed\", \"selected\"", exception1.Message);
 
         var exception2 = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Page.QuerySelectorAsync("role=foo[bar . qux=true]"));
         StringAssert.Contains("Unknown attribute \"bar.qux\"", exception2.Message);

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -373,6 +373,33 @@ public class TracingTests : ContextTestEx
         });
     }
 
+    [PlaywrightTest("tracing.spec.ts", "should record HAR via startHar/stopHar")]
+    public async Task ShouldRecordHarViaStartHarStopHar()
+    {
+        using var tmp = new TempDirectory();
+        var harPath = Path.Combine(tmp.Path, "test.har");
+
+        await Context.Tracing.StartHarAsync(harPath);
+        var page = await Context.NewPageAsync();
+        await page.GotoAsync(Server.EmptyPage);
+        await Context.Tracing.StopHarAsync();
+
+        Assert.True(File.Exists(harPath));
+        var content = File.ReadAllText(harPath);
+        StringAssert.Contains(Server.EmptyPage, content);
+    }
+
+    [PlaywrightTest("tracing.spec.ts", "should throw on duplicate startHar")]
+    public async Task ShouldThrowOnDuplicateStartHar()
+    {
+        using var tmp = new TempDirectory();
+        var harPath = Path.Combine(tmp.Path, "test.har");
+        await Context.Tracing.StartHarAsync(harPath);
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() => Context.Tracing.StartHarAsync(harPath));
+        StringAssert.Contains("HAR recording has already been started", exception.Message);
+        await Context.Tracing.StopHarAsync();
+    }
+
     private async Task ShowTraceViewerAsync(string path, Func<TraceViewerPage, Task> callback)
     {
         var (executablePath, _) = Driver.GetExecutablePath();

--- a/src/Playwright.Tests/TracingTests.cs
+++ b/src/Playwright.Tests/TracingTests.cs
@@ -433,7 +433,7 @@ class TraceViewerPage(IPage page)
 
     public ILocator ActionTitles => Page.Locator(".action-title");
 
-    public ILocator StackFrames => Page.GetByRole(AriaRole.List, new() { Name = "Stack trace" }).GetByRole(AriaRole.Listitem);
+    public ILocator StackFrames => Page.GetByRole(AriaRole.Listbox, new() { Name = "Stack trace" }).GetByRole(AriaRole.Option);
 
     public async Task SelectActionAsync(string title, int ordinal = 0)
     {

--- a/src/Playwright/API/Generated/Enums/PseudoElement.cs
+++ b/src/Playwright/API/Generated/Enums/PseudoElement.cs
@@ -22,30 +22,14 @@
  * SOFTWARE.
  */
 
-using System.Text.Json.Serialization;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class LocatorAssertionsToHaveCSSOptions
+public enum PseudoElement
 {
-    public LocatorAssertionsToHaveCSSOptions() { }
-
-    public LocatorAssertionsToHaveCSSOptions(LocatorAssertionsToHaveCSSOptions clone)
-    {
-        if (clone == null)
-        {
-            return;
-        }
-
-        Pseudo = clone.Pseudo;
-        Timeout = clone.Timeout;
-    }
-
-    /// <summary><para>Pseudo-element to read computed styles from.</para></summary>
-    [JsonPropertyName("pseudo")]
-    public PseudoElement? Pseudo { get; set; }
-
-    /// <summary><para>Time to retry the assertion for in milliseconds. Defaults to <c>5000</c>.</para></summary>
-    [JsonPropertyName("timeout")]
-    public float? Timeout { get; set; }
+    [EnumMember(Value = "before")]
+    Before,
+    [EnumMember(Value = "after")]
+    After,
 }

--- a/src/Playwright/API/Generated/IAPIRequestContext.cs
+++ b/src/Playwright/API/Generated/IAPIRequestContext.cs
@@ -32,26 +32,24 @@ namespace Microsoft.Playwright;
 /// configure micro-services, prepare environment or the service to your e2e test.
 /// </para>
 /// <para>
-/// Each Playwright browser context has associated with it <see cref="IAPIRequestContext"/>
-/// instance which shares cookie storage with the browser context and can be accessed
-/// via <see cref="IBrowserContext.APIRequest"/> or <see cref="IPage.APIRequest"/>.
-/// It is also possible to create a new APIRequestContext instance manually by calling
-/// <see cref="IAPIRequest.NewContextAsync"/>.
+/// Each Playwright browser context has an associated <see cref="IAPIRequestContext"/>,
+/// accessible via <see cref="IBrowserContext.APIRequest"/> or <see cref="IPage.APIRequest"/>
+/// (these return the
+/// </para>
+/// <para>
+/// **same instance** — <c>page.request</c> is a shortcut for <c>page.context().request</c>).
+/// You can also create a standalone, isolated instance with <see cref="IAPIRequest.NewContextAsync"/>.
 /// </para>
 /// <para>**Cookie management**</para>
 /// <para>
-/// <see cref="IAPIRequestContext"/> returned by <see cref="IBrowserContext.APIRequest"/>
-/// and <see cref="IPage.APIRequest"/> shares cookie storage with the corresponding
-/// <see cref="IBrowserContext"/>. Each API request will have <c>Cookie</c> header populated
-/// with the values from the browser context. If the API response contains <c>Set-Cookie</c>
-/// header it will automatically update <see cref="IBrowserContext"/> cookies and requests
-/// made from the page will pick them up. This means that if you log in using this API,
-/// your e2e test will be logged in and vice versa.
+/// The <see cref="IAPIRequestContext"/> returned by <see cref="IBrowserContext.APIRequest"/>
+/// and
 /// </para>
+/// <para><see cref="IPage.APIRequest"/> uses the same cookie jar as its <see cref="IBrowserContext"/>:</para>
 /// <para>
-/// If you want API requests to not interfere with the browser cookies you should create
-/// a new <see cref="IAPIRequestContext"/> by calling <see cref="IAPIRequest.NewContextAsync"/>.
-/// Such <c>APIRequestContext</c> object will have its own isolated cookie storage.
+/// If you want API requests that do **not** share cookies with the browser, create
+/// an isolated context via <see cref="IAPIRequest.NewContextAsync"/>. Such <c>APIRequestContext</c>
+/// object will have its own isolated cookie storage.
 /// </para>
 /// </summary>
 public partial interface IAPIRequestContext
@@ -265,4 +263,6 @@ public partial interface IAPIRequestContext
     /// </summary>
     /// <param name="options">Call options</param>
     Task<string> StorageStateAsync(APIRequestContextStorageStateOptions? options = default);
+
+    public ITracing Tracing { get; }
 }

--- a/src/Playwright/API/Generated/IBrowser.cs
+++ b/src/Playwright/API/Generated/IBrowser.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Playwright;
 /// </summary>
 public partial interface IBrowser
 {
+    /// <summary><para>Emitted when a new browser context is created.</para></summary>
+    event EventHandler<IBrowserContext> Context;
+
     /// <summary>
     /// <para>
     /// Emitted when Browser gets disconnected from the browser application. This might

--- a/src/Playwright/API/Generated/IBrowserContext.cs
+++ b/src/Playwright/API/Generated/IBrowserContext.cs
@@ -133,6 +133,41 @@ public partial interface IBrowserContext
 
     /// <summary>
     /// <para>
+    /// Emitted when attachment download started in any page belonging to this context.
+    /// User can access basic file operations on downloaded content via the passed <see
+    /// cref="IDownload"/> instance. See also <see cref="IPage.Download"/> to receive events
+    /// about a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IDownload> Download;
+
+    /// <summary>
+    /// <para>
+    /// Emitted when a frame is attached in any page belonging to this context. See also
+    /// <see cref="IPage.FrameAttached"/> to receive events about a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IFrame> FrameAttached;
+
+    /// <summary>
+    /// <para>
+    /// Emitted when a frame is detached in any page belonging to this context. See also
+    /// <see cref="IPage.FrameDetached"/> to receive events about a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IFrame> FrameDetached;
+
+    /// <summary>
+    /// <para>
+    /// Emitted when a frame is navigated to a new url in any page belonging to this context.
+    /// See also <see cref="IPage.FrameNavigated"/> to receive events about navigations
+    /// in a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IFrame> FrameNavigated;
+
+    /// <summary>
+    /// <para>
     /// The event is emitted when a new Page is created in the BrowserContext. The page
     /// may still be loading. The event will also fire for popup pages. See also <see cref="IPage.Popup"/>
     /// to receive events about popups relevant to a specific page.
@@ -164,6 +199,23 @@ public partial interface IBrowserContext
     /// </para>
     /// </remarks>
     event EventHandler<IPage> Page;
+
+    /// <summary>
+    /// <para>
+    /// Emitted when a page in this context is closed. See also <see cref="IPage.Close"/>
+    /// to receive events about a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IPage> PageClose;
+
+    /// <summary>
+    /// <para>
+    /// Emitted when the JavaScript <a href="https://developer.mozilla.org/en-US/docs/Web/Events/load"><c>load</c></a>
+    /// event is dispatched in any page belonging to this context. See also <see cref="IPage.Load"/>
+    /// to receive events about a specific page.
+    /// </para>
+    /// </summary>
+    event EventHandler<IPage> PageLoad;
 
     /// <summary>
     /// <para>
@@ -384,8 +436,7 @@ public partial interface IBrowserContext
     /// </summary>
     /// <param name="name">Name of the function on the window object.</param>
     /// <param name="callback">Callback function that will be called in the Playwright's context.</param>
-    /// <param name="options">Call options</param>
-    Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback, BrowserContextExposeBindingOptions? options = default);
+    Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback);
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/ILocator.cs
+++ b/src/Playwright/API/Generated/ILocator.cs
@@ -457,6 +457,32 @@ public partial interface ILocator
     Task DragToAsync(ILocator target, LocatorDragToOptions? options = default);
 
     /// <summary>
+    /// <para>Simulate an external drag-and-drop of files or clipboard-like data onto this locator.</para>
+    /// <para>**Details**</para>
+    /// <para>
+    /// Dispatches the native <c>dragenter</c>, <c>dragover</c>, and <c>drop</c> events
+    /// at the center of the target element with a synthetic <see cref="DataTransfer"/>
+    /// carrying the provided files and/or data entries. Works cross-browser by constructing
+    /// the <see cref="DataTransfer"/> in the page context.
+    /// </para>
+    /// <para>
+    /// If the target element's <c>dragover</c> listener does not call <c>preventDefault()</c>,
+    /// the target is considered to have rejected the drop: Playwright dispatches <c>dragleave</c>
+    /// and this method throws.
+    /// </para>
+    /// <para>**Usage**</para>
+    /// <para>Drop a file buffer onto an upload area:</para>
+    /// <para>Drop plain text and a URL together:</para>
+    /// </summary>
+    /// <param name="payload">
+    /// Data to drop onto the target. Provide <c>files</c> (file paths or in-memory buffers),
+    /// <c>data</c> (a mime-type → string map for clipboard-like content such as <c>text/plain</c>,
+    /// <c>text/html</c>, <c>text/uri-list</c>), or both.
+    /// </param>
+    /// <param name="options">Call options</param>
+    Task DropAsync(DropPayload payload, LocatorDropOptions? options = default);
+
+    /// <summary>
     /// <para>
     /// Always prefer using <see cref="ILocator"/>s and web assertions over <see cref="IElementHandle"/>s
     /// because latter are inherently racy.
@@ -938,13 +964,17 @@ public partial interface ILocator
     /// <param name="options">Call options</param>
     ILocator GetByTitle(Regex text, LocatorGetByTitleOptions? options = default);
 
+    /// <summary><para>Hides the element highlight previously added by <see cref="ILocator.HighlightAsync"/>.</para></summary>
+    Task HideHighlightAsync();
+
     /// <summary>
     /// <para>
     /// Highlight the corresponding element(s) on the screen. Useful for debugging, don't
     /// commit the code that uses <see cref="ILocator.HighlightAsync"/>.
     /// </para>
     /// </summary>
-    Task HighlightAsync();
+    /// <param name="options">Call options</param>
+    Task<IAsyncDisposable> HighlightAsync(LocatorHighlightOptions? options = default);
 
     /// <summary>
     /// <para>Hover over the matching element.</para>

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -824,8 +824,7 @@ public partial interface IPage
     /// </remarks>
     /// <param name="name">Name of the function on the window object.</param>
     /// <param name="callback">Callback function that will be called in the Playwright's context.</param>
-    /// <param name="options">Call options</param>
-    Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback, PageExposeBindingOptions? options = default);
+    Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback);
 
     /// <summary>
     /// <para>
@@ -1356,6 +1355,14 @@ public partial interface IPage
     /// </param>
     /// <param name="options">Call options</param>
     Task<IResponse?> GotoAsync(string url, PageGotoOptions? options = default);
+
+    /// <summary>
+    /// <para>
+    /// Hide all locator highlight overlays previously added by <see cref="ILocator.HighlightAsync"/>
+    /// on this page.
+    /// </para>
+    /// </summary>
+    Task HideHighlightAsync();
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/IPageAssertions.cs
+++ b/src/Playwright/API/Generated/IPageAssertions.cs
@@ -62,6 +62,25 @@ public partial interface IPageAssertions
     public IPageAssertions Not { get; }
 
     /// <summary>
+    /// <para>
+    /// Asserts that the page body matches the given <a href="https://playwright.dev/dotnet/docs/aria-snapshots">accessibility
+    /// snapshot</a>.
+    /// </para>
+    /// <para>**Usage**</para>
+    /// <code>
+    /// await page.GotoAsync("https://demo.playwright.dev/todomvc/");<br/>
+    /// await Expect(page).ToMatchAriaSnapshotAsync(@"<br/>
+    ///   - heading ""todos""<br/>
+    ///   - textbox ""What needs to be done?""<br/>
+    /// ");
+    /// </code>
+    /// </summary>
+    /// <param name="expected">
+    /// </param>
+    /// <param name="options">Call options</param>
+    Task ToMatchAriaSnapshotAsync(string expected, PageAssertionsToMatchAriaSnapshotOptions? options = default);
+
+    /// <summary>
     /// <para>Ensures the page has the given title.</para>
     /// <para>**Usage**</para>
     /// <code>await Expect(Page).ToHaveTitleAsync("Playwright");</code>

--- a/src/Playwright/API/Generated/ITracing.cs
+++ b/src/Playwright/API/Generated/ITracing.cs
@@ -161,6 +161,28 @@ public partial interface ITracing
     Task StartChunkAsync(TracingStartChunkOptions? options = default);
 
     /// <summary>
+    /// <para>
+    /// Start recording a HAR (HTTP Archive) of network activity in this context. The HAR
+    /// file is written to disk when <see cref="ITracing.StopHarAsync"/> is called, or when
+    /// the returned <see cref="Disposable"/> is disposed.
+    /// </para>
+    /// <para>Only one HAR recording can be active at a time per <see cref="IBrowserContext"/>.</para>
+    /// <para>**Usage**</para>
+    /// <code>
+    /// await context.Tracing.StartHarAsync("trace.har");<br/>
+    /// var page = await context.NewPageAsync();<br/>
+    /// await page.GotoAsync("https://playwright.dev");<br/>
+    /// await context.Tracing.StopHarAsync();
+    /// </code>
+    /// </summary>
+    /// <param name="path">
+    /// Path on the filesystem to write the HAR file to. If the file name ends with <c>.zip</c>,
+    /// the HAR is saved as a zip archive with response bodies attached as separate files.
+    /// </param>
+    /// <param name="options">Call options</param>
+    Task<IAsyncDisposable> StartHarAsync(string path, TracingStartHarOptions? options = default);
+
+    /// <summary>
     /// <para>Use <c>test.step</c> instead when available.</para>
     /// <para>
     /// Creates a new group within the trace, assigning any subsequent API calls to this
@@ -197,4 +219,7 @@ public partial interface ITracing
     /// </summary>
     /// <param name="options">Call options</param>
     Task StopChunkAsync(TracingStopChunkOptions? options = default);
+
+    /// <summary><para>Stop HAR recording and save the HAR file to the path given to <see cref="ITracing.StartHarAsync"/>.</para></summary>
+    Task StopHarAsync();
 }

--- a/src/Playwright/API/Generated/IWebError.cs
+++ b/src/Playwright/API/Generated/IWebError.cs
@@ -44,4 +44,6 @@ public partial interface IWebError
 
     /// <summary><para>Unhandled error that was thrown.</para></summary>
     string Error { get; }
+
+    WebErrorLocation Location { get; }
 }

--- a/src/Playwright/API/Generated/IWebSocketRoute.cs
+++ b/src/Playwright/API/Generated/IWebSocketRoute.cs
@@ -23,6 +23,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.Playwright;
@@ -200,6 +201,25 @@ public partial interface IWebSocketRoute
     /// </summary>
     /// <param name="message">Message to send.</param>
     void Send(byte[] message);
+
+    /// <summary>
+    /// <para>
+    /// The list of WebSocket subprotocols requested by the page, as passed via the second
+    /// argument to the <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket"><c>WebSocket</c>
+    /// constructor</a>. Corresponds to the <c>Sec-WebSocket-Protocol</c> request header.
+    /// </para>
+    /// <para>Returns an empty array if no protocols were specified.</para>
+    /// <para>**Usage**</para>
+    /// <code>
+    /// await page.RouteWebSocketAsync("wss://example.com/ws", ws =&gt; {<br/>
+    ///   if (ws.Protocols.Contains("chat.v2"))<br/>
+    ///     ws.OnMessage(frame =&gt; ws.Send($"v2:{frame.Text}"));<br/>
+    ///   else<br/>
+    ///     ws.CloseAsync(new() { Code = 1002, Reason = "Unsupported protocol" });<br/>
+    /// });
+    /// </code>
+    /// </summary>
+    IReadOnlyList<string> Protocols { get; }
 
     /// <summary><para>URL of the WebSocket created in the page.</para></summary>
     string Url { get; }

--- a/src/Playwright/API/Generated/Options/BrowserTypeConnectOverCDPOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserTypeConnectOverCDPOptions.cs
@@ -40,6 +40,7 @@ public class BrowserTypeConnectOverCDPOptions
 
         Headers = clone.Headers;
         IsLocal = clone.IsLocal;
+        NoDefaults = clone.NoDefaults;
         SlowMo = clone.SlowMo;
         Timeout = clone.Timeout;
     }
@@ -57,6 +58,21 @@ public class BrowserTypeConnectOverCDPOptions
     /// </summary>
     [JsonPropertyName("isLocal")]
     public bool? IsLocal { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// When true, Playwright will not apply its default overrides to the existing default
+    /// browser context. Specifically, <see cref="IBrowser.NewContextAsync"/> is left at
+    /// the browser's setting, focus emulation is not enabled, and media emulation options
+    /// (such as <see cref="IBrowser.NewContextAsync"/>, <see cref="IBrowser.NewContextAsync"/>,
+    /// <see cref="IBrowser.NewContextAsync"/>, and <see cref="IBrowser.NewContextAsync"/>)
+    /// are not applied. Useful when attaching to a user's daily-driver browser where these
+    /// overrides would interfere with existing browser state. New contexts created via
+    /// <see cref="IBrowser.NewContextAsync"/> are not affected. Defaults to <c>false</c>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("noDefaults")]
+    public bool? NoDefaults { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameGetByRoleOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameGetByRoleOptions.cs
@@ -39,6 +39,9 @@ public class FrameGetByRoleOptions
         }
 
         Checked = clone.Checked;
+        Description = clone.Description;
+        DescriptionRegex = clone.DescriptionRegex;
+        DescriptionString = clone.DescriptionString;
         Disabled = clone.Disabled;
         Exact = clone.Exact;
         Expanded = clone.Expanded;
@@ -62,6 +65,48 @@ public class FrameGetByRoleOptions
     public bool? Checked { get; set; }
 
     /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrame.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrame.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionRegex")]
+    public Regex? DescriptionRegex { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrame.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionString")]
+    public string? DescriptionString { get; set; }
+
+    /// <summary>
     /// <para>An attribute that is usually set by <c>aria-disabled</c> or <c>disabled</c>.</para>
     /// <para>
     /// Unlike most other attributes, <c>disabled</c> is inherited through the DOM hierarchy.
@@ -80,9 +125,9 @@ public class FrameGetByRoleOptions
 
     /// <summary>
     /// <para>
-    /// Whether <see cref="IFrame.GetByRole"/> is matched exactly: case-sensitive and whole-string.
-    /// Defaults to false. Ignored when <see cref="IFrame.GetByRole"/> is a regular expression.
-    /// Note that exact match still trims whitespace.
+    /// Whether <see cref="IFrame.GetByRole"/> and <see cref="IFrame.GetByRole"/> are matched
+    /// exactly: case-sensitive and whole-string. Defaults to false. Ignored when the value
+    /// is a regular expression. Note that exact match still trims whitespace.
     /// </para>
     /// </summary>
     [JsonPropertyName("exact")]

--- a/src/Playwright/API/Generated/Options/FrameLocatorGetByRoleOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameLocatorGetByRoleOptions.cs
@@ -39,6 +39,9 @@ public class FrameLocatorGetByRoleOptions
         }
 
         Checked = clone.Checked;
+        Description = clone.Description;
+        DescriptionRegex = clone.DescriptionRegex;
+        DescriptionString = clone.DescriptionString;
         Disabled = clone.Disabled;
         Exact = clone.Exact;
         Expanded = clone.Expanded;
@@ -62,6 +65,48 @@ public class FrameLocatorGetByRoleOptions
     public bool? Checked { get; set; }
 
     /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrameLocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrameLocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionRegex")]
+    public Regex? DescriptionRegex { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IFrameLocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionString")]
+    public string? DescriptionString { get; set; }
+
+    /// <summary>
     /// <para>An attribute that is usually set by <c>aria-disabled</c> or <c>disabled</c>.</para>
     /// <para>
     /// Unlike most other attributes, <c>disabled</c> is inherited through the DOM hierarchy.
@@ -80,9 +125,9 @@ public class FrameLocatorGetByRoleOptions
 
     /// <summary>
     /// <para>
-    /// Whether <see cref="IFrameLocator.GetByRole"/> is matched exactly: case-sensitive
-    /// and whole-string. Defaults to false. Ignored when <see cref="IFrameLocator.GetByRole"/>
-    /// is a regular expression. Note that exact match still trims whitespace.
+    /// Whether <see cref="IFrameLocator.GetByRole"/> and <see cref="IFrameLocator.GetByRole"/>
+    /// are matched exactly: case-sensitive and whole-string. Defaults to false. Ignored
+    /// when the value is a regular expression. Note that exact match still trims whitespace.
     /// </para>
     /// </summary>
     [JsonPropertyName("exact")]

--- a/src/Playwright/API/Generated/Options/LocatorAriaSnapshotOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorAriaSnapshotOptions.cs
@@ -37,10 +37,22 @@ public class LocatorAriaSnapshotOptions
             return;
         }
 
+        Boxes = clone.Boxes;
         Depth = clone.Depth;
         Mode = clone.Mode;
         Timeout = clone.Timeout;
     }
+
+    /// <summary>
+    /// <para>
+    /// When <c>true</c>, appends each element's bounding box as <c>[box=x,y,width,height]</c>
+    /// to the snapshot. Coordinates are relative to the viewport, in CSS pixels, as returned
+    /// by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect"><c>Element.getBoundingClientRect()</c></a>.
+    /// Defaults to <c>false</c>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("boxes")]
+    public bool? Boxes { get; set; }
 
     /// <summary><para>When specified, limits the depth of the snapshot.</para></summary>
     [JsonPropertyName("depth")]

--- a/src/Playwright/API/Generated/Options/LocatorDropOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorDropOptions.cs
@@ -26,47 +26,29 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class PageAriaSnapshotOptions
+public class LocatorDropOptions
 {
-    public PageAriaSnapshotOptions() { }
+    public LocatorDropOptions() { }
 
-    public PageAriaSnapshotOptions(PageAriaSnapshotOptions clone)
+    public LocatorDropOptions(LocatorDropOptions clone)
     {
         if (clone == null)
         {
             return;
         }
 
-        Boxes = clone.Boxes;
-        Depth = clone.Depth;
-        Mode = clone.Mode;
+        Position = clone.Position;
         Timeout = clone.Timeout;
     }
 
     /// <summary>
     /// <para>
-    /// When <c>true</c>, appends each element's bounding box as <c>[box=x,y,width,height]</c>
-    /// to the snapshot. Coordinates are relative to the viewport, in CSS pixels, as returned
-    /// by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect"><c>Element.getBoundingClientRect()</c></a>.
-    /// Defaults to <c>false</c>.
+    /// A point to use relative to the top-left corner of element padding box. If not specified,
+    /// uses some visible point of the element.
     /// </para>
     /// </summary>
-    [JsonPropertyName("boxes")]
-    public bool? Boxes { get; set; }
-
-    /// <summary><para>When specified, limits the depth of the snapshot.</para></summary>
-    [JsonPropertyName("depth")]
-    public int? Depth { get; set; }
-
-    /// <summary>
-    /// <para>
-    /// When set to <c>"ai"</c>, returns a snapshot optimized for AI consumption: including
-    /// element references like <c>[ref=e2]</c> and snapshots of <c>&lt;iframe&gt;</c>s.
-    /// Defaults to <c>"default"</c>.
-    /// </para>
-    /// </summary>
-    [JsonPropertyName("mode")]
-    public AriaSnapshotMode? Mode { get; set; }
+    [JsonPropertyName("position")]
+    public Position? Position { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorGetByRoleOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorGetByRoleOptions.cs
@@ -39,6 +39,9 @@ public class LocatorGetByRoleOptions
         }
 
         Checked = clone.Checked;
+        Description = clone.Description;
+        DescriptionRegex = clone.DescriptionRegex;
+        DescriptionString = clone.DescriptionString;
         Disabled = clone.Disabled;
         Exact = clone.Exact;
         Expanded = clone.Expanded;
@@ -62,6 +65,48 @@ public class LocatorGetByRoleOptions
     public bool? Checked { get; set; }
 
     /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="ILocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="ILocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionRegex")]
+    public Regex? DescriptionRegex { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="ILocator.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionString")]
+    public string? DescriptionString { get; set; }
+
+    /// <summary>
     /// <para>An attribute that is usually set by <c>aria-disabled</c> or <c>disabled</c>.</para>
     /// <para>
     /// Unlike most other attributes, <c>disabled</c> is inherited through the DOM hierarchy.
@@ -80,9 +125,9 @@ public class LocatorGetByRoleOptions
 
     /// <summary>
     /// <para>
-    /// Whether <see cref="ILocator.GetByRole"/> is matched exactly: case-sensitive and
-    /// whole-string. Defaults to false. Ignored when <see cref="ILocator.GetByRole"/> is
-    /// a regular expression. Note that exact match still trims whitespace.
+    /// Whether <see cref="ILocator.GetByRole"/> and <see cref="ILocator.GetByRole"/> are
+    /// matched exactly: case-sensitive and whole-string. Defaults to false. Ignored when
+    /// the value is a regular expression. Note that exact match still trims whitespace.
     /// </para>
     /// </summary>
     [JsonPropertyName("exact")]

--- a/src/Playwright/API/Generated/Options/LocatorHighlightOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorHighlightOptions.cs
@@ -26,26 +26,26 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class LocatorAssertionsToHaveCSSOptions
+public class LocatorHighlightOptions
 {
-    public LocatorAssertionsToHaveCSSOptions() { }
+    public LocatorHighlightOptions() { }
 
-    public LocatorAssertionsToHaveCSSOptions(LocatorAssertionsToHaveCSSOptions clone)
+    public LocatorHighlightOptions(LocatorHighlightOptions clone)
     {
         if (clone == null)
         {
             return;
         }
 
-        Pseudo = clone.Pseudo;
-        Timeout = clone.Timeout;
+        Style = clone.Style;
     }
 
-    /// <summary><para>Pseudo-element to read computed styles from.</para></summary>
-    [JsonPropertyName("pseudo")]
-    public PseudoElement? Pseudo { get; set; }
-
-    /// <summary><para>Time to retry the assertion for in milliseconds. Defaults to <c>5000</c>.</para></summary>
-    [JsonPropertyName("timeout")]
-    public float? Timeout { get; set; }
+    /// <summary>
+    /// <para>
+    /// Additional inline CSS applied to the highlight overlay, e.g. <c>"outline: 2px dashed
+    /// red"</c>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("style")]
+    public string? Style { get; set; }
 }

--- a/src/Playwright/API/Generated/Options/PageAssertionsToMatchAriaSnapshotOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageAssertionsToMatchAriaSnapshotOptions.cs
@@ -26,24 +26,19 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class LocatorAssertionsToHaveCSSOptions
+public class PageAssertionsToMatchAriaSnapshotOptions
 {
-    public LocatorAssertionsToHaveCSSOptions() { }
+    public PageAssertionsToMatchAriaSnapshotOptions() { }
 
-    public LocatorAssertionsToHaveCSSOptions(LocatorAssertionsToHaveCSSOptions clone)
+    public PageAssertionsToMatchAriaSnapshotOptions(PageAssertionsToMatchAriaSnapshotOptions clone)
     {
         if (clone == null)
         {
             return;
         }
 
-        Pseudo = clone.Pseudo;
         Timeout = clone.Timeout;
     }
-
-    /// <summary><para>Pseudo-element to read computed styles from.</para></summary>
-    [JsonPropertyName("pseudo")]
-    public PseudoElement? Pseudo { get; set; }
 
     /// <summary><para>Time to retry the assertion for in milliseconds. Defaults to <c>5000</c>.</para></summary>
     [JsonPropertyName("timeout")]

--- a/src/Playwright/API/Generated/Options/PageGetByRoleOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageGetByRoleOptions.cs
@@ -39,6 +39,9 @@ public class PageGetByRoleOptions
         }
 
         Checked = clone.Checked;
+        Description = clone.Description;
+        DescriptionRegex = clone.DescriptionRegex;
+        DescriptionString = clone.DescriptionString;
         Disabled = clone.Disabled;
         Exact = clone.Exact;
         Expanded = clone.Expanded;
@@ -62,6 +65,48 @@ public class PageGetByRoleOptions
     public bool? Checked { get; set; }
 
     /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IPage.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IPage.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionRegex")]
+    public Regex? DescriptionRegex { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Option to match the <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>. By default, matching is case-insensitive and searches for a substring,
+    /// use <see cref="IPage.GetByRole"/> to control this behavior.
+    /// </para>
+    /// <para>
+    /// Learn more about <a href="https://w3c.github.io/accname/#dfn-accessible-description">accessible
+    /// description</a>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("descriptionString")]
+    public string? DescriptionString { get; set; }
+
+    /// <summary>
     /// <para>An attribute that is usually set by <c>aria-disabled</c> or <c>disabled</c>.</para>
     /// <para>
     /// Unlike most other attributes, <c>disabled</c> is inherited through the DOM hierarchy.
@@ -80,9 +125,9 @@ public class PageGetByRoleOptions
 
     /// <summary>
     /// <para>
-    /// Whether <see cref="IPage.GetByRole"/> is matched exactly: case-sensitive and whole-string.
-    /// Defaults to false. Ignored when <see cref="IPage.GetByRole"/> is a regular expression.
-    /// Note that exact match still trims whitespace.
+    /// Whether <see cref="IPage.GetByRole"/> and <see cref="IPage.GetByRole"/> are matched
+    /// exactly: case-sensitive and whole-string. Defaults to false. Ignored when the value
+    /// is a regular expression. Note that exact match still trims whitespace.
     /// </para>
     /// </summary>
     [JsonPropertyName("exact")]

--- a/src/Playwright/API/Generated/Options/ScreencastStartOptions.cs
+++ b/src/Playwright/API/Generated/Options/ScreencastStartOptions.cs
@@ -44,7 +44,12 @@ public class ScreencastStartOptions
         Quality = clone.Quality;
     }
 
-    /// <summary><para>Callback that receives JPEG-encoded frame data.</para></summary>
+    /// <summary>
+    /// <para>
+    /// Callback that receives JPEG-encoded frame data along with the page viewport size
+    /// at the time of capture.
+    /// </para>
+    /// </summary>
     [JsonPropertyName("onFrame")]
     public Func<ScreencastFrame, Task>? OnFrame { get; set; }
 

--- a/src/Playwright/API/Generated/Options/TracingStartHarOptions.cs
+++ b/src/Playwright/API/Generated/Options/TracingStartHarOptions.cs
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Playwright;
+
+public class TracingStartHarOptions
+{
+    public TracingStartHarOptions() { }
+
+    public TracingStartHarOptions(TracingStartHarOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
+
+        Content = clone.Content;
+        Mode = clone.Mode;
+        UrlFilter = clone.UrlFilter;
+        UrlFilterRegex = clone.UrlFilterRegex;
+        UrlFilterString = clone.UrlFilterString;
+    }
+
+    /// <summary>
+    /// <para>
+    /// Optional setting to control resource content management. If <c>omit</c> is specified,
+    /// content is not persisted. If <c>attach</c> is specified, resources are persisted
+    /// as separate files or entries in the ZIP archive. If <c>embed</c> is specified, content
+    /// is stored inline the HAR file as per HAR specification. Defaults to <c>attach</c>
+    /// for <c>.zip</c> output files and to <c>embed</c> for all other file extensions.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("content")]
+    public HarContentPolicy? Content { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// When set to <c>minimal</c>, only record information necessary for routing from HAR.
+    /// This omits sizes, timing, page, cookies, security and other types of HAR information
+    /// that are not used when replaying from HAR. Defaults to <c>full</c>.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public HarMode? Mode { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// A glob or regex pattern to filter requests that are stored in the HAR. Defaults
+    /// to none.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("urlFilter")]
+    public string? UrlFilter { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// A glob or regex pattern to filter requests that are stored in the HAR. Defaults
+    /// to none.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("urlFilterRegex")]
+    public Regex? UrlFilterRegex { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// A glob or regex pattern to filter requests that are stored in the HAR. Defaults
+    /// to none.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("urlFilterString")]
+    public string? UrlFilterString { get; set; }
+}

--- a/src/Playwright/API/Generated/Types/DropPayload.cs
+++ b/src/Playwright/API/Generated/Types/DropPayload.cs
@@ -22,30 +22,14 @@
  * SOFTWARE.
  */
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class LocatorAssertionsToHaveCSSOptions
+public partial class DropPayload
 {
-    public LocatorAssertionsToHaveCSSOptions() { }
-
-    public LocatorAssertionsToHaveCSSOptions(LocatorAssertionsToHaveCSSOptions clone)
-    {
-        if (clone == null)
-        {
-            return;
-        }
-
-        Pseudo = clone.Pseudo;
-        Timeout = clone.Timeout;
-    }
-
-    /// <summary><para>Pseudo-element to read computed styles from.</para></summary>
-    [JsonPropertyName("pseudo")]
-    public PseudoElement? Pseudo { get; set; }
-
-    /// <summary><para>Time to retry the assertion for in milliseconds. Defaults to <c>5000</c>.</para></summary>
-    [JsonPropertyName("timeout")]
-    public float? Timeout { get; set; }
+    /// <summary><para></para></summary>
+    [JsonPropertyName("data")]
+    public IEnumerable<KeyValuePair<string, string>>? Data { get; set; }
 }

--- a/src/Playwright/API/Generated/Types/ScreencastFrame.cs
+++ b/src/Playwright/API/Generated/Types/ScreencastFrame.cs
@@ -33,4 +33,14 @@ public partial class ScreencastFrame
     [Required]
     [JsonPropertyName("data")]
     public byte[] Data { get; set; } = default!;
+
+    /// <summary><para>Width of the page viewport at the time the frame was captured.</para></summary>
+    [Required]
+    [JsonPropertyName("viewportWidth")]
+    public int ViewportWidth { get; set; } = default!;
+
+    /// <summary><para>Height of the page viewport at the time the frame was captured.</para></summary>
+    [Required]
+    [JsonPropertyName("viewportHeight")]
+    public int ViewportHeight { get; set; } = default!;
 }

--- a/src/Playwright/API/Generated/Types/WebErrorLocation.cs
+++ b/src/Playwright/API/Generated/Types/WebErrorLocation.cs
@@ -22,33 +22,25 @@
  * SOFTWARE.
  */
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class PageExposeBindingOptions
+public partial class WebErrorLocation
 {
-    public PageExposeBindingOptions() { }
+    /// <summary><para>URL of the resource.</para></summary>
+    [Required]
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = default!;
 
-    public PageExposeBindingOptions(PageExposeBindingOptions clone)
-    {
-        if (clone == null)
-        {
-            return;
-        }
+    /// <summary><para>0-based line number in the resource.</para></summary>
+    [Required]
+    [JsonPropertyName("line")]
+    public int Line { get; set; } = default!;
 
-        Handle = clone.Handle;
-    }
-
-    /// <summary>
-    /// <para>**DEPRECATED** This option will be removed in the future.</para>
-    /// <para>
-    /// Whether to pass the argument as a handle, instead of passing by value. When passing
-    /// a handle, only one argument is supported. When passing by value, multiple arguments
-    /// are supported.
-    /// </para>
-    /// </summary>
-    [JsonPropertyName("handle")]
-    [System.Obsolete]
-    public bool? Handle { get; set; }
+    /// <summary><para>0-based column number in the resource.</para></summary>
+    [Required]
+    [JsonPropertyName("column")]
+    public int Column { get; set; } = default!;
 }

--- a/src/Playwright/API/Supplements/DropPayload.cs
+++ b/src/Playwright/API/Supplements/DropPayload.cs
@@ -22,33 +22,28 @@
  * SOFTWARE.
  */
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public class BrowserContextExposeBindingOptions
+public partial class DropPayload
 {
-    public BrowserContextExposeBindingOptions() { }
-
-    public BrowserContextExposeBindingOptions(BrowserContextExposeBindingOptions clone)
-    {
-        if (clone == null)
-        {
-            return;
-        }
-
-        Handle = clone.Handle;
-    }
-
     /// <summary>
-    /// <para>**DEPRECATED** This option will be removed in the future.</para>
     /// <para>
-    /// Whether to pass the argument as a handle, instead of passing by value. When passing
-    /// a handle, only one argument is supported. When passing by value, multiple arguments
-    /// are supported.
+    /// File paths to drop onto the target. The files are read from disk and dispatched
+    /// as a synthetic <c>DataTransfer</c>.
     /// </para>
     /// </summary>
-    [JsonPropertyName("handle")]
-    [System.Obsolete]
-    public bool? Handle { get; set; }
+    [JsonIgnore]
+    public IEnumerable<string>? FilePaths { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// In-memory file payloads to drop onto the target. Use this when the file content
+    /// is not on disk.
+    /// </para>
+    /// </summary>
+    [JsonIgnore]
+    public IEnumerable<FilePayload>? Files { get; set; }
 }

--- a/src/Playwright/API/Supplements/IBrowserContext.cs
+++ b/src/Playwright/API/Supplements/IBrowserContext.cs
@@ -41,28 +41,25 @@ namespace Microsoft.Playwright;
 /// </summary>
 public partial interface IBrowserContext : IAsyncDisposable
 {
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync(string name, Action<BindingSource> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<T>(string name, Action<BindingSource, T> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
-    Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback);
-
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<T1, T2, TResult>(string name, Func<BindingSource, T1, T2, TResult> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<T1, T2, T3, TResult>(string name, Func<BindingSource, T1, T2, T3, TResult> callback);
 
-    /// <inheritdoc cref="ExposeBindingAsync(string, Action, BrowserContextExposeBindingOptions)"/>
+    /// <inheritdoc cref="ExposeBindingAsync(string, Action)"/>
     Task<IAsyncDisposable> ExposeBindingAsync<T1, T2, T3, T4, TResult>(string name, Func<BindingSource, T1, T2, T3, T4, TResult> callback);
 
     /// <inheritdoc cref="ExposeFunctionAsync(string, Action)"/>

--- a/src/Playwright/API/Supplements/IPage.cs
+++ b/src/Playwright/API/Supplements/IPage.cs
@@ -43,8 +43,6 @@ public partial interface IPage : IAsyncDisposable
 
     Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback);
 
-    Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback);
-
     Task<IAsyncDisposable> ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback);
 
     Task<IAsyncDisposable> ExposeBindingAsync<T1, T2, TResult>(string name, Func<BindingSource, T1, T2, TResult> callback);

--- a/src/Playwright/CompatibilitySuppressions.xml
+++ b/src/Playwright/CompatibilitySuppressions.xml
@@ -10,7 +10,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Microsoft.Playwright.BrowserContextExposeBindingOptions</Target>
+    <Left>lib/netstandard2.0/Microsoft.Playwright.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Playwright.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Microsoft.Playwright.IAccessibility</Target>
+    <Left>lib/netstandard2.0/Microsoft.Playwright.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Playwright.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Microsoft.Playwright.PageExposeBindingOptions</Target>
     <Left>lib/netstandard2.0/Microsoft.Playwright.dll</Left>
     <Right>lib/netstandard2.0/Microsoft.Playwright.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -207,6 +221,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Microsoft.Playwright.IBrowserContext.RouteAsync(System.Text.RegularExpressions.Regex,System.Func{Microsoft.Playwright.IRoute,System.Threading.Tasks.Task},Microsoft.Playwright.BrowserContextRouteOptions)</Target>
+    <Left>lib/netstandard2.0/Microsoft.Playwright.dll</Left>
+    <Right>lib/netstandard2.0/Microsoft.Playwright.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Microsoft.Playwright.ILocator.HighlightAsync</Target>
     <Left>lib/netstandard2.0/Microsoft.Playwright.dll</Left>
     <Right>lib/netstandard2.0/Microsoft.Playwright.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Playwright/Core/APIRequestContext.cs
+++ b/src/Playwright/Core/APIRequestContext.cs
@@ -47,6 +47,8 @@ internal class APIRequestContext : ChannelOwner, IAPIRequestContext
         _tracing = initializer.Tracing;
     }
 
+    public ITracing Tracing => _tracing;
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async ValueTask DisposeAsync()
     {

--- a/src/Playwright/Core/AssertionsBase.cs
+++ b/src/Playwright/Core/AssertionsBase.cs
@@ -88,12 +88,13 @@ internal abstract class AssertionsBase
             {
                 message += "\n" + result.ErrorMessage;
             }
+            var ariaSnapshotSuffix = string.IsNullOrEmpty(result.ReceivedAriaSnapshot) ? string.Empty : $"\nAria snapshot:\n{result.ReceivedAriaSnapshot}";
             var prefix = CustomMessage != null ? CustomMessage + "\n\n" : string.Empty;
             if (expected == null)
             {
-                throw new PlaywrightException($"{prefix}{message} {log}");
+                throw new PlaywrightException($"{prefix}{message} {log}{ariaSnapshotSuffix}");
             }
-            throw new PlaywrightException($"{prefix}{message} '{FormatValue(expected)}'\nBut was: '{FormatValue(actual)}' {log}");
+            throw new PlaywrightException($"{prefix}{message} '{FormatValue(expected)}'\nBut was: '{FormatValue(actual)}' {log}{ariaSnapshotSuffix}");
         }
     }
 

--- a/src/Playwright/Core/BindingCall.cs
+++ b/src/Playwright/Core/BindingCall.cs
@@ -57,16 +57,9 @@ internal class BindingCall : ChannelOwner
                 new BindingSource(_initializer.Frame.Page.Context, _initializer.Frame.Page, _initializer.Frame),
             };
 
-            if (methodParams.Length == 1 && methodParams[0] == typeof(IJSHandle))
+            for (int i = 0; i < methodParams.Length; i++)
             {
-                args.Add(_initializer.Handle);
-            }
-            else
-            {
-                for (int i = 0; i < methodParams.Length; i++)
-                {
-                    args.Add(ScriptsHelper.ParseEvaluateResult(_initializer.Args[i], methodParams[i]));
-                }
+                args.Add(ScriptsHelper.ParseEvaluateResult(_initializer.Args[i], methodParams[i]));
             }
 
             object? result = binding.DynamicInvoke(args.ToArray());

--- a/src/Playwright/Core/Browser.cs
+++ b/src/Playwright/Core/Browser.cs
@@ -55,6 +55,8 @@ internal class Browser : ChannelOwner, IBrowser
 
     public event EventHandler<IBrowser>? Disconnected;
 
+    public event EventHandler<IBrowserContext>? Context;
+
     public IReadOnlyList<IBrowserContext> Contexts => _contexts.ToArray();
 
     public bool IsConnected { get; private set; }
@@ -285,6 +287,7 @@ internal class Browser : ChannelOwner, IBrowser
             context._tracing._tracesDir = _tracesDir;
             _browserType.Playwright._selectors._contextsForSelectors.Add(context);
         }
+        Context?.Invoke(this, context);
     }
 
     internal void DidClose()

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -47,7 +47,6 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     internal readonly Tracing _tracing;
     private readonly Clock _clock;
     internal readonly APIRequestContext _request;
-    private readonly Dictionary<string, HarRecorder> _harRecorders = new();
     internal readonly List<IWorker> _serviceWorkers = new();
     private readonly List<WebSocketRouteHandler> _webSocketRoutes = new();
     private List<RouteHandler> _routes = new();
@@ -99,6 +98,18 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     }
 
     public event EventHandler<IPage>? Page;
+
+    public event EventHandler<IPage>? PageClose;
+
+    public event EventHandler<IPage>? PageLoad;
+
+    public event EventHandler<IFrame>? FrameAttached;
+
+    public event EventHandler<IFrame>? FrameDetached;
+
+    public event EventHandler<IFrame>? FrameNavigated;
+
+    public event EventHandler<IDownload>? Download;
 
     public event EventHandler<IPage>? BackgroundPage;
 
@@ -204,7 +215,10 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
                     var error = serverParams.GetProperty("error").ToObject<SerializedError>(_connection.DefaultJsonSerializerOptions)!;
                     var pageObject = serverParams.GetProperty("page").ToObject<Page>(_connection.DefaultJsonSerializerOptions);
                     var parsedError = string.IsNullOrEmpty(error.Error.Stack) ? $"{error.Error.Name}: {error.Error.Message}" : error.Error.Stack;
-                    WebError?.Invoke(this, new WebError(pageObject, parsedError));
+                    var location = serverParams.TryGetProperty("location", out var locElement)
+                        ? locElement.ToObject<WebErrorLocation>(_connection.DefaultJsonSerializerOptions)
+                        : null;
+                    WebError?.Invoke(this, new WebError(pageObject, parsedError, location!));
                     pageObject?.FirePageError(parsedError);
                     break;
                 }
@@ -365,31 +379,7 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
         ClosingOrClosed = true;
         await _request.DisposeAsync(options?.Reason).ConfigureAwait(false);
         await WrapApiCallAsync(
-            async () =>
-        {
-            foreach (var harRecorder in _harRecorders)
-            {
-                var artifact = (await SendMessageToServerAsync(
-                    "harExport",
-                    new Dictionary<string, object?>
-                    {
-                        ["harId"] = harRecorder.Key,
-                    }).ConfigureAwait(false)).GetObject<Artifact>("artifact", _connection)!;
-                // Server side will compress artifact if content is attach or if file is .zip.
-                var isCompressed = harRecorder.Value.Content == HarContentPolicy.Attach || harRecorder.Value.Path.EndsWith(".zip", StringComparison.Ordinal);
-                var needCompressed = harRecorder.Value.Path.EndsWith(".zip", StringComparison.Ordinal);
-                if (isCompressed && !needCompressed)
-                {
-                    await artifact.SaveAsAsync(harRecorder.Value.Path + ".tmp").ConfigureAwait(false);
-                    await _connection.LocalUtils!.HarUnzipAsync(harRecorder.Value.Path + ".tmp", harRecorder.Value.Path).ConfigureAwait(false);
-                }
-                else
-                {
-                    await artifact.SaveAsAsync(harRecorder.Value.Path).ConfigureAwait(false);
-                }
-                await artifact.DeleteAsync().ConfigureAwait(false);
-            }
-        },
+            async () => await _tracing.ExportAllHarsAsync().ConfigureAwait(false),
             true).ConfigureAwait(false);
         await SendMessageToServerAsync("close", new Dictionary<string, object?>
         {
@@ -413,10 +403,8 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
             }).ConfigureAwait(false))?.GetProperty("cookies").ToObject<IReadOnlyList<BrowserContextCookiesResult>>()!;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback, BrowserContextExposeBindingOptions? options = default)
-#pragma warning disable CS0612 // Type or member is obsolete
-        => ExposeBindingAsync(name, callback, handle: options?.Handle ?? false);
-#pragma warning restore CS0612 // Type or member is obsolete
+    public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback)
+        => ExposeBindingAsync(name, (Delegate)callback);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action<BindingSource> callback)
@@ -429,10 +417,6 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback)
         => ExposeBindingAsync(name, (Delegate)callback);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback)
-        => ExposeBindingAsync(name, callback, true);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback)
@@ -840,6 +824,18 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
         _closeTcs.TrySetResult(true);
     }
 
+    internal void FirePageClose(IPage page) => PageClose?.Invoke(this, page);
+
+    internal void FirePageLoad(IPage page) => PageLoad?.Invoke(this, page);
+
+    internal void FireFrameAttached(IFrame frame) => FrameAttached?.Invoke(this, frame);
+
+    internal void FireFrameDetached(IFrame frame) => FrameDetached?.Invoke(this, frame);
+
+    internal void FireFrameNavigated(IFrame frame) => FrameNavigated?.Invoke(this, frame);
+
+    internal void FireDownload(IDownload download) => Download?.Invoke(this, download);
+
     private void Channel_OnPage(object sender, Page page)
     {
         page.Context = this;
@@ -862,7 +858,7 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
 
     private void Channel_Route(object sender, Route route) => _ = OnRouteAsync(route).ConfigureAwait(false);
 
-    private async Task<IAsyncDisposable> ExposeBindingAsync(string name, Delegate callback, bool handle = false)
+    private async Task<IAsyncDisposable> ExposeBindingAsync(string name, Delegate callback)
     {
         foreach (var page in _pages)
         {
@@ -884,7 +880,6 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
             new Dictionary<string, object?>
             {
                 ["name"] = name,
-                ["needsHandle"] = handle,
             }).ConfigureAwait(false);
         return result.GetObject<Disposable>("disposable", _connection)!;
     }
@@ -902,33 +897,8 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
         }
     }
 
-    internal async Task RecordIntoHarAsync(string har, Page? page, BrowserContextRouteFromHAROptions options, HarContentPolicy? contentPolicy)
-    {
-        contentPolicy = contentPolicy ?? RouteFromHarUpdateContentPolicyToHarContentPolicy(options?.UpdateContent);
-        var urlGlob = options?.Url ?? options?.UrlString;
-
-        var recordHarArgs = new Dictionary<string, object?>();
-        recordHarArgs["zip"] = har.EndsWith(".zip");
-        recordHarArgs["content"] = contentPolicy ?? HarContentPolicy.Attach;
-        if (!string.IsNullOrEmpty(urlGlob))
-        {
-            recordHarArgs["urlGlob"] = urlGlob;
-        }
-        if (options?.UrlRegex != null)
-        {
-            var (source, flags) = options.UrlRegex.GetSourceAndFlags();
-            recordHarArgs["urlRegexSource"] = source;
-            recordHarArgs["urlRegexFlags"] = flags;
-        }
-        recordHarArgs["mode"] = options?.UpdateMode ?? HarMode.Minimal;
-
-        var harId = (await SendMessageToServerAsync("harStart", new Dictionary<string, object?>
-            {
-                { "page", page },
-                { "options", recordHarArgs },
-            }).ConfigureAwait(false)).Value.GetProperty("harId").ToString();
-        _harRecorders.Add(harId, new(har, contentPolicy ?? HarContentPolicy.Attach));
-    }
+    internal Task<string> RecordIntoHarAsync(string har, Page? page, BrowserContextRouteFromHAROptions options, HarContentPolicy? contentPolicy, string? resourcesDir = null)
+        => _tracing.RecordIntoHarAsync(har, page, contentPolicy ?? RouteFromHarUpdateContentPolicyToHarContentPolicy(options?.UpdateContent), options?.Url ?? options?.UrlString, options?.UrlRegex, options?.UpdateMode ?? HarMode.Minimal, resourcesDir);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task RouteFromHARAsync(string har, BrowserContextRouteFromHAROptions? options = null)
@@ -994,17 +964,4 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
             ["patterns"] = patterns,
         }).ConfigureAwait(false);
     }
-}
-
-internal class HarRecorder
-{
-    internal HarRecorder(string path, HarContentPolicy? content)
-    {
-        Path = path;
-        Content = content;
-    }
-
-    internal string Path { get; }
-
-    internal HarContentPolicy? Content { get; }
 }

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -899,6 +899,37 @@ internal class Frame : ChannelOwner, IFrame
             ["targetPosition"] = options?.TargetPosition,
         });
 
+    internal async Task DropAsync(string selector, DropPayload payload, Position? position, float? timeout, bool strict)
+    {
+        SetInputFilesFiles? fileParams = null;
+        if (payload.FilePaths != null)
+        {
+            fileParams = await SetInputFilesHelpers.ConvertInputFilesAsync(payload.FilePaths, (BrowserContext)Page.Context).ConfigureAwait(false);
+        }
+        else if (payload.Files != null)
+        {
+            fileParams = SetInputFilesHelpers.ConvertInputFiles(payload.Files);
+        }
+
+        var data = payload.Data?.Select(kv => new Dictionary<string, object?>
+        {
+            ["mimeType"] = kv.Key,
+            ["value"] = kv.Value,
+        }).ToArray();
+
+        await SendMessageToServerAsync("drop", new Dictionary<string, object?>
+        {
+            ["selector"] = selector,
+            ["strict"] = strict,
+            ["position"] = position,
+            ["payloads"] = fileParams?.Payloads,
+            ["localPaths"] = fileParams?.LocalPaths,
+            ["streams"] = fileParams?.Streams,
+            ["data"] = data,
+            ["timeout"] = Timeout(timeout),
+        }).ConfigureAwait(false);
+    }
+
     internal async Task<FrameExpectResult> ExpectAsync(string? selector, string expression, FrameExpectOptions options)
     {
         var result = await SendMessageToServerAsync("expect", new Dictionary<string, object?>
@@ -914,9 +945,16 @@ internal class Frame : ChannelOwner, IFrame
             ["timeout"] = options.Timeout,
         }).ConfigureAwait(false);
         var parsed = result.Value.ToObject<FrameExpectResult>();
-        if (result.Value.TryGetProperty("received", out var received))
+        if (result.Value.TryGetProperty("received", out var received) && received.ValueKind == JsonValueKind.Object)
         {
-            parsed.Received = ScriptsHelper.ParseEvaluateResult<object>(received);
+            if (received.TryGetProperty("value", out var receivedValue))
+            {
+                parsed.Received = ScriptsHelper.ParseEvaluateResult<object>(receivedValue);
+            }
+            if (received.TryGetProperty("ariaSnapshot", out var ariaSnapshot) && ariaSnapshot.ValueKind == JsonValueKind.String)
+            {
+                parsed.ReceivedAriaSnapshot = ariaSnapshot.GetString();
+            }
         }
         return parsed;
     }
@@ -981,8 +1019,15 @@ internal class Frame : ChannelOwner, IFrame
         return waiter;
     }
 
-    internal Task HighlightAsync(string selector)
+    internal Task HighlightAsync(string selector, string? style = null)
         => SendMessageToServerAsync("highlight", new Dictionary<string, object?>
+        {
+            ["selector"] = selector,
+            ["style"] = style,
+        });
+
+    internal Task HideHighlightAsync(string selector)
+        => SendMessageToServerAsync("hideHighlight", new Dictionary<string, object?>
         {
             ["selector"] = selector,
         });

--- a/src/Playwright/Core/LocalUtils.cs
+++ b/src/Playwright/Core/LocalUtils.cs
@@ -84,11 +84,12 @@ internal class LocalUtils : ChannelOwner
                   { "harId", harId },
         });
 
-    internal Task HarUnzipAsync(string zipFile, string harFile)
+    internal Task HarUnzipAsync(string zipFile, string harFile, string? resourcesDir = null)
          => SendMessageToServerAsync("harUnzip", new Dictionary<string, object?>
         {
                   { "zipFile", zipFile },
                   { "harFile", harFile },
+                  { "resourcesDir", resourcesDir },
         });
 
     internal async Task<JsonPipe> ConnectAsync(string wsEndpoint, IEnumerable<KeyValuePair<string, string>>? headers = default, float? slowMo = default, float? timeout = default, string? exposeNetwork = default)

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -176,6 +176,9 @@ internal class Locator : ILocator
     public Task DragToAsync(ILocator target, LocatorDragToOptions? options = null)
         => _frame.DragAndDropAsync(_selector, ((Locator)target)._selector, ConvertOptions<FrameDragAndDropOptions>(options));
 
+    public Task DropAsync(DropPayload payload, LocatorDropOptions? options = null)
+        => _frame.DropAsync(_selector, payload, options?.Position, options?.Timeout, strict: true);
+
     public Task<JsonElement?> EvaluateAsync(string expression, object? arg = null, LocatorEvaluateOptions? options = null)
         => EvaluateAsync<JsonElement?>(expression, arg, options);
 
@@ -197,7 +200,13 @@ internal class Locator : ILocator
     public Task ClearAsync(LocatorClearOptions? options = null)
         => this._frame.WrapApiCallAsync(() => _frame.FillAsync(_selector, string.Empty, ConvertOptions<FrameFillOptions>(options)), false, "Clear");
 
-    public Task HighlightAsync() => _frame.HighlightAsync(_selector);
+    public async Task<IAsyncDisposable> HighlightAsync(LocatorHighlightOptions? options = default)
+    {
+        await _frame.HighlightAsync(_selector, options?.Style).ConfigureAwait(false);
+        return new DisposableStub(() => HideHighlightAsync());
+    }
+
+    public Task HideHighlightAsync() => _frame.HideHighlightAsync(_selector);
 
     ILocator ILocator.Locator(string selector, LocatorLocatorOptions? options)
         => new Locator(_frame, $"{_selector} >> {selector}", options);

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -258,7 +258,9 @@ internal class Page : ChannelOwner, IPage
                 WebSocket?.Invoke(this, serverParams.GetProperty("webSocket").ToObject<WebSocket>(_connection.DefaultJsonSerializerOptions));
                 break;
             case "download":
-                Download?.Invoke(this, new Download(this, serverParams.GetProperty("url").ToObject<string>(_connection.DefaultJsonSerializerOptions), serverParams.GetProperty("suggestedFilename").ToObject<string>(_connection.DefaultJsonSerializerOptions), serverParams.GetProperty("artifact").ToObject<Artifact>(_connection.DefaultJsonSerializerOptions)));
+                var download = new Download(this, serverParams.GetProperty("url").ToObject<string>(_connection.DefaultJsonSerializerOptions), serverParams.GetProperty("suggestedFilename").ToObject<string>(_connection.DefaultJsonSerializerOptions), serverParams.GetProperty("artifact").ToObject<Artifact>(_connection.DefaultJsonSerializerOptions));
+                Download?.Invoke(this, download);
+                Context?.FireDownload(download);
                 break;
             case "viewportSizeChanged":
                 var size = serverParams.GetProperty("viewportSize").ToObject<ViewportSize>(_connection.DefaultJsonSerializerOptions);
@@ -826,10 +828,11 @@ internal class Page : ChannelOwner, IPage
         }).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback, PageExposeBindingOptions? options = default)
-#pragma warning disable CS0612 // Type or member is obsolete
-        => InnerExposeBindingAsync(name, callback, options?.Handle ?? false);
-#pragma warning restore CS0612 // Type or member is obsolete
+    public Task HideHighlightAsync() => SendMessageToServerAsync("hideHighlight");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action callback)
+        => InnerExposeBindingAsync(name, callback);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync(string name, Action<BindingSource> callback)
@@ -842,10 +845,6 @@ internal class Page : ChannelOwner, IPage
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, TResult> callback)
         => InnerExposeBindingAsync(name, callback);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public Task<IAsyncDisposable> ExposeBindingAsync<TResult>(string name, Func<BindingSource, IJSHandle, TResult> callback)
-        => InnerExposeBindingAsync(name, callback, true);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IAsyncDisposable> ExposeBindingAsync<T, TResult>(string name, Func<BindingSource, T, TResult> callback)
@@ -1203,7 +1202,10 @@ internal class Page : ChannelOwner, IPage
     internal void NotifyPopup(Page page) => Popup?.Invoke(this, page);
 
     internal void OnFrameNavigated(Frame frame)
-        => FrameNavigated?.Invoke(this, frame);
+    {
+        FrameNavigated?.Invoke(this, frame);
+        Context?.FireFrameNavigated(frame);
+    }
 
     internal void FireConsole(IConsoleMessage message) => _consoleImpl?.Invoke(this, message);
 
@@ -1219,7 +1221,11 @@ internal class Page : ChannelOwner, IPage
 
     internal void FireResponse(IResponse response) => _responseImpl?.Invoke(this, response);
 
-    internal void FireLoad() => Load?.Invoke(this, this);
+    internal void FireLoad()
+    {
+        Load?.Invoke(this, this);
+        Context?.FirePageLoad(this);
+    }
 
     internal void FireDOMContentLoaded() => DOMContentLoaded?.Invoke(this, this);
 
@@ -1292,6 +1298,7 @@ internal class Page : ChannelOwner, IPage
         Context._pages.Remove(this);
         DisposeHarRouters();
         Close?.Invoke(this, this);
+        Context?.FirePageClose(this);
     }
 
     private void Channel_Crashed()
@@ -1365,6 +1372,7 @@ internal class Page : ChannelOwner, IPage
         frame.IsDetached = true;
         frame.ParentFrame?._childFrames?.Remove(frame);
         FrameDetached?.Invoke(this, args);
+        Context?.FireFrameDetached(args);
     }
 
     private void Channel_FrameAttached(object sender, IFrame args)
@@ -1374,9 +1382,10 @@ internal class Page : ChannelOwner, IPage
         _frames.Add(frame);
         frame.ParentFrame?._childFrames?.Add(frame);
         FrameAttached?.Invoke(this, args);
+        Context?.FireFrameAttached(args);
     }
 
-    private async Task<IAsyncDisposable> InnerExposeBindingAsync(string name, Delegate callback, bool handle = false)
+    private async Task<IAsyncDisposable> InnerExposeBindingAsync(string name, Delegate callback)
     {
         if (Bindings.ContainsKey(name))
         {
@@ -1390,7 +1399,6 @@ internal class Page : ChannelOwner, IPage
             new Dictionary<string, object?>
             {
                 ["name"] = name,
-                ["needsHandle"] = handle,
             }).ConfigureAwait(false);
         return result.GetObject<Disposable>("disposable", _connection)!;
     }

--- a/src/Playwright/Core/PageAssertions.cs
+++ b/src/Playwright/Core/PageAssertions.cs
@@ -60,4 +60,11 @@ internal class PageAssertions : AssertionsBase, IPageAssertions
 
     public Task ToHaveURLAsync(Regex urlOrRegExp, PageAssertionsToHaveURLOptions? options = null) =>
         ExpectImplAsync("to.have.url", ExpectedRegex(urlOrRegExp, new() { IgnoreCase = options?.IgnoreCase }), urlOrRegExp, "Page URL expected to match regex", "Expect \"ToHaveURLAsync\"", ConvertToFrameExpectOptions(options));
+
+    public Task ToMatchAriaSnapshotAsync(string expected, PageAssertionsToMatchAriaSnapshotOptions? options = null)
+    {
+        var commonOptions = ConvertToFrameExpectOptions(options);
+        commonOptions.ExpectedValue = ScriptsHelper.SerializedArgument(expected);
+        return ExpectImplAsync("to.match.aria", null as ExpectedTextValue[], expected, "Page expected to match Aria snapshot", "Expect \"ToMatchAriaSnapshotAsync\"", commonOptions);
+    }
 }

--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -24,8 +24,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
 using Microsoft.Playwright.Transport;
@@ -35,10 +37,12 @@ namespace Microsoft.Playwright.Core;
 
 internal class Tracing : ChannelOwner, ITracing
 {
+    private readonly Dictionary<string, HarRecorder> _harRecorders = new();
     internal string? _tracesDir;
     private bool _includeSources;
     private string? _stacksId;
     private bool _isTracing;
+    private string? _harId;
 
     public Tracing(ChannelOwner parent, string guid) : base(parent, guid)
     {
@@ -199,4 +203,164 @@ internal class Tracing : ChannelOwner, ITracing
 
     public Task GroupEndAsync()
         => SendMessageToServerAsync("tracingGroupEnd");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task<IAsyncDisposable> StartHarAsync(string path, TracingStartHarOptions? options = default)
+    {
+        if (_harId != null)
+        {
+            throw new PlaywrightException("HAR recording has already been started");
+        }
+        var defaultContent = path.EndsWith(".zip", StringComparison.Ordinal) ? HarContentPolicy.Attach : HarContentPolicy.Embed;
+        _harId = await RecordIntoHarAsync(
+            path,
+            null,
+            options?.Content ?? defaultContent,
+            options?.UrlFilter ?? options?.UrlFilterString,
+            options?.UrlFilterRegex,
+            options?.Mode ?? HarMode.Full,
+            null).ConfigureAwait(false);
+        return new DisposableStub(() => StopHarAsync());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task StopHarAsync()
+    {
+        var harId = _harId;
+        if (harId == null)
+        {
+            throw new PlaywrightException("HAR recording has not been started");
+        }
+        _harId = null;
+        await ExportHarAsync(harId).ConfigureAwait(false);
+    }
+
+    internal async Task<string> RecordIntoHarAsync(string har, Page? page, HarContentPolicy? content, string? urlGlob, Regex? urlRegex, HarMode? mode, string? resourcesDir)
+    {
+        var isZip = har.EndsWith(".zip", StringComparison.Ordinal);
+        var recordHarArgs = new Dictionary<string, object?>();
+        var contentPolicy = content ?? HarContentPolicy.Attach;
+        recordHarArgs["content"] = contentPolicy;
+        if (!isZip)
+        {
+            recordHarArgs["harPath"] = har;
+        }
+        if (!string.IsNullOrEmpty(resourcesDir))
+        {
+            recordHarArgs["resourcesDir"] = resourcesDir;
+        }
+        if (!string.IsNullOrEmpty(urlGlob))
+        {
+            recordHarArgs["urlGlob"] = urlGlob;
+        }
+        if (urlRegex != null)
+        {
+            var (source, flags) = urlRegex.GetSourceAndFlags();
+            recordHarArgs["urlRegexSource"] = source;
+            recordHarArgs["urlRegexFlags"] = flags;
+        }
+        recordHarArgs["mode"] = mode ?? HarMode.Minimal;
+
+        var harId = (await SendMessageToServerAsync("harStart", new Dictionary<string, object?>
+        {
+            ["page"] = page,
+            ["options"] = recordHarArgs,
+        }).ConfigureAwait(false)).Value.GetProperty("harId").ToString();
+        _harRecorders.Add(harId, new(har, contentPolicy, resourcesDir));
+        return harId;
+    }
+
+    internal async Task ExportAllHarsAsync()
+    {
+        foreach (var harId in _harRecorders.Keys.ToArray())
+        {
+            await ExportHarAsync(harId).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ExportHarAsync(string harId)
+    {
+        if (!_harRecorders.TryGetValue(harId, out var recorder))
+        {
+            return;
+        }
+        _harRecorders.Remove(harId);
+        var isZip = recorder.Path.EndsWith(".zip", StringComparison.Ordinal);
+        var isLocal = !_connection.IsRemote;
+
+        if (isLocal)
+        {
+            var entriesResult = await SendMessageToServerAsync("harExport", new Dictionary<string, object?>
+            {
+                ["harId"] = harId,
+                ["mode"] = "entries",
+            }).ConfigureAwait(false);
+            if (!isZip)
+            {
+                // Server wrote HAR and resources to the user's chosen paths.
+                return;
+            }
+            if (_connection.LocalUtils == null)
+            {
+                throw new PlaywrightException("Cannot save zipped HAR in thin clients");
+            }
+            List<NameValue> entries = new();
+            if (entriesResult.Value.TryGetProperty("entries", out var entriesElement))
+            {
+                foreach (var current in entriesElement.EnumerateArray())
+                {
+                    var entry = current.Deserialize<NameValue>();
+                    if (entry != null)
+                    {
+                        entries.Add(entry);
+                    }
+                }
+            }
+            await _connection.LocalUtils.ZipAsync(recorder.Path, entries, "write", null, false).ConfigureAwait(false);
+            return;
+        }
+
+        var archiveResult = await SendMessageToServerAsync("harExport", new Dictionary<string, object?>
+        {
+            ["harId"] = harId,
+            ["mode"] = "archive",
+        }).ConfigureAwait(false);
+        var artifact = archiveResult.GetObject<Artifact>("artifact", _connection);
+        if (artifact == null)
+        {
+            return;
+        }
+        // The server always returns a zipped artifact in archive mode.
+        // Unzip when the target file is not a .zip.
+        if (!isZip)
+        {
+            if (_connection.LocalUtils == null)
+            {
+                throw new PlaywrightException("Uncompressed HAR is not supported in thin clients");
+            }
+            await artifact.SaveAsAsync(recorder.Path + ".tmp").ConfigureAwait(false);
+            await _connection.LocalUtils.HarUnzipAsync(recorder.Path + ".tmp", recorder.Path, recorder.ResourcesDir).ConfigureAwait(false);
+        }
+        else
+        {
+            await artifact.SaveAsAsync(recorder.Path).ConfigureAwait(false);
+        }
+        await artifact.DeleteAsync().ConfigureAwait(false);
+    }
+
+    internal class HarRecorder
+    {
+        internal HarRecorder(string path, HarContentPolicy? content, string? resourcesDir)
+        {
+            Path = path;
+            Content = content;
+            ResourcesDir = resourcesDir;
+        }
+
+        internal string Path { get; }
+
+        internal HarContentPolicy? Content { get; }
+
+        internal string? ResourcesDir { get; }
+    }
 }

--- a/src/Playwright/Core/WebError.cs
+++ b/src/Playwright/Core/WebError.cs
@@ -26,13 +26,16 @@ namespace Microsoft.Playwright.Core;
 
 internal class WebError : IWebError
 {
-    public WebError(Page page, string error)
+    public WebError(Page page, string error, WebErrorLocation location)
     {
         Page = page;
         Error = error;
+        Location = location;
     }
 
     public IPage Page { get; }
 
     public string Error { get; }
+
+    public WebErrorLocation Location { get; }
 }

--- a/src/Playwright/Core/WebSocketRoute.cs
+++ b/src/Playwright/Core/WebSocketRoute.cs
@@ -53,6 +53,8 @@ internal class WebSocketRoute : ChannelOwner, IWebSocketRoute
 
     public string Url => _initializer.Url;
 
+    public IReadOnlyList<string> Protocols => _initializer.Protocols ?? (IReadOnlyList<string>)Array.Empty<string>();
+
     internal override void OnMessage(string method, JsonElement serverParams)
     {
         switch (method)
@@ -197,6 +199,8 @@ internal class ServerWebSocketRoute : IWebSocketRoute
     }
 
     public string Url => _webSocketRoute._initializer.Url;
+
+    public IReadOnlyList<string> Protocols => _webSocketRoute.Protocols;
 
     public async Task CloseAsync(WebSocketRouteCloseOptions? options = null)
     {

--- a/src/Playwright/Transport/Protocol/FrameExpectResult.cs
+++ b/src/Playwright/Transport/Protocol/FrameExpectResult.cs
@@ -29,6 +29,8 @@ internal class FrameExpectResult
 
     public object Received { get; set; } = null!;
 
+    public string? ReceivedAriaSnapshot { get; set; }
+
     public string[] Log { get; set; } = null!;
 
     public string? ErrorMessage { get; set; }

--- a/src/Playwright/Transport/Protocol/Generated/BindingCallInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BindingCallInitializer.cs
@@ -37,7 +37,4 @@ internal class BindingCallInitializer
 
     [JsonPropertyName("args")]
     public List<System.Text.Json.JsonElement> Args { get; set; } = null!;
-
-    [JsonPropertyName("handle")]
-    public Core.JSHandle Handle { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/RecordHarOptions.cs
+++ b/src/Playwright/Transport/Protocol/Generated/RecordHarOptions.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Playwright.Transport.Protocol;
 
 internal class RecordHarOptions
 {
-    [JsonPropertyName("zip")]
-    public bool? Zip { get; set; }
-
     [JsonPropertyName("content")]
     public string Content { get; set; } = null!;
 
@@ -45,4 +42,10 @@ internal class RecordHarOptions
 
     [JsonPropertyName("urlRegexFlags")]
     public string UrlRegexFlags { get; set; } = null!;
+
+    [JsonPropertyName("harPath")]
+    public string HarPath { get; set; } = null!;
+
+    [JsonPropertyName("resourcesDir")]
+    public string ResourcesDir { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WebSocketRouteInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WebSocketRouteInitializer.cs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
@@ -30,4 +31,7 @@ internal class WebSocketRouteInitializer
 {
     [JsonPropertyName("url")]
     public string Url { get; set; } = null!;
+
+    [JsonPropertyName("protocols")]
+    public List<string> Protocols { get; set; } = null!;
 }


### PR DESCRIPTION
## Summary
- Roll Playwright driver to 1.60.0
- New APIs: `Browser.Context` event, `BrowserContext` lifecycle events (`PageLoad`/`PageClose`/`FrameAttached`/`FrameDetached`/`FrameNavigated`/`Download`), `Locator.DropAsync`, `Locator.HighlightAsync` (now returns `IAsyncDisposable`, accepts `style`), `Locator.HideHighlightAsync`, `Page.HideHighlightAsync`, `Tracing.StartHarAsync`/`StopHarAsync`, `PageAssertions.ToMatchAriaSnapshotAsync`, `WebSocketRoute.Protocols`, `WebError.Location`, `APIRequestContext.Tracing`, `ConnectOverCDPOptions.NoDefaults`, `GetByRoleOptions.Description`, `AriaSnapshotOptions.Boxes`, `LocatorAssertionsToHaveCSSOptions.Pseudo`.
- HAR protocol moved from `BrowserContext` to `Tracing` channel; switched from `zip` flag to `harPath`/`resourcesDir`; export now goes through `entries`/`archive` modes.
- Expect `received` wire shape is now `{ value, ariaSnapshot? }`; aria snapshot surfaces in failure messages.
- Removed `ExposeBindingAsync` `IJSHandle` overloads and the `Handle` binding option, matching upstream.