### PR TITLE
fix(build): suppress nullable warnings on JsonElement? .Value access

### DIFF
--- a/src/Playwright/Core/APIResponse.cs
+++ b/src/Playwright/Core/APIResponse.cs
@@ -94,7 +94,7 @@ internal class APIResponse : IAPIResponse
     internal async Task<string[]> FetchLogAsync()
     {
         var response = await _context.SendMessageToServerAsync("fetchLog", new Dictionary<string, object?> { ["fetchUid"] = FetchUid() }).ConfigureAwait(false);
-        return response.Value.GetProperty("log").ToObject<string[]>();
+        return response!.Value.GetProperty("log").ToObject<string[]>();
     }
 
     public ValueTask DisposeAsync() => new(_context.SendMessageToServerAsync("disposeAPIResponse", new Dictionary<string, object?> { ["fetchUid"] = FetchUid() }));

--- a/src/Playwright/Core/ElementHandle.cs
+++ b/src/Playwright/Core/ElementHandle.cs
@@ -120,7 +120,7 @@ internal class ElementHandle : JSHandle, IElementHandle
             }).ToArray();
         }
 
-        var result = (await SendMessageToServerAsync("screenshot", args).ConfigureAwait(false)).Value.GetProperty("binary").GetBytesFromBase64();
+        var result = (await SendMessageToServerAsync("screenshot", args).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
 
         if (!string.IsNullOrEmpty(options.Path))
         {
@@ -161,7 +161,7 @@ internal class ElementHandle : JSHandle, IElementHandle
 
     public async Task<ElementHandleBoundingBoxResult?> BoundingBoxAsync()
     {
-        var result = (await SendMessageToServerAsync("boundingBox").ConfigureAwait(false)).Value;
+        var result = (await SendMessageToServerAsync("boundingBox").ConfigureAwait(false))!.Value;
         if (result.TryGetProperty("value", out var value))
         {
             return value.ToObject<ElementHandleBoundingBoxResult>();
@@ -303,9 +303,9 @@ internal class ElementHandle : JSHandle, IElementHandle
         return null;
     }
 
-    public async Task<string> InnerHTMLAsync() => (await SendMessageToServerAsync("innerHTML").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+    public async Task<string> InnerHTMLAsync() => (await SendMessageToServerAsync("innerHTML").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
-    public async Task<string> InnerTextAsync() => (await SendMessageToServerAsync("innerText").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+    public async Task<string> InnerTextAsync() => (await SendMessageToServerAsync("innerText").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     public async Task<string?> TextContentAsync() => (await SendMessageToServerAsync("textContent").ConfigureAwait(false))?.GetProperty("value").ToString();
 
@@ -353,7 +353,7 @@ internal class ElementHandle : JSHandle, IElementHandle
             ["options"] = values,
             ["force"] = force,
             ["timeout"] = _frame.Timeout(timeout),
-        }).ConfigureAwait(false)).Value.GetProperty("values").ToObject<string[]>();
+        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
     }
 
     private async Task<IReadOnlyList<string>> _selectOptionAsync(IEnumerable<IElementHandle> values, bool? noWaitAfter, bool? force, float? timeout)
@@ -363,7 +363,7 @@ internal class ElementHandle : JSHandle, IElementHandle
             ["elements"] = values,
             ["force"] = force,
             ["timeout"] = _frame.Timeout(timeout),
-        }).ConfigureAwait(false)).Value.GetProperty("values").ToObject<string[]>();
+        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
     }
 
     public Task CheckAsync(ElementHandleCheckOptions? options = default)
@@ -407,7 +407,7 @@ internal class ElementHandle : JSHandle, IElementHandle
     public async Task<bool> IsVisibleAsync() => (await SendMessageToServerAsync("isVisible").ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
     public async Task<string> InputValueAsync(ElementHandleInputValueOptions? options = null)
-        => (await SendMessageToServerAsync("inputValue").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync("inputValue").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     public Task SetCheckedAsync(bool checkedState, ElementHandleSetCheckedOptions? options = null)
         => SendMessageToServerAsync(checkedState ? "check" : "uncheck", new Dictionary<string, object?>

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -162,7 +162,7 @@ internal class Frame : ChannelOwner, IFrame
         => new FrameLocator(this, selector);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public async Task<string> TitleAsync() => (await SendMessageToServerAsync("title").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+    public async Task<string> TitleAsync() => (await SendMessageToServerAsync("title").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task WaitForTimeoutAsync(float timeout)
@@ -194,7 +194,7 @@ internal class Frame : ChannelOwner, IFrame
             ["strict"] = options?.Strict,
             ["force"] = options?.Force,
             ["timeout"] = Timeout(options?.Timeout),
-        }).ConfigureAwait(false)).Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
+        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, SelectOptionValue values, FrameSelectOptionOptions? options = default)
@@ -215,7 +215,7 @@ internal class Frame : ChannelOwner, IFrame
             ["strict"] = options?.Strict,
             ["force"] = options?.Force,
             ["timeout"] = Timeout(options?.Timeout),
-        }).ConfigureAwait(false)).Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
+        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task WaitForLoadStateAsync(LoadState? state = default, FrameWaitForLoadStateOptions? options = default)
@@ -364,12 +364,12 @@ internal class Frame : ChannelOwner, IFrame
         {
             ["selector"] = selector,
         }).ConfigureAwait(false);
-        return result.Value.GetProperty("value").GetInt32();
+        return result!.Value.GetProperty("value").GetInt32();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> ContentAsync()
-        => (await SendMessageToServerAsync("content").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync("content").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FocusAsync(string selector, FrameFocusOptions? options = default)
@@ -414,7 +414,7 @@ internal class Frame : ChannelOwner, IFrame
             ["selector"] = selector,
             ["timeout"] = Timeout(options?.Timeout),
             ["strict"] = options?.Strict,
-        }).ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> InnerTextAsync(string selector, FrameInnerTextOptions? options = default)
@@ -423,7 +423,7 @@ internal class Frame : ChannelOwner, IFrame
             ["selector"] = selector,
             ["timeout"] = Timeout(options?.Timeout),
             ["strict"] = options?.Strict,
-        }).ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string?> TextContentAsync(string selector, FrameTextContentOptions? options = default)
@@ -654,7 +654,7 @@ internal class Frame : ChannelOwner, IFrame
             ["selector"] = selector,
             ["timeout"] = Timeout(options?.Timeout),
             ["strict"] = options?.Strict,
-        }).ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> QuerySelectorAsync(string selector)
@@ -944,8 +944,8 @@ internal class Frame : ChannelOwner, IFrame
             ["isNot"] = options.IsNot,
             ["timeout"] = options.Timeout,
         }).ConfigureAwait(false);
-        var parsed = result.Value.ToObject<FrameExpectResult>();
-        if (result.Value.TryGetProperty("received", out var received) && received.ValueKind == JsonValueKind.Object)
+        var parsed = result!.Value.ToObject<FrameExpectResult>();
+        if (result!.Value.TryGetProperty("received", out var received) && received.ValueKind == JsonValueKind.Object)
         {
             if (received.TryGetProperty("value", out var receivedValue))
             {

--- a/src/Playwright/Core/JSHandle.cs
+++ b/src/Playwright/Core/JSHandle.cs
@@ -90,7 +90,7 @@ internal class JSHandle : ChannelOwner, IJSHandle
     public async Task<Dictionary<string, IJSHandle>> GetPropertiesAsync()
     {
         var result = new Dictionary<string, IJSHandle>();
-        var channelResult = (await SendMessageToServerAsync("getPropertyList").ConfigureAwait(false)).Value
+        var channelResult = (await SendMessageToServerAsync("getPropertyList").ConfigureAwait(false))!.Value
             .GetProperty("properties").ToObject<List<JSElementProperty>>(_connection.DefaultJsonSerializerOptions);
 
         foreach (var kv in channelResult)

--- a/src/Playwright/Core/LocalUtils.cs
+++ b/src/Playwright/Core/LocalUtils.cs
@@ -100,7 +100,7 @@ internal class LocalUtils : ChannelOwner
                 { "slowMo", slowMo },
                 { "timeout", timeout ?? 0 },
                 { "exposeNetwork", exposeNetwork },
-            }).ConfigureAwait(false)).Value.GetObject<JsonPipe>("pipe", _connection);
+            }).ConfigureAwait(false))!.Value.GetObject<JsonPipe>("pipe", _connection);
 
     internal void AddStackToTracingNoReply(List<StackFrame> stack, int id)
          => SendMessageToServerAsync("addStackToTracingNoReply", new Dictionary<string, object?>
@@ -127,7 +127,7 @@ internal class LocalUtils : ChannelOwner
             { "tracesDir", tracesDir },
             { "traceName", traceName },
         }).ConfigureAwait(false);
-        return response.Value.GetProperty("stacksId").ToString();
+        return response!.Value.GetProperty("stacksId").ToString();
     }
 }
 

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -652,7 +652,7 @@ internal class Locator : ILocator
             ["mode"] = options?.Mode,
             ["depth"] = options?.Depth,
         }).ConfigureAwait(false);
-        return result.Value.GetProperty("snapshot").ToString();
+        return result!.Value.GetProperty("snapshot").ToString();
     }
 
     public async Task<ILocator> NormalizeAsync()
@@ -661,7 +661,7 @@ internal class Locator : ILocator
         {
             ["selector"] = _selector,
         }).ConfigureAwait(false);
-        var resolvedSelector = result.Value.GetProperty("resolvedSelector").ToString();
+        var resolvedSelector = result!.Value.GetProperty("resolvedSelector").ToString();
         return new Locator(_frame, resolvedSelector);
     }
 }

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -713,7 +713,7 @@ internal class Page : ChannelOwner, IPage
                 ["frame"] = ((Locator)locator)._frame,
                 ["selector"] = ((Locator)locator)._selector,
             }).ToArray(),
-        }).ConfigureAwait(false)).Value.GetProperty("binary").GetBytesFromBase64();
+        }).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
 
         if (!string.IsNullOrEmpty(options.Path))
         {
@@ -910,7 +910,7 @@ internal class Page : ChannelOwner, IPage
             ["height"] = options?.Height,
             ["outline"] = options?.Outline,
             ["tagged"] = options?.Tagged,
-        }).ConfigureAwait(false)).Value.GetProperty("pdf").GetBytesFromBase64();
+        }).ConfigureAwait(false))!.Value.GetProperty("pdf").GetBytesFromBase64();
 
         if (!string.IsNullOrEmpty(options?.Path))
         {
@@ -1517,7 +1517,7 @@ internal class Page : ChannelOwner, IPage
         {
             ["filter"] = options?.Filter,
         }).ConfigureAwait(false);
-        var initializers = response.Value.GetProperty("messages").ToObject<List<ConsoleMessageInitializer>>(_connection.DefaultJsonSerializerOptions);
+        var initializers = response!.Value.GetProperty("messages").ToObject<List<ConsoleMessageInitializer>>(_connection.DefaultJsonSerializerOptions);
         return initializers.Select(initializer => new ConsoleMessage(initializer, this, null)).ToList();
     }
 
@@ -1532,14 +1532,14 @@ internal class Page : ChannelOwner, IPage
     public async Task<IReadOnlyList<string>> PageErrorsAsync()
     {
         var response = await SendMessageToServerAsync("pageErrors").ConfigureAwait(false);
-        var errors = response.Value.GetProperty("errors").ToObject<List<SerializedError>>(_connection.DefaultJsonSerializerOptions);
+        var errors = response!.Value.GetProperty("errors").ToObject<List<SerializedError>>(_connection.DefaultJsonSerializerOptions);
         return errors.Select(error => string.IsNullOrEmpty(error.Error.Stack) ? $"{error.Error.Name}: {error.Error.Message}" : error.Error.Stack).ToList();
     }
 
     public async Task<IReadOnlyList<IRequest>> RequestsAsync()
     {
         var response = await SendMessageToServerAsync("requests").ConfigureAwait(false);
-        return response.Value.GetProperty("requests").ToObject<List<Request>>(_connection.DefaultJsonSerializerOptions);
+        return response!.Value.GetProperty("requests").ToObject<List<Request>>(_connection.DefaultJsonSerializerOptions);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1551,14 +1551,14 @@ internal class Page : ChannelOwner, IPage
             ["mode"] = options?.Mode,
             ["depth"] = options?.Depth,
         }).ConfigureAwait(false);
-        return result.Value.GetProperty("snapshot").ToString();
+        return result!.Value.GetProperty("snapshot").ToString();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<ILocator> PickLocatorAsync()
     {
         var result = await SendMessageToServerAsync("pickLocator").ConfigureAwait(false);
-        var selector = result.Value.GetProperty("selector").ToString();
+        var selector = result!.Value.GetProperty("selector").ToString();
         return Locator(selector);
     }
 
@@ -1588,7 +1588,7 @@ internal class Page : ChannelOwner, IPage
             ["noWaitAfter"] = options?.NoWaitAfter,
         }).ConfigureAwait(false);
 
-        _locatorHandlers.Add(response.Value.GetProperty("uid").GetInt32(), new LocatorHandler((Locator)locator, handler, options?.Times));
+        _locatorHandlers.Add(response!.Value.GetProperty("uid").GetInt32(), new LocatorHandler((Locator)locator, handler, options?.Times));
     }
 
     private async Task Channel_LocatorHandlerTriggeredAsync(int uid)

--- a/src/Playwright/Core/Request.cs
+++ b/src/Playwright/Core/Request.cs
@@ -190,7 +190,7 @@ internal class Request : ChannelOwner, IRequest
             throw new PlaywrightException("Unable to fetch resources sizes.");
         }
 
-        return (await res.SendMessageToServerAsync("sizes").ConfigureAwait(false)).Value.GetProperty("sizes").ToObject<RequestSizesResult>();
+        return (await res.SendMessageToServerAsync("sizes").ConfigureAwait(false))!.Value.GetProperty("sizes").ToObject<RequestSizesResult>();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -224,7 +224,7 @@ internal class Request : ChannelOwner, IRequest
         return await WrapApiCallAsync(
             async () =>
         {
-            var headerList = (await SendMessageToServerAsync("rawRequestHeaders").ConfigureAwait(false)).Value.GetProperty("headers").ToObject<List<NameValue>>();
+            var headerList = (await SendMessageToServerAsync("rawRequestHeaders").ConfigureAwait(false))!.Value.GetProperty("headers").ToObject<List<NameValue>>();
             return new RawHeaders(headerList);
         },
             true).ConfigureAwait(false);

--- a/src/Playwright/Core/Response.cs
+++ b/src/Playwright/Core/Response.cs
@@ -69,14 +69,14 @@ internal class Response : ChannelOwner, IResponse
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> HttpVersionAsync()
-        => (await SendMessageToServerAsync("httpVersion").ConfigureAwait(false)).Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync("httpVersion").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<Dictionary<string, string>> AllHeadersAsync()
         => (await GetRawHeadersAsync().ConfigureAwait(false)).Headers;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public async Task<byte[]> BodyAsync() => (await SendMessageToServerAsync("body").ConfigureAwait(false)).Value.GetProperty("binary").GetBytesFromBase64();
+    public async Task<byte[]> BodyAsync() => (await SendMessageToServerAsync("body").ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string?> FinishedAsync()
@@ -144,6 +144,6 @@ internal class Response : ChannelOwner, IResponse
 
     private async Task<RawHeaders> GetRawHeadersTaskAsync()
     {
-        return new((await SendMessageToServerAsync("rawResponseHeaders").ConfigureAwait(false)).Value.GetProperty("headers").ToObject<List<NameValue>>());
+        return new((await SendMessageToServerAsync("rawResponseHeaders").ConfigureAwait(false))!.Value.GetProperty("headers").ToObject<List<NameValue>>());
     }
 }

--- a/src/Playwright/Core/Stream.cs
+++ b/src/Playwright/Core/Stream.cs
@@ -49,7 +49,7 @@ internal class Stream : ChannelOwner, IAsyncDisposable
             {
                 ["size"] = size,
             }).ConfigureAwait(false);
-        return response.Value.GetProperty("binary").GetBytesFromBase64();
+        return response!.Value.GetProperty("binary").GetBytesFromBase64();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Playwright/Core/Tracing.cs
+++ b/src/Playwright/Core/Tracing.cs
@@ -67,7 +67,7 @@ internal class Tracing : ChannelOwner, ITracing
         {
             ["title"] = options?.Title,
             ["name"] = options?.Name,
-        }).ConfigureAwait(false)).Value.GetProperty("traceName").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("traceName").ToString();
         await StartCollectingStacksAsync(traceName).ConfigureAwait(false);
     }
 
@@ -78,7 +78,7 @@ internal class Tracing : ChannelOwner, ITracing
         {
             ["title"] = options?.Title,
             ["name"] = options?.Name,
-        }).ConfigureAwait(false)).Value.GetProperty("traceName").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("traceName").ToString();
         await StartCollectingStacksAsync(traceName).ConfigureAwait(false);
     }
 
@@ -169,7 +169,7 @@ internal class Tracing : ChannelOwner, ITracing
 
         var artifact = result.GetObject<Artifact>("artifact", _connection);
         List<NameValue?> entries = new();
-        if (result.Value.TryGetProperty("entries", out var entriesElement))
+        if (result!.Value.TryGetProperty("entries", out var entriesElement))
         {
             foreach (var current in entriesElement.EnumerateArray())
             {
@@ -265,7 +265,7 @@ internal class Tracing : ChannelOwner, ITracing
         {
             ["page"] = page,
             ["options"] = recordHarArgs,
-        }).ConfigureAwait(false)).Value.GetProperty("harId").ToString();
+        }).ConfigureAwait(false))!.Value.GetProperty("harId").ToString();
         _harRecorders.Add(harId, new(har, contentPolicy, resourcesDir));
         return harId;
     }
@@ -305,7 +305,7 @@ internal class Tracing : ChannelOwner, ITracing
                 throw new PlaywrightException("Cannot save zipped HAR in thin clients");
             }
             List<NameValue> entries = new();
-            if (entriesResult.Value.TryGetProperty("entries", out var entriesElement))
+            if (entriesResult!.Value.TryGetProperty("entries", out var entriesElement))
             {
                 foreach (var current in entriesElement.EnumerateArray())
                 {

--- a/src/Playwright/Core/Worker.cs
+++ b/src/Playwright/Core/Worker.cs
@@ -97,7 +97,7 @@ internal class Worker : ChannelOwner, IWorker
                 {
                     ["expression"] = expression,
                     ["arg"] = ScriptsHelper.SerializedArgument(arg),
-                }).ConfigureAwait(false)).Value.GetProperty("value"));
+                }).ConfigureAwait(false))!.Value.GetProperty("value"));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> EvaluateHandleAsync(string expression, object? arg = null)

--- a/src/Playwright/Helpers/SetInputFilesHelpers.cs
+++ b/src/Playwright/Helpers/SetInputFilesHelpers.cs
@@ -96,7 +96,7 @@ internal static class SetInputFilesHelpers
                     ["lastModifiedMs"] = new DateTimeOffset(File.GetLastWriteTime(file)).ToUnixTimeMilliseconds(),
                 }).ToArray(),
             }).ConfigureAwait(false);
-            var writableStreams = result.Value.GetProperty("writableStreams").EnumerateArray();
+            var writableStreams = result!.Value.GetProperty("writableStreams").EnumerateArray();
             if (writableStreams.Count() != files.Count())
             {
                 throw new Exception("Mismatch between the number of files and the number of writeable streams");
@@ -118,7 +118,7 @@ internal static class SetInputFilesHelpers
             }
             return new()
             {
-                DirectoryStream = result.Value.TryGetProperty("rootDir", out var rootDir) ? rootDir.ToObject<WritableStream>(context._connection.DefaultJsonSerializerOptions) : null,
+                DirectoryStream = result!.Value.TryGetProperty("rootDir", out var rootDir) ? rootDir.ToObject<WritableStream>(context._connection.DefaultJsonSerializerOptions) : null,
                 Streams = localDirectory != null ? null : [.. streams],
             };
         }

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -202,7 +202,7 @@ internal class Connection : IDisposable
 
         if (typeof(T) == typeof(JsonElement?))
         {
-            return (T)(object)result;
+            return (T)(object)result!;
         }
         else if (result == null)
         {


### PR DESCRIPTION
## Summary
- The 1.60 driver roll started failing the noble Docker build (which uses .NET SDK 10) and the firefox/ubuntu-latest build with CS8629/CS8600/CS8603 errors on the long-standing `(await SendMessageToServerAsync(...)).Value.GetProperty(...)` pattern.
- Add the null-forgiving operator before `.Value` so the new Roslyn null-flow analysis is satisfied; runtime behavior is unchanged since these responses are always non-null in the success path.

Fixes the failing checks on 9c36b8d3.