### PR TITLE
devops: allow manual dispatch of test_docker workflow

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - main
       - release-*
+  workflow_dispatch:
 jobs:
   build:
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `.github/workflows/test_docker.yml` so the docker tests can be run manually from the Actions tab.