### PR TITLE
feat(mstest,nunit): add LaunchOptionsAsync override

### DIFF
--- a/src/Playwright.MSTest/BrowserService.cs
+++ b/src/Playwright.MSTest/BrowserService.cs
@@ -42,12 +42,12 @@ internal class BrowserService : IWorkerService
         Browser = browser;
     }
 
-    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions)
+    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
-        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions).ConfigureAwait(false)));
+        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions, launchOptions).ConfigureAwait(false)));
     }
 
-    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions)
+    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
         if (connectOptions.HasValue && connectOptions.Value.WSEndpoint != null)
         {
@@ -63,7 +63,7 @@ internal class BrowserService : IWorkerService
         {
             return legacyBrowser;
         }
-        return await browserType.LaunchAsync(PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
+        return await browserType.LaunchAsync(launchOptions ?? PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
     }
 
     // TODO: Remove at some point

--- a/src/Playwright.MSTest/BrowserTest.cs
+++ b/src/Playwright.MSTest/BrowserTest.cs
@@ -44,7 +44,7 @@ public class BrowserTest : PlaywrightTest
     [TestInitialize]
     public async Task BrowserSetup()
     {
-        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync()).ConfigureAwait(false);
+        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync(), await LaunchOptionsAsync()).ConfigureAwait(false);
         Browser = service.Browser;
     }
 
@@ -63,4 +63,6 @@ public class BrowserTest : PlaywrightTest
     }
 
     public virtual Task<(string, BrowserTypeConnectOptions?)?> ConnectOptionsAsync() => Task.FromResult<(string, BrowserTypeConnectOptions?)?>(null);
+
+    public virtual Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync() => Task.FromResult<BrowserTypeLaunchOptions?>(null);
 }

--- a/src/Playwright.NUnit/BrowserService.cs
+++ b/src/Playwright.NUnit/BrowserService.cs
@@ -42,12 +42,12 @@ internal class BrowserService : IWorkerService
         Browser = browser;
     }
 
-    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions)
+    public static Task<BrowserService> Register(WorkerAwareTest test, IBrowserType browserType, (string, BrowserTypeConnectOptions?)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
-        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions).ConfigureAwait(false)));
+        return test.RegisterService("Browser", async () => new BrowserService(await CreateBrowser(browserType, connectOptions, launchOptions).ConfigureAwait(false)));
     }
 
-    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions)
+    private static async Task<IBrowser> CreateBrowser(IBrowserType browserType, (string WSEndpoint, BrowserTypeConnectOptions? Options)? connectOptions, BrowserTypeLaunchOptions? launchOptions)
     {
         if (connectOptions.HasValue && connectOptions.Value.WSEndpoint != null)
         {
@@ -63,7 +63,7 @@ internal class BrowserService : IWorkerService
         {
             return legacyBrowser;
         }
-        return await browserType.LaunchAsync(PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
+        return await browserType.LaunchAsync(launchOptions ?? PlaywrightSettingsProvider.LaunchOptions).ConfigureAwait(false);
     }
 
     // TODO: Remove at some point

--- a/src/Playwright.NUnit/BrowserTest.cs
+++ b/src/Playwright.NUnit/BrowserTest.cs
@@ -43,7 +43,7 @@ public class BrowserTest : PlaywrightTest
     [SetUp]
     public async Task BrowserSetup()
     {
-        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync()).ConfigureAwait(false);
+        var service = await BrowserService.Register(this, BrowserType, await ConnectOptionsAsync(), await LaunchOptionsAsync()).ConfigureAwait(false);
         Browser = service.Browser;
     }
 
@@ -62,4 +62,6 @@ public class BrowserTest : PlaywrightTest
     }
 
     public virtual Task<(string, BrowserTypeConnectOptions?)?> ConnectOptionsAsync() => Task.FromResult<(string, BrowserTypeConnectOptions?)?>(null);
+
+    public virtual Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync() => Task.FromResult<BrowserTypeLaunchOptions?>(null);
 }

--- a/src/Playwright.TestingHarnessTest/tests/mstest.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/mstest.spec.ts
@@ -535,3 +535,41 @@ test.describe('ConnectOptions', () => {
     expect(result.total).toBe(1);
   });
 });
+
+test.describe('LaunchOptions', () => {
+  test('should be able to override launch options via LaunchOptionsAsync', async ({ runTest }) => {
+    const result = await runTest({
+      'ExampleTests.cs': `
+        using System;
+        using System.Threading.Tasks;
+        using Microsoft.Playwright;
+        using Microsoft.Playwright.MSTest;
+        using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+        namespace Playwright.TestingHarnessTest.MSTest;
+
+        [TestClass]
+        public class <class-name> : PageTest
+        {
+            [TestMethod]
+            public async Task Test()
+            {
+                await Page.GotoAsync("about:blank");
+                Console.WriteLine("User-Agent: " + await Page.EvaluateAsync<string>("() => navigator.userAgent"));
+            }
+
+            public override Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync()
+            {
+                return Task.FromResult<BrowserTypeLaunchOptions?>(new BrowserTypeLaunchOptions
+                {
+                    Args = new[] { "--user-agent=hello" },
+                });
+            }
+        }`,
+    }, 'dotnet test');
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.total).toBe(1);
+    expect(result.stdout).toContain("User-Agent: hello");
+  });
+});

--- a/src/Playwright.TestingHarnessTest/tests/nunit.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/nunit.spec.ts
@@ -532,3 +532,40 @@ test.describe('ConnectOptions', () => {
     expect(result.total).toBe(1);
   });
 });
+
+test.describe('LaunchOptions', () => {
+  test('should be able to override launch options via LaunchOptionsAsync', async ({ runTest }) => {
+    const result = await runTest({
+      'ExampleTests.cs': `
+        using System;
+        using System.Threading.Tasks;
+        using Microsoft.Playwright;
+        using Microsoft.Playwright.NUnit;
+        using NUnit.Framework;
+
+        namespace Playwright.TestingHarnessTest.NUnit;
+
+        public class <class-name> : PageTest
+        {
+            [Test]
+            public async Task Test()
+            {
+                await Page.GotoAsync("about:blank");
+                Console.WriteLine("User-Agent: " + await Page.EvaluateAsync<string>("() => navigator.userAgent"));
+            }
+
+            public override Task<BrowserTypeLaunchOptions?> LaunchOptionsAsync()
+            {
+                return Task.FromResult<BrowserTypeLaunchOptions?>(new BrowserTypeLaunchOptions
+                {
+                    Args = new[] { "--user-agent=hello" },
+                });
+            }
+        }`,
+    }, 'dotnet test');
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.total).toBe(1);
+    expect(result.stdout).toContain("User-Agent: hello");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a virtual `LaunchOptionsAsync()` to the MSTest and NUnit `BrowserTest` harnesses, letting tests override browser launch options from code (e.g. toggle headed/headless) instead of only via env vars / `.runsettings`.
- The override is threaded through `BrowserService` and takes precedence over `PlaywrightSettingsProvider.LaunchOptions` when non-null.
- Mirrors the xUnit.v3 implementation from #3304; `Playwright.MSTest.v4` picks this up automatically since it compiles the MSTest sources.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3315