### PR TITLE
devops(driver): assemble driver from npm package and Node.js builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,11 +36,13 @@ function download_driver() {
 function roll_driver() {
   new_driver_version="$1"
   upstream_package_version=$(node -e "console.log(require('${upstream_repo_path}/package.json').version)")
-  echo "Rolling .NET driver to driver ${new_driver_version} and upstream version ${upstream_package_version}..."
+  new_node_version=$(sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p' "${upstream_repo_path}/utils/build/build-playwright-driver.sh")
+  echo "Rolling .NET driver to driver ${new_driver_version} (Node.js ${new_node_version}) and upstream version ${upstream_package_version}..."
 
   xml_file_path="./src/Common/Version.props"
   xml_file_contents=$(cat "${xml_file_path}")
   xml_file_contents=$(echo "${xml_file_contents}" | sed "s|<DriverVersion>.*</DriverVersion>|<DriverVersion>${new_driver_version}</DriverVersion>|")
+  xml_file_contents=$(echo "${xml_file_contents}" | sed "s|<DriverNodeVersion>.*</DriverNodeVersion>|<DriverNodeVersion>${new_node_version}</DriverNodeVersion>|")
   echo "${xml_file_contents}" > "${xml_file_path}"
 
   echo "Generating API..."

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -3,6 +3,9 @@
     <AssemblyVersion>1.60.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <DriverVersion>1.60.0</DriverVersion>
+    <!-- The Node.js version bundled with the driver. Kept in sync with NODE_VERSION
+         in upstream's utils/build/build-playwright-driver.sh by the roll script. -->
+    <DriverNodeVersion>24.15.0</DriverNodeVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright/Playwright.csproj
+++ b/src/Playwright/Playwright.csproj
@@ -44,13 +44,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove=".drivers\**" />
-    <None Include=".drivers\linux\package\**" Link=".playwright\package\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\package" />
-    <None Include=".drivers\linux\LICENSE" Pack="true" PackagePath=".playwright\node" />
-    <None Include=".drivers\linux\node" Link=".playwright\node\linux-x64\node" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\node\linux-x64" />
-    <None Include=".drivers\linux-arm64\node" Link=".playwright\node\linux-arm64\node" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\node\linux-arm64" />
-    <None Include=".drivers\mac\node" Link=".playwright\node\darwin-x64\node" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\node\darwin-x64" />
-    <None Include=".drivers\mac-arm64\node" Link=".playwright\node\darwin-arm64\node" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\node\darwin-arm64" />
-    <None Include=".drivers\win32_x64\node.exe" Link=".playwright\node\win32_x64\node.exe" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright\node\win32_x64" />
+    <!-- The .drivers directory (assembled by Playwright.Tooling) mirrors the .playwright
+         layout shipped in the package: package/** plus node/<platform>/node binaries. -->
+    <None Include=".drivers\**" Exclude=".drivers\.stamp" Link=".playwright\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath=".playwright" />
     <None Include="build\playwright.ps1" Link="playwright.ps1" CopyToOutputDirectory="PreserveNewest" />
     <None Include="build\**" Pack="true" PackagePath="buildTransitive" />
     <None Include="build\**" Pack="true" PackagePath="build" />

--- a/src/tools/Playwright.Tooling/DriverDownloader.cs
+++ b/src/tools/Playwright.Tooling/DriverDownloader.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
@@ -34,32 +35,248 @@ using CommandLine;
 
 namespace Playwright.Tooling;
 
+/// <summary>
+/// Assembles the Playwright driver into src/Playwright/.drivers from the
+/// playwright-core npm package and the official Node.js builds, mirroring what
+/// upstream's utils/build/build-playwright-driver.sh bundles into the prebuilt
+/// driver archives. The resulting directory layout matches the .playwright
+/// folder shipped in the NuGet package:
+///   .drivers/package/**                  - playwright-core npm package contents
+///   .drivers/node/LICENSE                - Node.js license
+///   .drivers/node/&lt;platform&gt;/node[.exe]  - per-platform Node.js binary.
+/// </summary>
 internal class DriverDownloader
 {
-    private static readonly string[] _platforms = new[]
+    // Directory names under .drivers/node/ are the platform ids that Driver.cs
+    // resolves at runtime; the suffixes name the Node.js download for that platform.
+    private static readonly (string PlatformId, string NodeSuffix)[] _platforms = new[]
     {
-            "mac",
-            "mac-arm64",
-            "linux",
-            "linux-arm64",
-            "win32_x64",
+            ("darwin-x64", "darwin-x64"),
+            ("darwin-arm64", "darwin-arm64"),
+            ("linux-x64", "linux-x64"),
+            ("linux-arm64", "linux-arm64"),
+            ("win32_x64", "win-x64"),
     };
 
     public string BasePath { get; set; }
 
     public string DriverVersion { get; set; }
 
+    public string NodeVersion { get; set; }
+
     internal static Task RunAsync(DownloadDriversOptions o)
     {
         var props = new XmlDocument();
         props.Load(Path.Combine(o.BasePath, "src", "Common", "Version.props"));
         string driverVersion = props.DocumentElement.SelectSingleNode("/Project/PropertyGroup/DriverVersion").FirstChild.Value;
+        string nodeVersion = props.DocumentElement.SelectSingleNode("/Project/PropertyGroup/DriverNodeVersion").FirstChild.Value;
 
         return new DriverDownloader()
         {
             BasePath = o.BasePath,
             DriverVersion = driverVersion,
+            NodeVersion = nodeVersion,
         }.ExecuteAsync();
+    }
+
+    private static async Task ExtractEntryAsync(TarEntry entry, string destination)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destination));
+        // Write the file instead of TarEntry.ExtractToFile to give it a current
+        // modification time. npm publishes tarballs with an mtime far in the past,
+        // which breaks "newer file wins" update checks down the line, see
+        // https://github.com/microsoft/playwright-dotnet/issues/2069.
+        using (var output = File.Create(destination))
+        {
+            if (entry.DataStream != null)
+            {
+                await entry.DataStream.CopyToAsync(output).ConfigureAwait(false);
+            }
+        }
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(destination, entry.Mode);
+        }
+    }
+
+    private static void ExtractZipEntry(ZipArchive zip, string entryName, string destination)
+    {
+        var entry = zip.GetEntry(entryName) ?? throw new Exception($"Could not find {entryName} in the archive");
+        Directory.CreateDirectory(Path.GetDirectoryName(destination));
+        using var output = File.Create(destination);
+        using var input = entry.Open();
+        input.CopyTo(output);
+    }
+
+    private static async Task<Stream> GetStreamAsync(HttpClient client, string url)
+    {
+        var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            response.Dispose();
+            throw new Exception($"Failed to download {url} with status {response.StatusCode} and content {content}.");
+        }
+        return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+    }
+
+    private static async Task WithRetriesAsync(string url, Func<Task> action)
+    {
+        const int maxAttempts = 3;
+        for (int attempt = 1; ; attempt++)
+        {
+            try
+            {
+                Console.WriteLine($"Downloading {url}");
+                await action().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                Console.WriteLine($"Attempt {attempt} to download {url} failed: {ex.Message}, retrying...");
+                await Task.Delay(TimeSpan.FromSeconds(attempt)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Unable to download {url}", ex);
+            }
+        }
+    }
+
+    private async Task<bool> ExecuteAsync()
+    {
+        var driversDirectory = new DirectoryInfo(Path.Combine(BasePath, "src", "Playwright", ".drivers"));
+        string stamp = $"driver {DriverVersion} node {NodeVersion}";
+        string stampFile = Path.Combine(driversDirectory.FullName, ".stamp");
+
+        if (File.Exists(stampFile) && File.ReadAllText(stampFile) == stamp)
+        {
+            Console.WriteLine("Drivers are up-to-date");
+        }
+        else
+        {
+            if (driversDirectory.Exists)
+            {
+                driversDirectory.Delete(true);
+            }
+
+            driversDirectory.Create();
+
+            using var client = new HttpClient();
+            client.Timeout = TimeSpan.FromMinutes(5);
+            client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
+
+            var tasks = new List<Task>
+            {
+                DownloadPlaywrightPackageAsync(client, driversDirectory.FullName),
+            };
+            foreach (var (platformId, nodeSuffix) in _platforms)
+            {
+                tasks.Add(DownloadNodeAsync(client, driversDirectory.FullName, platformId, nodeSuffix));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            File.WriteAllText(stampFile, stamp);
+        }
+
+        // update readme
+        await UpdateBrowserVersionsAsync(BasePath, DriverVersion).ConfigureAwait(false);
+
+        return true;
+    }
+
+    private async Task DownloadPlaywrightPackageAsync(HttpClient client, string driversDirectory)
+    {
+        string url = $"https://registry.npmjs.org/playwright-core/-/playwright-core-{DriverVersion}.tgz";
+        await WithRetriesAsync(url, async () =>
+        {
+            using var stream = await GetStreamAsync(client, url).ConfigureAwait(false);
+            using var gzip = new GZipStream(stream, CompressionMode.Decompress);
+            using var tar = new TarReader(gzip);
+            bool extractedAnything = false;
+            while (await tar.GetNextEntryAsync().ConfigureAwait(false) is { } entry)
+            {
+                // npm tarballs nest all package contents under a top-level "package/" directory,
+                // which conveniently matches the layout we want under .drivers/.
+                if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile) || !entry.Name.StartsWith("package/", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                await ExtractEntryAsync(entry, Path.Combine(driversDirectory, entry.Name)).ConfigureAwait(false);
+                extractedAnything = true;
+            }
+            if (!extractedAnything)
+            {
+                throw new Exception($"No files were extracted from {url}");
+            }
+        }).ConfigureAwait(false);
+        Console.WriteLine($"Extracted playwright-core {DriverVersion}");
+    }
+
+    private async Task DownloadNodeAsync(HttpClient client, string driversDirectory, string platformId, string nodeSuffix)
+    {
+        bool isWindows = nodeSuffix.StartsWith("win-", StringComparison.Ordinal);
+        string archiveDir = $"node-v{NodeVersion}-{nodeSuffix}";
+        string url = $"https://nodejs.org/dist/v{NodeVersion}/{archiveDir}.{(isWindows ? "zip" : "tar.gz")}";
+        string nodeEntry = isWindows ? $"{archiveDir}/node.exe" : $"{archiveDir}/bin/node";
+        string nodeDestination = Path.Combine(driversDirectory, "node", platformId, isWindows ? "node.exe" : "node");
+        // Every Node.js archive carries the same LICENSE; extract it from a single
+        // designated platform to avoid parallel writes to the same file.
+        string licenseDestination = platformId == "linux-x64" ? Path.Combine(driversDirectory, "node", "LICENSE") : null;
+
+        await WithRetriesAsync(url, async () =>
+        {
+            bool extractedNode = false;
+            bool extractedLicense = licenseDestination == null;
+
+            if (isWindows)
+            {
+                // ZipArchive needs a seekable stream, so buffer the archive in memory.
+                using var buffer = new MemoryStream();
+                using (var stream = await GetStreamAsync(client, url).ConfigureAwait(false))
+                {
+                    await stream.CopyToAsync(buffer).ConfigureAwait(false);
+                }
+                buffer.Position = 0;
+                using var zip = new ZipArchive(buffer);
+                ExtractZipEntry(zip, nodeEntry, nodeDestination);
+                extractedNode = true;
+                if (!extractedLicense)
+                {
+                    ExtractZipEntry(zip, $"{archiveDir}/LICENSE", licenseDestination);
+                    extractedLicense = true;
+                }
+            }
+            else
+            {
+                using var stream = await GetStreamAsync(client, url).ConfigureAwait(false);
+                using var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                using var tar = new TarReader(gzip);
+                while ((!extractedNode || !extractedLicense) && await tar.GetNextEntryAsync().ConfigureAwait(false) is { } entry)
+                {
+                    if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile))
+                    {
+                        continue;
+                    }
+                    if (entry.Name == nodeEntry)
+                    {
+                        await ExtractEntryAsync(entry, nodeDestination).ConfigureAwait(false);
+                        extractedNode = true;
+                    }
+                    else if (!extractedLicense && entry.Name == $"{archiveDir}/LICENSE")
+                    {
+                        await ExtractEntryAsync(entry, licenseDestination).ConfigureAwait(false);
+                        extractedLicense = true;
+                    }
+                }
+            }
+
+            if (!extractedNode || !extractedLicense)
+            {
+                throw new Exception($"Could not find the Node.js binary or LICENSE in {url}");
+            }
+        }).ConfigureAwait(false);
+        Console.WriteLine($"Extracted Node.js {NodeVersion} for {platformId}");
     }
 
     private async Task UpdateBrowserVersionsAsync(string basePath, string driverVersion)
@@ -95,95 +312,6 @@ internal class DriverDownloader
             Console.WriteLine($"This is usually due to the readme file not yet existing for {driverVersion}.");
             Console.WriteLine(e.Message);
         }
-    }
-
-    private async Task DownloadDriverAsync(DirectoryInfo destinationDirectory, string driverVersion, string platform)
-    {
-        Console.WriteLine("Downloading driver for " + platform);
-        string cdn = "https://playwright.azureedge.net/builds/driver";
-        if (
-            driverVersion.Contains("-alpha")
-            || driverVersion.Contains("-beta")
-            || driverVersion.Contains("-next"))
-        {
-            cdn += "/next";
-        }
-
-        using var client = new HttpClient();
-        client.Timeout = TimeSpan.FromMinutes(5);
-        // Azure seems to not like requests without a user agent.
-        client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
-        string url = $"{cdn}/playwright-{driverVersion}-{platform}.zip";
-
-        try
-        {
-            var response = await client.GetAsync(url).ConfigureAwait(false);
-
-            if (response.StatusCode != System.Net.HttpStatusCode.OK)
-            {
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                throw new Exception($"Failed to download driver from {url} with status {response.StatusCode} and content {content}.");
-            }
-
-            var directory = new DirectoryInfo(Path.Combine(destinationDirectory.FullName, platform));
-
-            if (directory.Exists)
-            {
-                directory.Delete(true);
-            }
-
-            new ZipArchive(await response.Content.ReadAsStreamAsync().ConfigureAwait(false)).ExtractToDirectory(directory.FullName);
-
-            Console.WriteLine($"Driver for {platform} downloaded");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Unable to download driver for {driverVersion} using url {url}");
-            throw new($"Unable to download driver for {driverVersion} using url {url}", ex);
-        }
-    }
-
-    private async Task<bool> ExecuteAsync()
-    {
-        var destinationDirectory = new DirectoryInfo(Path.Combine(BasePath, "src", "Playwright", ".drivers"));
-        var dedupeDirectory = new DirectoryInfo(Path.Combine(BasePath, "src", "Playwright", ".playwright"));
-        string driverVersion = DriverVersion;
-
-        var versionFile = new FileInfo(Path.Combine(destinationDirectory.FullName, driverVersion));
-
-        if (!versionFile.Exists)
-        {
-            if (destinationDirectory.Exists)
-            {
-                Directory.Delete(destinationDirectory.FullName, true);
-            }
-
-            if (dedupeDirectory.Exists)
-            {
-                Directory.Delete(dedupeDirectory.FullName, true);
-            }
-
-            destinationDirectory.Create();
-
-            var tasks = new List<Task>();
-
-            foreach (var platform in _platforms)
-            {
-                tasks.Add(DownloadDriverAsync(destinationDirectory, driverVersion, platform));
-            }
-
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-            versionFile.CreateText();
-        }
-        else
-        {
-            Console.WriteLine("Drivers are up-to-date");
-        }
-
-        // update readme
-        await UpdateBrowserVersionsAsync(BasePath, driverVersion).ConfigureAwait(false);
-
-        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
- `build.sh --download-driver` now assembles `src/Playwright/.drivers` from the `playwright-core` npm package and the official Node.js builds, instead of downloading prebuilt driver archives from the CDN.
- `.drivers` now mirrors the shipped `.playwright` layout (one copy of `package/`, per-platform node binaries), simplifying packaging in `Playwright.csproj` to a single glob.
- The bundled Node.js version is pinned as `DriverNodeVersion` in `Version.props`; `build.sh --roll` keeps it in sync with upstream.
- `api.json` and `protocol.yml` are no longer shipped in the NuGet package; nothing in this repo uses them. The package contents are otherwise identical to the released 1.60.0.