### PR TITLE
chore: roll driver to 1.62.0-alpha-1781285727000

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->148.0.7778.96<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| WebKit <!-- GEN:webkit-version -->26.4<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->150.0.2<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->149.0.7827.55<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| WebKit <!-- GEN:webkit-version -->26.5<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->151.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 Playwright for .NET is the official language port of [Playwright](https://playwright.dev), the library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.60.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.61.0-alpha-1781260242000</DriverVersion>
+    <DriverVersion>1.62.0-alpha-1781285727000</DriverVersion>
     <!-- The Node.js version bundled with the driver. Kept in sync with NODE_VERSION
          in upstream's utils/build/build-playwright-driver.sh by the roll script. -->
     <DriverNodeVersion>24.16.0</DriverNodeVersion>

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <AssemblyVersion>1.60.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.60.0</DriverVersion>
+    <DriverVersion>1.61.0-alpha-1781260242000</DriverVersion>
     <!-- The Node.js version bundled with the driver. Kept in sync with NODE_VERSION
          in upstream's utils/build/build-playwright-driver.sh by the roll script. -->
-    <DriverNodeVersion>24.15.0</DriverNodeVersion>
+    <DriverNodeVersion>24.16.0</DriverNodeVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -7,19 +7,19 @@
     "": {
       "name": "playwright.testingharnesstest",
       "devDependencies": {
-        "@playwright/test": "1.61.0-alpha-1781260242000",
+        "@playwright/test": "1.62.0-alpha-1781285727000",
         "@types/node": "^22.12.0",
         "fast-xml-parser": "^4.5.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-IRv/7+z9Ld+6EN8UPkQqb87vw1Rmk5t16mu+WFtwAuGg8IiouFHxv94TK10enXHboA8aW1j4C/TxDXDNfggLBg==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-QnzOX5IfBz6xIaKqhKINbEFfzDwXEw/N54cP/QKAo+sSJP9R8ms+L4ZaQSFIOQkNiwiqV8Pgo4Q1WU3iaS5SAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0-alpha-1781260242000"
+        "playwright": "1.62.0-alpha-1781285727000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -77,13 +77,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-ItRNtxzoirRlKFZ0j2uxpDZe9fq49IDUPIqndFgxbo9EX9GvZHR+pA6h71T4vk85z/qYJ1lhYlDMFvVKT5Pehg==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-8h6DFX7COprG+e1gr9QRJH1CBAeSkolThegV7Nre48W9SAPKGR0++l2olvETiz+TF0qA+GsJcaGHcCk0+lX5Aw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0-alpha-1781260242000"
+        "playwright-core": "1.62.0-alpha-1781285727000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-E3k5vAZEsvTc04qDtadEqiQFxLR3/jGtH6l1PzAN8pU/jVDYg8kk409JVX0TLq5b1M2UFtFb0WK9JDleBvNpwA==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-NPwzQBFzNeKMHbh1kshW/o4DcPpLeRuLFv8cPToF6JcTYLEy242WXkAh9LwEMiEtRVS45xWQ3Y90LO4FJKCTzA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -124,12 +124,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-IRv/7+z9Ld+6EN8UPkQqb87vw1Rmk5t16mu+WFtwAuGg8IiouFHxv94TK10enXHboA8aW1j4C/TxDXDNfggLBg==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-QnzOX5IfBz6xIaKqhKINbEFfzDwXEw/N54cP/QKAo+sSJP9R8ms+L4ZaQSFIOQkNiwiqV8Pgo4Q1WU3iaS5SAA==",
       "dev": true,
       "requires": {
-        "playwright": "1.61.0-alpha-1781260242000"
+        "playwright": "1.62.0-alpha-1781285727000"
       }
     },
     "@types/node": {
@@ -158,19 +158,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-ItRNtxzoirRlKFZ0j2uxpDZe9fq49IDUPIqndFgxbo9EX9GvZHR+pA6h71T4vk85z/qYJ1lhYlDMFvVKT5Pehg==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-8h6DFX7COprG+e1gr9QRJH1CBAeSkolThegV7Nre48W9SAPKGR0++l2olvETiz+TF0qA+GsJcaGHcCk0+lX5Aw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.61.0-alpha-1781260242000"
+        "playwright-core": "1.62.0-alpha-1781285727000"
       }
     },
     "playwright-core": {
-      "version": "1.61.0-alpha-1781260242000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781260242000.tgz",
-      "integrity": "sha512-E3k5vAZEsvTc04qDtadEqiQFxLR3/jGtH6l1PzAN8pU/jVDYg8kk409JVX0TLq5b1M2UFtFb0WK9JDleBvNpwA==",
+      "version": "1.62.0-alpha-1781285727000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1781285727000.tgz",
+      "integrity": "sha512-NPwzQBFzNeKMHbh1kshW/o4DcPpLeRuLFv8cPToF6JcTYLEy242WXkAh9LwEMiEtRVS45xWQ3Y90LO4FJKCTzA==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -7,19 +7,19 @@
     "": {
       "name": "playwright.testingharnesstest",
       "devDependencies": {
-        "@playwright/test": "1.60.0",
+        "@playwright/test": "1.61.0-alpha-1781260242000",
         "@types/node": "^22.12.0",
         "fast-xml-parser": "^4.5.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-IRv/7+z9Ld+6EN8UPkQqb87vw1Rmk5t16mu+WFtwAuGg8IiouFHxv94TK10enXHboA8aW1j4C/TxDXDNfggLBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0-alpha-1781260242000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -77,13 +77,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-ItRNtxzoirRlKFZ0j2uxpDZe9fq49IDUPIqndFgxbo9EX9GvZHR+pA6h71T4vk85z/qYJ1lhYlDMFvVKT5Pehg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0-alpha-1781260242000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-E3k5vAZEsvTc04qDtadEqiQFxLR3/jGtH6l1PzAN8pU/jVDYg8kk409JVX0TLq5b1M2UFtFb0WK9JDleBvNpwA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -124,12 +124,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-IRv/7+z9Ld+6EN8UPkQqb87vw1Rmk5t16mu+WFtwAuGg8IiouFHxv94TK10enXHboA8aW1j4C/TxDXDNfggLBg==",
       "dev": true,
       "requires": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0-alpha-1781260242000"
       }
     },
     "@types/node": {
@@ -158,19 +158,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-ItRNtxzoirRlKFZ0j2uxpDZe9fq49IDUPIqndFgxbo9EX9GvZHR+pA6h71T4vk85z/qYJ1lhYlDMFvVKT5Pehg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0-alpha-1781260242000"
       }
     },
     "playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0-alpha-1781260242000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1781260242000.tgz",
+      "integrity": "sha512-E3k5vAZEsvTc04qDtadEqiQFxLR3/jGtH6l1PzAN8pU/jVDYg8kk409JVX0TLq5b1M2UFtFb0WK9JDleBvNpwA==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.60.0",
+    "@playwright/test": "1.61.0-alpha-1781260242000",
     "@types/node": "^22.12.0",
     "fast-xml-parser": "^4.5.0"
   }

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.61.0-alpha-1781260242000",
+    "@playwright/test": "1.62.0-alpha-1781285727000",
     "@types/node": "^22.12.0",
     "fast-xml-parser": "^4.5.0"
   }

--- a/src/Playwright.Tests/BrowserContextWebAuthnTests.cs
+++ b/src/Playwright.Tests/BrowserContextWebAuthnTests.cs
@@ -1,0 +1,193 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Text.Json;
+
+namespace Microsoft.Playwright.Tests;
+
+///<playwright-file>browsercontext-webauthn.spec.ts</playwright-file>
+public class BrowserContextWebAuthnTests : BrowserTestEx
+{
+    // Server.Prefix is http://localhost:<port>.
+    private const string RpId = "localhost";
+
+    [PlaywrightTest("browsercontext-webauthn.spec.ts", "should not intercept navigator.credentials without install()")]
+    public async Task ShouldNotInterceptNavigatorCredentialsWithoutInstall()
+    {
+        await using var context = await Browser.NewContextAsync();
+        // Seed a credential, but do not install the interceptor.
+        await context.Credentials.CreateAsync(RpId);
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(Server.EmptyPage);
+
+        Assert.IsFalse(await page.EvaluateAsync<bool>("() => globalThis.__pwWebAuthnInstalled === true"));
+    }
+
+    [PlaywrightTest("browsercontext-webauthn.spec.ts", "should seed a known credential and authenticate")]
+    public async Task ShouldSeedAKnownCredentialAndAuthenticate()
+    {
+        // This is the easiest way to create credentials. In practice, this
+        // probably comes from environment.
+        await using var source = await Browser.NewContextAsync();
+        var known = await source.Credentials.CreateAsync(RpId);
+
+        // A fresh context imports the known credential and signs in with it.
+        await using var context = await Browser.NewContextAsync();
+        await context.Credentials.CreateAsync(known.RpId, new()
+        {
+            Id = known.Id,
+            UserHandle = known.UserHandle,
+            PrivateKey = known.PrivateKey,
+            PublicKey = known.PublicKey,
+        });
+        await context.Credentials.InstallAsync();
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(Server.EmptyPage);
+
+        var result = await page.EvaluateAsync<JsonElement>(@"async ({ rpId, credentialId }) => {
+            const b64UrlToBytes = (s) => {
+                let str = s.replace(/-/g, '+').replace(/_/g, '/');
+                while (str.length % 4)
+                    str += '=';
+                const bin = atob(str);
+                const u8 = new Uint8Array(bin.length);
+                for (let i = 0; i < bin.length; i++)
+                    u8[i] = bin.charCodeAt(i);
+                return u8;
+            };
+            const challenge = crypto.getRandomValues(new Uint8Array(32));
+            const cred = await navigator.credentials.get({
+                publicKey: {
+                    challenge,
+                    rpId,
+                    allowCredentials: [{ type: 'public-key', id: b64UrlToBytes(credentialId) }],
+                    userVerification: 'preferred',
+                },
+            });
+            const resp = cred.response;
+            return {
+                id: cred.id,
+                type: cred.type,
+                hasClientData: resp.clientDataJSON.byteLength > 0,
+                hasAuthData: resp.authenticatorData.byteLength > 0,
+                hasSignature: resp.signature.byteLength > 0,
+                authDataFlags: new Uint8Array(resp.authenticatorData)[32],
+            };
+        }", new { rpId = RpId, credentialId = known.Id });
+
+        Assert.AreEqual(known.Id, result.GetProperty("id").GetString());
+        Assert.AreEqual("public-key", result.GetProperty("type").GetString());
+        Assert.IsTrue(result.GetProperty("hasClientData").GetBoolean());
+        Assert.IsTrue(result.GetProperty("hasAuthData").GetBoolean());
+        Assert.IsTrue(result.GetProperty("hasSignature").GetBoolean());
+        // UP (0x01) | UV (0x04) = 0x05
+        Assert.AreEqual(0x05, result.GetProperty("authDataFlags").GetInt32() & 0x05);
+
+        // After the credential is deleted, the page can no longer authenticate with it.
+        await context.Credentials.DeleteAsync(known.Id);
+        Assert.IsEmpty(await context.Credentials.GetAsync());
+
+        var error = await page.EvaluateAsync<string>(@"async ({ rpId, credentialId }) => {
+            const b64UrlToBytes = (s) => {
+                let str = s.replace(/-/g, '+').replace(/_/g, '/');
+                while (str.length % 4)
+                    str += '=';
+                const bin = atob(str);
+                const u8 = new Uint8Array(bin.length);
+                for (let i = 0; i < bin.length; i++)
+                    u8[i] = bin.charCodeAt(i);
+                return u8;
+            };
+            const challenge = crypto.getRandomValues(new Uint8Array(32));
+            try {
+                await navigator.credentials.get({
+                    publicKey: {
+                        challenge,
+                        rpId,
+                        allowCredentials: [{ type: 'public-key', id: b64UrlToBytes(credentialId) }],
+                    },
+                });
+                return 'no-error';
+            } catch (e) {
+                return e.name;
+            }
+        }", new { rpId = RpId, credentialId = known.Id });
+        Assert.AreEqual("NotAllowedError", error);
+    }
+
+    [PlaywrightTest("browsercontext-webauthn.spec.ts", "should capture a page-created credential and reuse it in another context")]
+    public async Task ShouldCaptureAPageCreatedCredentialAndReuseItInAnotherContext()
+    {
+        // Setup context: the app registers a passkey via navigator.credentials.create().
+        await using var setupContext = await Browser.NewContextAsync();
+        await setupContext.Credentials.InstallAsync();
+        var setupPage = await setupContext.NewPageAsync();
+        await setupPage.GotoAsync(Server.EmptyPage);
+
+        var createdId = await setupPage.EvaluateAsync<string>(@"async ({ rpId }) => {
+            const challenge = crypto.getRandomValues(new Uint8Array(32));
+            const created = await navigator.credentials.create({
+                publicKey: {
+                    challenge,
+                    rp: { id: rpId, name: 'Test RP' },
+                    user: { id: new Uint8Array([1, 2, 3, 4]), name: 'u', displayName: 'User' },
+                    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+                    authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' },
+                },
+            });
+            return created.id;
+        }", new { rpId = RpId });
+
+        var credentials = await setupContext.Credentials.GetAsync(new() { RpId = RpId });
+        Assert.AreEqual(1, credentials.Count);
+        var captured = credentials[0];
+        Assert.AreEqual(createdId, captured.Id);
+        StringAssert.IsMatch("^[A-Za-z0-9_-]+$", captured.PrivateKey);
+        StringAssert.IsMatch("^[A-Za-z0-9_-]+$", captured.PublicKey);
+
+        // Reuse the captured passkey in a fresh context and sign in with it.
+        await using var context = await Browser.NewContextAsync();
+        await context.Credentials.CreateAsync(captured.RpId, new()
+        {
+            Id = captured.Id,
+            UserHandle = captured.UserHandle,
+            PrivateKey = captured.PrivateKey,
+            PublicKey = captured.PublicKey,
+        });
+        await context.Credentials.InstallAsync();
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(Server.EmptyPage);
+
+        var gotId = await page.EvaluateAsync<string>(@"async ({ rpId }) => {
+            const challenge = crypto.getRandomValues(new Uint8Array(32));
+            // No allowCredentials — relies on the re-seeded credential being discoverable.
+            const cred = await navigator.credentials.get({
+                publicKey: { challenge, rpId, userVerification: 'preferred' },
+            });
+            return cred.id;
+        }", new { rpId = RpId });
+
+        Assert.AreEqual(createdId, gotId);
+    }
+}

--- a/src/Playwright.Tests/GlobalFetchTests.cs
+++ b/src/Playwright.Tests/GlobalFetchTests.cs
@@ -235,6 +235,42 @@ public class GlobalFetchTests : PlaywrightTestEx
         await request.DisposeAsync();
     }
 
+    [PlaywrightTest("global-fetch.spec.ts", "should return server address from response")]
+    [Ignore("Server address is not reported for reused keep-alive sockets, pending an upstream fix")]
+    public async Task ShouldReturnServerAddressFromResponse()
+    {
+        var request = await Playwright.APIRequest.NewContextAsync();
+        var response = await request.GetAsync(Server.EmptyPage);
+        var addr = await response.ServerAddrAsync();
+        Assert.IsNotNull(addr);
+        StringAssert.IsMatch("^(127\\.0\\.0\\.1|::1)$", addr.IpAddress);
+        Assert.AreEqual(Server.Port, addr.Port);
+        await request.DisposeAsync();
+    }
+
+    [PlaywrightTest("global-fetch.spec.ts", "should return security details from response")]
+    [Ignore("Security details are not reported for reused keep-alive sockets, pending an upstream fix")]
+    public async Task ShouldReturnSecurityDetailsFromResponse()
+    {
+        var request = await Playwright.APIRequest.NewContextAsync(new() { IgnoreHTTPSErrors = true });
+        var response = await request.GetAsync(HttpsServer.EmptyPage);
+        var details = await response.SecurityDetailsAsync();
+        Assert.IsNotNull(details);
+        Assert.AreEqual("puppeteer-tests", details.SubjectName);
+        Assert.AreEqual("puppeteer-tests", details.Issuer);
+        StringAssert.Contains("TLS", details.Protocol);
+        await request.DisposeAsync();
+    }
+
+    [PlaywrightTest("global-fetch.spec.ts", "should return null security details for http response")]
+    public async Task ShouldReturnNullSecurityDetailsForHttpResponse()
+    {
+        var request = await Playwright.APIRequest.NewContextAsync();
+        var response = await request.GetAsync(Server.EmptyPage);
+        Assert.IsNull(await response.SecurityDetailsAsync());
+        await request.DisposeAsync();
+    }
+
     [PlaywrightTest("global-fetch.spec.ts", "should resolve url relative to global baseURL option")]
     public async Task ShouldResolveUrlRelativeToGlobalBaseURLOption()
     {

--- a/src/Playwright.Tests/GlobalFetchTests.cs
+++ b/src/Playwright.Tests/GlobalFetchTests.cs
@@ -236,29 +236,35 @@ public class GlobalFetchTests : PlaywrightTestEx
     }
 
     [PlaywrightTest("global-fetch.spec.ts", "should return server address from response")]
-    [Ignore("Server address is not reported for reused keep-alive sockets, pending an upstream fix")]
     public async Task ShouldReturnServerAddressFromResponse()
     {
         var request = await Playwright.APIRequest.NewContextAsync();
-        var response = await request.GetAsync(Server.EmptyPage);
-        var addr = await response.ServerAddrAsync();
-        Assert.IsNotNull(addr);
-        StringAssert.IsMatch("^(127\\.0\\.0\\.1|::1)$", addr.IpAddress);
-        Assert.AreEqual(Server.Port, addr.Port);
+        // The second request reuses the keep-alive socket and should report the address as well.
+        for (int i = 0; i < 2; i++)
+        {
+            var response = await request.GetAsync(Server.EmptyPage);
+            var addr = await response.ServerAddrAsync();
+            Assert.IsNotNull(addr);
+            StringAssert.IsMatch("^(127\\.0\\.0\\.1|::1)$", addr.IpAddress);
+            Assert.AreEqual(Server.Port, addr.Port);
+        }
         await request.DisposeAsync();
     }
 
     [PlaywrightTest("global-fetch.spec.ts", "should return security details from response")]
-    [Ignore("Security details are not reported for reused keep-alive sockets, pending an upstream fix")]
     public async Task ShouldReturnSecurityDetailsFromResponse()
     {
         var request = await Playwright.APIRequest.NewContextAsync(new() { IgnoreHTTPSErrors = true });
-        var response = await request.GetAsync(HttpsServer.EmptyPage);
-        var details = await response.SecurityDetailsAsync();
-        Assert.IsNotNull(details);
-        Assert.AreEqual("puppeteer-tests", details.SubjectName);
-        Assert.AreEqual("puppeteer-tests", details.Issuer);
-        StringAssert.Contains("TLS", details.Protocol);
+        // The second request reuses the keep-alive socket and should report the details as well.
+        for (int i = 0; i < 2; i++)
+        {
+            var response = await request.GetAsync(HttpsServer.EmptyPage);
+            var details = await response.SecurityDetailsAsync();
+            Assert.IsNotNull(details);
+            Assert.AreEqual("puppeteer-tests", details.SubjectName);
+            Assert.AreEqual("puppeteer-tests", details.Issuer);
+            StringAssert.Contains("TLS", details.Protocol);
+        }
         await request.DisposeAsync();
     }
 

--- a/src/Playwright.Tests/PageAriaSnapshotTests.cs
+++ b/src/Playwright.Tests/PageAriaSnapshotTests.cs
@@ -155,4 +155,48 @@ public class PageAriaSnapshotTests : PageTestEx
                 - /url: /auth?r=/
         ");
     }
+
+    [PlaywrightTest("to-match-aria-snapshot.spec.ts", "invalid attribute")]
+    public async Task InvalidAttribute()
+    {
+        await Page.SetContentAsync(@"
+            <input type=""text"" aria-label=""Email"" aria-invalid=""true"" value=""not-an-email"">
+            <input type=""text"" aria-label=""Name"" value=""Alice"">
+        ");
+
+        await Expect(Page.Locator("body")).ToMatchAriaSnapshotAsync(@"
+            - textbox ""Email"" [invalid]: not-an-email
+            - textbox ""Name"": Alice
+        ");
+
+        await Expect(Page.Locator("body")).ToMatchAriaSnapshotAsync(@"
+            - textbox ""Email"" [invalid=true]: not-an-email
+            - textbox ""Name"" [invalid=false]: Alice
+        ");
+
+        // `aria-invalid="grammar"` and `aria-invalid="spelling"` surface their underlying value.
+        await Page.SetContentAsync(@"
+            <input type=""text"" aria-label=""Bio"" aria-invalid=""grammar"">
+            <input type=""text"" aria-label=""Note"" aria-invalid=""spelling"">
+        ");
+        await Expect(Page.Locator("body")).ToMatchAriaSnapshotAsync(@"
+            - textbox ""Bio"" [invalid=grammar]
+            - textbox ""Note"" [invalid=spelling]
+        ");
+
+        // A `grammar` value is distinct from a plain `true` invalid state.
+        var exception = await PlaywrightAssert.ThrowsAsync<PlaywrightException>(() =>
+        {
+            return Expect(Page.Locator("body")).ToMatchAriaSnapshotAsync(@"
+                - textbox ""Bio"" [invalid]
+            ", new() { Timeout = 300 });
+        });
+        StringAssert.Contains("[invalid=grammar]", exception.Message);
+
+        // Any other non-false value falls back to `true`.
+        await Page.SetContentAsync(@"<input type=""text"" aria-label=""Zip"" aria-invalid=""garbage"">");
+        await Expect(Page.Locator("body")).ToMatchAriaSnapshotAsync(@"
+            - textbox ""Zip"" [invalid]
+        ");
+    }
 }

--- a/src/Playwright.Tests/PageLocalStorageTests.cs
+++ b/src/Playwright.Tests/PageLocalStorageTests.cs
@@ -1,0 +1,148 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace Microsoft.Playwright.Tests;
+
+///<playwright-file>page-localstorage.spec.ts</playwright-file>
+public class PageLocalStorageTests : PageTestEx
+{
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.items returns empty array on fresh origin")]
+    public async Task LocalStorageItemsReturnsEmptyArrayOnFreshOrigin()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        Assert.IsEmpty(await Page.LocalStorage.ItemsAsync());
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.getItem returns null for missing key")]
+    public async Task LocalStorageGetItemReturnsNullForMissingKey()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        Assert.IsNull(await Page.LocalStorage.GetItemAsync("absent"));
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.setItem persists and surfaces in items()/getItem()")]
+    public async Task LocalStorageSetItemPersistsAndSurfacesInItemsGetItem()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.LocalStorage.SetItemAsync("alpha", "1");
+        await Page.LocalStorage.SetItemAsync("beta", "2");
+
+        var items = (await Page.LocalStorage.ItemsAsync()).OrderBy(item => item.Name).ToList();
+        Assert.AreEqual(2, items.Count);
+        Assert.AreEqual("alpha", items[0].Name);
+        Assert.AreEqual("1", items[0].Value);
+        Assert.AreEqual("beta", items[1].Name);
+        Assert.AreEqual("2", items[1].Value);
+        Assert.AreEqual("1", await Page.LocalStorage.GetItemAsync("alpha"));
+        Assert.AreEqual("1", await Page.EvaluateAsync<string>("() => localStorage.getItem('alpha')"));
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.setItem overwrites existing value")]
+    public async Task LocalStorageSetItemOverwritesExistingValue()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.LocalStorage.SetItemAsync("k", "first");
+        await Page.LocalStorage.SetItemAsync("k", "second");
+        Assert.AreEqual("second", await Page.LocalStorage.GetItemAsync("k"));
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.removeItem removes a single item")]
+    public async Task LocalStorageRemoveItemRemovesASingleItem()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.LocalStorage.SetItemAsync("a", "1");
+        await Page.LocalStorage.SetItemAsync("b", "2");
+
+        await Page.LocalStorage.RemoveItemAsync("a");
+        var items = await Page.LocalStorage.ItemsAsync();
+        Assert.AreEqual(1, items.Count);
+        Assert.AreEqual("b", items[0].Name);
+        Assert.AreEqual("2", items[0].Value);
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage.clear empties storage")]
+    public async Task LocalStorageClearEmptiesStorage()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.LocalStorage.SetItemAsync("a", "1");
+        await Page.LocalStorage.SetItemAsync("b", "2");
+
+        await Page.LocalStorage.ClearAsync();
+        Assert.IsEmpty(await Page.LocalStorage.ItemsAsync());
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "sessionStorage round-trip")]
+    public async Task SessionStorageRoundTrip()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        Assert.IsEmpty(await Page.SessionStorage.ItemsAsync());
+
+        await Page.SessionStorage.SetItemAsync("s1", "v1");
+        await Page.SessionStorage.SetItemAsync("s2", "v2");
+        var items = (await Page.SessionStorage.ItemsAsync()).OrderBy(item => item.Name).ToList();
+        Assert.AreEqual(2, items.Count);
+        Assert.AreEqual("s1", items[0].Name);
+        Assert.AreEqual("v1", items[0].Value);
+        Assert.AreEqual("s2", items[1].Name);
+        Assert.AreEqual("v2", items[1].Value);
+        Assert.AreEqual("v1", await Page.SessionStorage.GetItemAsync("s1"));
+
+        await Page.SessionStorage.RemoveItemAsync("s1");
+        items = (await Page.SessionStorage.ItemsAsync()).ToList();
+        Assert.AreEqual(1, items.Count);
+        Assert.AreEqual("s2", items[0].Name);
+
+        await Page.SessionStorage.ClearAsync();
+        Assert.IsEmpty(await Page.SessionStorage.ItemsAsync());
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "localStorage and sessionStorage are independent")]
+    public async Task LocalStorageAndSessionStorageAreIndependent()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        await Page.LocalStorage.SetItemAsync("shared", "local");
+        await Page.SessionStorage.SetItemAsync("shared", "session");
+
+        Assert.AreEqual("local", await Page.LocalStorage.GetItemAsync("shared"));
+        Assert.AreEqual("session", await Page.SessionStorage.GetItemAsync("shared"));
+
+        await Page.LocalStorage.ClearAsync();
+        Assert.IsEmpty(await Page.LocalStorage.ItemsAsync());
+        Assert.AreEqual("session", await Page.SessionStorage.GetItemAsync("shared"));
+    }
+
+    [PlaywrightTest("page-localstorage.spec.ts", "storage methods are scoped to the current origin")]
+    public async Task StorageMethodsAreScopedToTheCurrentOrigin()
+    {
+        await Page.GotoAsync(Server.Prefix + "/empty.html");
+        await Page.LocalStorage.SetItemAsync("k", "origin-1");
+
+        await Page.GotoAsync(Server.CrossProcessPrefix + "/empty.html");
+        Assert.IsEmpty(await Page.LocalStorage.ItemsAsync());
+        await Page.LocalStorage.SetItemAsync("k", "origin-2");
+
+        await Page.GotoAsync(Server.Prefix + "/empty.html");
+        Assert.AreEqual("origin-1", await Page.LocalStorage.GetItemAsync("k"));
+    }
+}

--- a/src/Playwright.Tests/ScreencastTests.cs
+++ b/src/Playwright.Tests/ScreencastTests.cs
@@ -282,6 +282,36 @@ public class ScreencastTests : BrowserTestEx
         await context.CloseAsync();
     }
 
+    [PlaywrightTest("screencast.spec.ts", "onFrame receives viewport size")]
+    public async Task OnFrameReceivesViewportSize()
+    {
+        var context = await Browser.NewContextAsync(new() { ViewportSize = new() { Width = 1000, Height = 400 } });
+        var page = await context.NewPageAsync();
+
+        var frames = new List<ScreencastFrame>();
+        await page.Screencast.StartAsync(new()
+        {
+            OnFrame = frame =>
+            {
+                frames.Add(frame);
+                return Task.CompletedTask;
+            },
+            Size = new() { Width = 500, Height = 400 },
+        });
+        await page.EvaluateAsync("() => document.body.style.backgroundColor = 'red'");
+        await Task.Delay(1000);
+        await page.Screencast.StopAsync();
+
+        Assert.Greater(frames.Count, 0);
+        foreach (var frame in frames)
+        {
+            Assert.AreEqual(1000, frame.ViewportWidth);
+            Assert.AreEqual(400, frame.ViewportHeight);
+            Assert.Greater(frame.Timestamp, 0);
+        }
+        await context.CloseAsync();
+    }
+
     [PlaywrightTest()]
     public async Task ShowOverlayAsync_ReturnsDisposableThatCompletesOnDispose()
     {

--- a/src/Playwright.Tests/SelectorsGetByTests.cs
+++ b/src/Playwright.Tests/SelectorsGetByTests.cs
@@ -48,6 +48,23 @@ public class SelectorsGetByTests : PageTestEx
         await Expect(Page.Locator("div").GetByTestId("Hello")).ToHaveTextAsync("Hello world");
     }
 
+    [PlaywrightTest("selector-get-by.spec.ts", "getByTestId with comma-separated testIdAttributes should match any")]
+    public async Task GetByTestIdWithCommaSeparatedTestIdAttributesShouldMatchAny()
+    {
+        await Page.SetContentAsync(@"
+            <section>
+              <div data-pw=""Hello"">first</div>
+              <div data-ti=""Hello"">second</div>
+              <div data-testid=""Hello"">third</div>
+            </section>
+        ");
+        Playwright.Selectors.SetTestIdAttribute("data-pw,data-ti");
+        await Expect(Page.GetByTestId("Hello")).ToHaveCountAsync(2);
+        await Expect(Page.GetByTestId("Hello")).ToHaveTextAsync(new string[] { "first", "second" });
+        await Expect(Page.MainFrame.GetByTestId("Hello")).ToHaveCountAsync(2);
+        await Expect(Page.Locator("section").GetByTestId("Hello")).ToHaveCountAsync(2);
+    }
+
     [PlaywrightTest("selector-get-by.spec.ts", "getByTestId should escape id")]
     public async Task GetByTestIdShouldEscapeId()
     {

--- a/src/Playwright.Tests/WebSocketTests.cs
+++ b/src/Playwright.Tests/WebSocketTests.cs
@@ -154,14 +154,8 @@ public class WebSocketTests : PageTestEx
 
         await socketErrorTcs.Task;
 
-        if (TestConstants.IsFirefox)
-        {
-            Assert.AreEqual("CLOSE_ABNORMAL", socketErrorTcs.Task.Result);
-        }
-        else
-        {
-            StringAssert.Contains(": 40", socketErrorTcs.Task.Result);
-        }
+        // Upstream test server responds with 400 here, while ours responds with 404.
+        StringAssert.Contains(": 404", socketErrorTcs.Task.Result);
     }
 
     [PlaywrightTest("web-socket.spec.ts", "should not have stray error events")]

--- a/src/Playwright/API/Generated/Enums/ScreencastCursor.cs
+++ b/src/Playwright/API/Generated/Enums/ScreencastCursor.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,12 +22,14 @@
  * SOFTWARE.
  */
 
-using System.Text.Json.Serialization;
+using System.Runtime.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class WebSocketInitializer
+public enum ScreencastCursor
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    [EnumMember(Value = "none")]
+    None,
+    [EnumMember(Value = "pointer")]
+    Pointer,
 }

--- a/src/Playwright/API/Generated/IAPIResponse.cs
+++ b/src/Playwright/API/Generated/IAPIResponse.cs
@@ -65,6 +65,24 @@ public partial interface IAPIResponse
     /// </summary>
     bool Ok { get; }
 
+    /// <summary>
+    /// <para>
+    /// Returns SSL and other security information. Resolves to <c>null</c> for non-HTTPS
+    /// responses. For redirected requests, returns the information for the last request
+    /// in the redirect chain.
+    /// </para>
+    /// </summary>
+    Task<ResponseSecurityDetailsResult?> SecurityDetailsAsync();
+
+    /// <summary>
+    /// <para>
+    /// Returns the IP address and port of the server. Resolves to <c>null</c> if the server
+    /// address is not available. For redirected requests, returns the information for the
+    /// last request in the redirect chain.
+    /// </para>
+    /// </summary>
+    Task<ResponseServerAddrResult?> ServerAddrAsync();
+
     /// <summary><para>Contains the status code of the response (e.g., 200 for a success).</para></summary>
     int Status { get; }
 

--- a/src/Playwright/API/Generated/IBrowserContext.cs
+++ b/src/Playwright/API/Generated/IBrowserContext.cs
@@ -66,6 +66,15 @@ public partial interface IBrowserContext
     /// <summary><para>Playwright has ability to mock clock and passage of time.</para></summary>
     public IClock Clock { get; }
 
+    /// <summary>
+    /// <para>
+    /// Virtual WebAuthn authenticator for this context. Lets tests seed credentials and
+    /// intercept <c>navigator.credentials.create()</c> / <c>navigator.credentials.get()</c>
+    /// ceremonies.
+    /// </para>
+    /// </summary>
+    public ICredentials Credentials { get; }
+
     /// <summary><para>Debugger allows to pause and resume the execution.</para></summary>
     public IDebugger Debugger { get; }
 

--- a/src/Playwright/API/Generated/ICredentials.cs
+++ b/src/Playwright/API/Generated/ICredentials.cs
@@ -36,7 +36,55 @@ namespace Microsoft.Playwright;
 /// </para>
 /// <para>There are two common ways to use it:</para>
 /// <para>**Usage: seed a known credential**</para>
+/// <code>
+/// var context = await browser.NewContextAsync();<br/>
+/// <br/>
+/// // A passkey your backend already provisioned for a test user.<br/>
+/// await context.Credentials.CreateAsync("example.com", new()<br/>
+/// {<br/>
+///     Id = knownCredentialId, // base64url<br/>
+///     UserHandle = knownUserHandle, // base64url<br/>
+///     PrivateKey = knownPrivateKey, // base64url PKCS#8 (DER)<br/>
+///     PublicKey = knownPublicKey, // base64url SPKI (DER)<br/>
+/// });<br/>
+/// await context.Credentials.InstallAsync();<br/>
+/// <br/>
+/// var page = await context.NewPageAsync();<br/>
+/// await page.GotoAsync("https://example.com/login");<br/>
+/// // The page's navigator.credentials.get() is answered with the seeded passkey.
+/// </code>
 /// <para>**Usage: capture a passkey, then reuse it**</para>
+/// <code>
+/// // setup test: let the app register a passkey, then save it.<br/>
+/// var context = await browser.NewContextAsync();<br/>
+/// await context.Credentials.InstallAsync();<br/>
+/// <br/>
+/// var page = await context.NewPageAsync();<br/>
+/// await page.GotoAsync("https://example.com/register");<br/>
+/// await page.GetByRole(AriaRole.Button, new() { Name = "Create a passkey" }).ClickAsync();<br/>
+/// <br/>
+/// // Read back the passkey the page registered — it includes the private key.<br/>
+/// var credentials = await context.Credentials.GetAsync(new() { RpId = "example.com" });<br/>
+/// File.WriteAllText("playwright/.auth/passkey.json", JsonSerializer.Serialize(credentials[0]));
+/// </code>
+/// <code>
+/// // later test: seed the captured passkey so the app starts already enrolled.<br/>
+/// var credential = JsonSerializer.Deserialize&lt;VirtualCredential&gt;(<br/>
+///     File.ReadAllText("playwright/.auth/passkey.json"));<br/>
+/// var context = await browser.NewContextAsync();<br/>
+/// await context.Credentials.CreateAsync(credential.RpId, new()<br/>
+/// {<br/>
+///     Id = credential.Id,<br/>
+///     UserHandle = credential.UserHandle,<br/>
+///     PrivateKey = credential.PrivateKey,<br/>
+///     PublicKey = credential.PublicKey,<br/>
+/// });<br/>
+/// await context.Credentials.InstallAsync();<br/>
+/// <br/>
+/// var page = await context.NewPageAsync();<br/>
+/// await page.GotoAsync("https://example.com/login");<br/>
+/// // navigator.credentials.get() resolves the captured passkey — already signed in.
+/// </code>
 /// <para>**Defaults**</para>
 /// </summary>
 public partial interface ICredentials

--- a/src/Playwright/API/Generated/ICredentials.cs
+++ b/src/Playwright/API/Generated/ICredentials.cs
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Playwright;
+
+/// <summary>
+/// <para>
+/// <c>Credentials</c> is a virtual WebAuthn authenticator scoped to a <see cref="IBrowserContext"/>.
+/// It lets tests register passkeys and answer <c>navigator.credentials.create()</c>
+/// / <c>navigator.credentials.get()</c> ceremonies in the page, without a real authenticator
+/// or hardware security key.
+/// </para>
+/// <para>There are two common ways to use it:</para>
+/// <para>**Usage: seed a known credential**</para>
+/// <para>**Usage: capture a passkey, then reuse it**</para>
+/// <para>**Defaults**</para>
+/// </summary>
+public partial interface ICredentials
+{
+    /// <summary>
+    /// <para>
+    /// Installs the virtual WebAuthn authenticator into the context, overriding <c>navigator.credentials.create()</c>
+    /// and <c>navigator.credentials.get()</c> in all current and future pages. Call this
+    /// before the page first touches <c>navigator.credentials</c>.
+    /// </para>
+    /// <para>
+    /// Required: until <see cref="ICredentials.InstallAsync"/> is called, no interception
+    /// is in place and the page sees the platform's native (or absent) WebAuthn behaviour.
+    /// Seeding credentials with <see cref="ICredentials.CreateAsync"/> without installing
+    /// populates the authenticator, but the page will never see those credentials.
+    /// </para>
+    /// </summary>
+    Task InstallAsync();
+
+    /// <summary>
+    /// <para>Seeds a virtual WebAuthn credential and returns it.</para>
+    /// <para>
+    /// With only <see cref="ICredentials.CreateAsync"/>, generates a fresh **ECDSA P-256**
+    /// keypair, credential id and user handle. The seeded credential is discoverable (resident),
+    /// so the page can resolve it from both username-then-passkey and usernameless passkey
+    /// flows. The returned object carries the private and public keys, so it can be persisted
+    /// to disk and re-seeded in a later test.
+    /// </para>
+    /// <para>
+    /// To **import a known credential**, supply all four of <see cref="ICredentials.CreateAsync"/>,
+    /// <see cref="ICredentials.CreateAsync"/>, <see cref="ICredentials.CreateAsync"/> and
+    /// <see cref="ICredentials.CreateAsync"/> together.
+    /// </para>
+    /// <para>
+    /// Call <see cref="ICredentials.InstallAsync"/> before navigating to a page that uses
+    /// WebAuthn.
+    /// </para>
+    /// </summary>
+    /// <param name="rpId">Relying party id (typically the site's effective domain).</param>
+    /// <param name="options">Call options</param>
+    Task<VirtualCredential> CreateAsync(string rpId, CredentialsCreateOptions? options = default);
+
+    /// <summary>
+    /// <para>
+    /// Removes a credential from the authenticator by its id. Works for any credential
+    /// currently held — both those seeded with <see cref="ICredentials.CreateAsync"/> and
+    /// those the page registered itself by calling <c>navigator.credentials.create()</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="id">Base64url-encoded credential id.</param>
+    Task DeleteAsync(string id);
+
+    /// <summary>
+    /// <para>
+    /// Returns every credential currently held by the authenticator, optionally filtered
+    /// by <see cref="ICredentials.GetAsync"/> or <see cref="ICredentials.GetAsync"/>. This
+    /// includes both credentials seeded with <see cref="ICredentials.CreateAsync"/> and
+    /// credentials the page registered itself by calling <c>navigator.credentials.create()</c>.
+    /// </para>
+    /// <para>
+    /// Each returned credential includes its private and public keys, so a passkey the
+    /// app just registered can be saved and re-seeded into a later test with <see cref="ICredentials.CreateAsync"/>
+    /// — see the second example in the class overview.
+    /// </para>
+    /// </summary>
+    /// <param name="options">Call options</param>
+    Task<IReadOnlyList<VirtualCredential>> GetAsync(CredentialsGetOptions? options = default);
+}

--- a/src/Playwright/API/Generated/IFrame.cs
+++ b/src/Playwright/API/Generated/IFrame.cs
@@ -387,7 +387,7 @@ public partial interface IFrame
     /// cref="IFrame.EvaluateAsync"/>:
     /// </para>
     /// <code>
-    /// var bodyHandle = await frame.EvaluateAsync("document.body");<br/>
+    /// var bodyHandle = await frame.EvaluateHandleAsync("document.body");<br/>
     /// var html = await frame.EvaluateAsync&lt;string&gt;("([body, suffix]) =&gt; body.innerHTML + suffix", new object [] { bodyHandle, "hello" });<br/>
     /// await bodyHandle.DisposeAsync();
     /// </code>

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -722,7 +722,7 @@ public partial interface IPage
     /// cref="IPage.EvaluateAsync"/>:
     /// </para>
     /// <code>
-    /// var bodyHandle = await page.EvaluateAsync("document.body");<br/>
+    /// var bodyHandle = await page.EvaluateHandleAsync("document.body");<br/>
     /// var html = await page.EvaluateAsync&lt;string&gt;("([body, suffix]) =&gt; body.innerHTML + suffix", new object [] { bodyHandle, "hello" });<br/>
     /// await bodyHandle.DisposeAsync();
     /// </code>
@@ -1567,6 +1567,22 @@ public partial interface IPage
     /// </para>
     /// </summary>
     Task ClearPageErrorsAsync();
+
+    /// <summary>
+    /// <para>
+    /// Provides access to the page's <c>localStorage</c> for the current origin. See <see
+    /// cref="IWebStorage"/>.
+    /// </para>
+    /// </summary>
+    public IWebStorage LocalStorage { get; }
+
+    /// <summary>
+    /// <para>
+    /// Provides access to the page's <c>sessionStorage</c> for the current origin. See
+    /// <see cref="IWebStorage"/>.
+    /// </para>
+    /// </summary>
+    public IWebStorage SessionStorage { get; }
 
     /// <summary>
     /// <para>
@@ -2899,13 +2915,13 @@ public partial interface IPage
     /// this.
     /// </para>
     /// <para>
-    /// <see cref="IPage.TapAsync"/> the method will throw if <see cref="IBrowser.NewContextAsync"/>
+    /// <see cref="IPage.TapAsync"/> will throw if the <see cref="IBrowser.NewContextAsync"/>
     /// option of the browser context is false.
     /// </para>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <see cref="IPage.TapAsync"/> the method will throw if <see cref="IBrowser.NewContextAsync"/>
+    /// <see cref="IPage.TapAsync"/> will throw if the <see cref="IBrowser.NewContextAsync"/>
     /// option of the browser context is false.
     /// </para>
     /// </remarks>

--- a/src/Playwright/API/Generated/ISelectors.cs
+++ b/src/Playwright/API/Generated/ISelectors.cs
@@ -81,6 +81,9 @@ public partial interface ISelectors
     /// is used by default.
     /// </para>
     /// </summary>
-    /// <param name="attributeName">Test id attribute name.</param>
+    /// <param name="attributeName">
+    /// Test id attribute name. To match elements with any of several attributes, pass them
+    /// as a comma-separated list, e.g. <c>"data-pw,data-ti"</c>.
+    /// </param>
     void SetTestIdAttribute(string attributeName);
 }

--- a/src/Playwright/API/Generated/ITouchscreen.cs
+++ b/src/Playwright/API/Generated/ITouchscreen.cs
@@ -46,13 +46,13 @@ public partial interface ITouchscreen
     /// the position (<see cref="ITouchscreen.TapAsync"/>,<see cref="ITouchscreen.TapAsync"/>).
     /// </para>
     /// <para>
-    /// <see cref="IPage.TapAsync"/> the method will throw if <see cref="IBrowser.NewContextAsync"/>
+    /// <see cref="ITouchscreen.TapAsync"/> will throw if the <see cref="IBrowser.NewContextAsync"/>
     /// option of the browser context is false.
     /// </para>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <see cref="IPage.TapAsync"/> the method will throw if <see cref="IBrowser.NewContextAsync"/>
+    /// <see cref="ITouchscreen.TapAsync"/> will throw if the <see cref="IBrowser.NewContextAsync"/>
     /// option of the browser context is false.
     /// </para>
     /// </remarks>

--- a/src/Playwright/API/Generated/IWebStorage.cs
+++ b/src/Playwright/API/Generated/IWebStorage.cs
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Playwright;
+
+/// <summary>
+/// <para>
+/// WebStorage exposes the page's <c>localStorage</c> or <c>sessionStorage</c> for the
+/// current origin via an async, <a href="https://developer.mozilla.org/en-US/docs/Web/API/Storage">browser-consistent</a>
+/// API.
+/// </para>
+/// <para>Instances are accessed through <see cref="IPage.LocalStorage"/> and <see cref="IPage.SessionStorage"/>.</para>
+/// <code>
+/// await page.GotoAsync("https://example.com");<br/>
+/// await page.LocalStorage.SetItemAsync("token", "abc");<br/>
+/// var token = await page.LocalStorage.GetItemAsync("token");<br/>
+/// var all = await page.LocalStorage.ItemsAsync();<br/>
+/// await page.LocalStorage.RemoveItemAsync("token");<br/>
+/// await page.LocalStorage.ClearAsync();
+/// </code>
+/// </summary>
+public partial interface IWebStorage
+{
+    /// <summary><para>Returns all items in the storage as name/value pairs.</para></summary>
+    Task<IReadOnlyList<WebStorageItem>> ItemsAsync();
+
+    /// <summary><para>Returns the value for the given <see cref="IWebStorage.GetItemAsync"/> if present.</para></summary>
+    /// <param name="name">Name of the item to retrieve.</param>
+    Task<string?> GetItemAsync(string name);
+
+    /// <summary>
+    /// <para>
+    /// Sets the value for the given <see cref="IWebStorage.SetItemAsync"/>. Overwrites
+    /// any existing value for that name.
+    /// </para>
+    /// </summary>
+    /// <param name="name">Name of the item to set.</param>
+    /// <param name="value">New value for the item.</param>
+    Task SetItemAsync(string name, string value);
+
+    /// <summary>
+    /// <para>
+    /// Removes the item with the given <see cref="IWebStorage.RemoveItemAsync"/>. No-op
+    /// if the item is absent.
+    /// </para>
+    /// </summary>
+    /// <param name="name">Name of the item to remove.</param>
+    Task RemoveItemAsync(string name);
+
+    /// <summary><para>Removes all items from the storage.</para></summary>
+    Task ClearAsync();
+}

--- a/src/Playwright/API/Generated/Options/BrowserTypeConnectOverCDPOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserTypeConnectOverCDPOptions.cs
@@ -38,12 +38,22 @@ public class BrowserTypeConnectOverCDPOptions
             return;
         }
 
+        ArtifactsDir = clone.ArtifactsDir;
         Headers = clone.Headers;
         IsLocal = clone.IsLocal;
         NoDefaults = clone.NoDefaults;
         SlowMo = clone.SlowMo;
         Timeout = clone.Timeout;
     }
+
+    /// <summary>
+    /// <para>
+    /// If specified, browser artifacts (such as traces and downloads) are saved into this
+    /// directory.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("artifactsDir")]
+    public string? ArtifactsDir { get; set; }
 
     /// <summary><para>Additional HTTP headers to be sent with connect request. Optional.</para></summary>
     [JsonPropertyName("headers")]

--- a/src/Playwright/API/Generated/Options/CredentialsCreateOptions.cs
+++ b/src/Playwright/API/Generated/Options/CredentialsCreateOptions.cs
@@ -22,35 +22,40 @@
  * SOFTWARE.
  */
 
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright;
 
-public partial class ScreencastFrame
+public class CredentialsCreateOptions
 {
-    /// <summary><para>JPEG-encoded frame data.</para></summary>
-    [Required]
-    [JsonPropertyName("data")]
-    public byte[] Data { get; set; } = default!;
+    public CredentialsCreateOptions() { }
 
-    /// <summary>
-    /// <para>
-    /// The timestamp of when the frame was presented by the browser, in milliseconds since
-    /// the Unix epoch.
-    /// </para>
-    /// </summary>
-    [Required]
-    [JsonPropertyName("timestamp")]
-    public float Timestamp { get; set; } = default!;
+    public CredentialsCreateOptions(CredentialsCreateOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
 
-    /// <summary><para>Width of the page viewport at the time the frame was captured.</para></summary>
-    [Required]
-    [JsonPropertyName("viewportWidth")]
-    public int ViewportWidth { get; set; } = default!;
+        Id = clone.Id;
+        PrivateKey = clone.PrivateKey;
+        PublicKey = clone.PublicKey;
+        UserHandle = clone.UserHandle;
+    }
 
-    /// <summary><para>Height of the page viewport at the time the frame was captured.</para></summary>
-    [Required]
-    [JsonPropertyName("viewportHeight")]
-    public int ViewportHeight { get; set; } = default!;
+    /// <summary><para>Base64url-encoded credential id. Auto-generated if omitted.</para></summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary><para>Base64url-encoded PKCS#8 (DER) private key. Auto-generated if omitted.</para></summary>
+    [JsonPropertyName("privateKey")]
+    public string? PrivateKey { get; set; }
+
+    /// <summary><para>Base64url-encoded SPKI (DER) public key. Auto-generated if omitted.</para></summary>
+    [JsonPropertyName("publicKey")]
+    public string? PublicKey { get; set; }
+
+    /// <summary><para>Base64url-encoded user handle. Auto-generated if omitted.</para></summary>
+    [JsonPropertyName("userHandle")]
+    public string? UserHandle { get; set; }
 }

--- a/src/Playwright/API/Generated/Options/CredentialsGetOptions.cs
+++ b/src/Playwright/API/Generated/Options/CredentialsGetOptions.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -24,10 +24,28 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class WebSocketInitializer
+public class CredentialsGetOptions
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    public CredentialsGetOptions() { }
+
+    public CredentialsGetOptions(CredentialsGetOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
+
+        Id = clone.Id;
+        RpId = clone.RpId;
+    }
+
+    /// <summary><para>Only return the credential with this base64url-encoded id.</para></summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary><para>Only return credentials for this relying party id.</para></summary>
+    [JsonPropertyName("rpId")]
+    public string? RpId { get; set; }
 }

--- a/src/Playwright/API/Generated/Options/ScreencastShowActionsOptions.cs
+++ b/src/Playwright/API/Generated/Options/ScreencastShowActionsOptions.cs
@@ -37,10 +37,21 @@ public class ScreencastShowActionsOptions
             return;
         }
 
+        Cursor = clone.Cursor;
         Duration = clone.Duration;
         FontSize = clone.FontSize;
         Position = clone.Position;
     }
+
+    /// <summary>
+    /// <para>
+    /// Cursor decoration shown for pointer actions. <c>"pointer"</c> (the default) renders
+    /// a mouse pointer that animates from the previous action point to the next one. <c>"none"</c>
+    /// disables the cursor decoration.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("cursor")]
+    public ScreencastCursor? Cursor { get; set; }
 
     /// <summary><para>How long each annotation is displayed in milliseconds. Defaults to <c>500</c>.</para></summary>
     [JsonPropertyName("duration")]

--- a/src/Playwright/API/Generated/Options/ScreencastStartOptions.cs
+++ b/src/Playwright/API/Generated/Options/ScreencastStartOptions.cs
@@ -42,6 +42,7 @@ public class ScreencastStartOptions
         OnFrame = clone.OnFrame;
         Path = clone.Path;
         Quality = clone.Quality;
+        Size = clone.Size;
     }
 
     /// <summary>
@@ -65,4 +66,17 @@ public class ScreencastStartOptions
     /// <summary><para>The quality of the image, between 0-100.</para></summary>
     [JsonPropertyName("quality")]
     public int? Quality { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Specifies the dimensions of screencast frames. The actual frame is scaled to preserve
+    /// the page's aspect ratio and may be smaller than these bounds. If a screencast is
+    /// already active (e.g. started by tracing or video recording), the existing configuration
+    /// takes precedence and the frame size may exceed these bounds or this option may be
+    /// ignored. If not specified the size will be equal to page viewport scaled down to
+    /// fit into 800×800.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("size")]
+    public ScreencastSize? Size { get; set; }
 }

--- a/src/Playwright/API/Generated/Types/ScreencastSize.cs
+++ b/src/Playwright/API/Generated/Types/ScreencastSize.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,12 +22,20 @@
  * SOFTWARE.
  */
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class WebSocketInitializer
+public partial class ScreencastSize
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    /// <summary><para>Max frame width in pixels.</para></summary>
+    [Required]
+    [JsonPropertyName("width")]
+    public int Width { get; set; } = default!;
+
+    /// <summary><para>Max frame height in pixels.</para></summary>
+    [Required]
+    [JsonPropertyName("height")]
+    public int Height { get; set; } = default!;
 }

--- a/src/Playwright/API/Generated/Types/VirtualCredential.cs
+++ b/src/Playwright/API/Generated/Types/VirtualCredential.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,12 +22,35 @@
  * SOFTWARE.
  */
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class WebSocketInitializer
+public partial class VirtualCredential
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    /// <summary><para>Base64url-encoded credential id.</para></summary>
+    [Required]
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = default!;
+
+    /// <summary><para>Relying party id.</para></summary>
+    [Required]
+    [JsonPropertyName("rpId")]
+    public string RpId { get; set; } = default!;
+
+    /// <summary><para>Base64url-encoded user handle.</para></summary>
+    [Required]
+    [JsonPropertyName("userHandle")]
+    public string UserHandle { get; set; } = default!;
+
+    /// <summary><para>Base64url-encoded PKCS#8 (DER) private key.</para></summary>
+    [Required]
+    [JsonPropertyName("privateKey")]
+    public string PrivateKey { get; set; } = default!;
+
+    /// <summary><para>Base64url-encoded SPKI (DER) public key.</para></summary>
+    [Required]
+    [JsonPropertyName("publicKey")]
+    public string PublicKey { get; set; } = default!;
 }

--- a/src/Playwright/API/Generated/Types/WebStorageItem.cs
+++ b/src/Playwright/API/Generated/Types/WebStorageItem.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,8 +22,20 @@
  * SOFTWARE.
  */
 
-namespace Microsoft.Playwright.Transport.Protocol;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
-internal class EventTargetInitializer
+namespace Microsoft.Playwright;
+
+public partial class WebStorageItem
 {
+    /// <summary><para></para></summary>
+    [Required]
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = default!;
+
+    /// <summary><para></para></summary>
+    [Required]
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = default!;
 }

--- a/src/Playwright/Core/APIResponse.cs
+++ b/src/Playwright/Core/APIResponse.cs
@@ -57,6 +57,23 @@ internal class APIResponse : IAPIResponse
 
     public string Url => _initializer.Url;
 
+    public Task<ResponseSecurityDetailsResult?> SecurityDetailsAsync()
+        => Task.FromResult(_initializer.SecurityDetails == null ? null : new ResponseSecurityDetailsResult
+        {
+            Issuer = _initializer.SecurityDetails.Issuer,
+            Protocol = _initializer.SecurityDetails.Protocol,
+            SubjectName = _initializer.SecurityDetails.SubjectName,
+            ValidFrom = _initializer.SecurityDetails.ValidFrom,
+            ValidTo = _initializer.SecurityDetails.ValidTo,
+        });
+
+    public Task<ResponseServerAddrResult?> ServerAddrAsync()
+        => Task.FromResult(_initializer.ServerAddr == null ? null : new ResponseServerAddrResult
+        {
+            IpAddress = _initializer.ServerAddr.IpAddress,
+            Port = _initializer.ServerAddr.Port,
+        });
+
     public async Task<byte[]> BodyAsync()
     {
         try

--- a/src/Playwright/Core/BrowserContext.cs
+++ b/src/Playwright/Core/BrowserContext.cs
@@ -62,6 +62,7 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     {
         _tracing = initializer.Tracing;
         _clock = new Clock(this);
+        Credentials = new Credentials(this);
         _request = initializer.RequestContext;
         _request._timeoutSettings = this._timeoutSettings;
         _initializer = initializer;
@@ -144,6 +145,8 @@ internal class BrowserContext : ChannelOwner, IBrowserContext
     public ITracing Tracing => _tracing;
 
     public IClock Clock => _clock;
+
+    public ICredentials Credentials { get; }
 
     public IBrowser? Browser => _browser;
 

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -270,6 +270,8 @@ internal class BrowserType : ChannelOwner, IBrowserType
                 { "slowMo", options.SlowMo },
                 { "timeout", TimeoutSettings.LaunchTimeout(options.Timeout) },
                 { "isLocal", options.IsLocal },
+                { "noDefaults", options.NoDefaults },
+                { "artifactsDir", options.ArtifactsDir },
             }).ConfigureAwait(false);
         Browser browser = result.GetProperty("browser").ToObject<Browser>(_connection.DefaultJsonSerializerOptions);
         browser.ConnectToBrowserType(this, null);

--- a/src/Playwright/Core/Credentials.cs
+++ b/src/Playwright/Core/Credentials.cs
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Playwright.Helpers;
+
+namespace Microsoft.Playwright.Core;
+
+internal class Credentials : ICredentials
+{
+    private readonly BrowserContext _browserContext;
+
+    public Credentials(BrowserContext browserContext)
+    {
+        _browserContext = browserContext;
+    }
+
+    public Task InstallAsync()
+        => _browserContext.SendMessageToServerAsync("credentialsInstall");
+
+    public async Task<VirtualCredential> CreateAsync(string rpId, CredentialsCreateOptions? options = default)
+    {
+        var result = await _browserContext.SendMessageToServerAsync("credentialsCreate", new Dictionary<string, object?>
+        {
+            ["rpId"] = rpId,
+            ["id"] = options?.Id,
+            ["userHandle"] = options?.UserHandle,
+            ["privateKey"] = options?.PrivateKey,
+            ["publicKey"] = options?.PublicKey,
+        }).ConfigureAwait(false);
+        return result!.Value.GetProperty("credential").ToObject<VirtualCredential>(_browserContext._connection.DefaultJsonSerializerOptions);
+    }
+
+    public Task DeleteAsync(string id)
+        => _browserContext.SendMessageToServerAsync("credentialsDelete", new Dictionary<string, object?>
+        {
+            ["id"] = id,
+        });
+
+    public async Task<IReadOnlyList<VirtualCredential>> GetAsync(CredentialsGetOptions? options = default)
+    {
+        var result = await _browserContext.SendMessageToServerAsync("credentialsGet", new Dictionary<string, object?>
+        {
+            ["rpId"] = options?.RpId,
+            ["id"] = options?.Id,
+        }).ConfigureAwait(false);
+        return result!.Value.GetProperty("credentials").ToObject<List<VirtualCredential>>(_browserContext._connection.DefaultJsonSerializerOptions);
+    }
+}

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -932,31 +932,49 @@ internal class Frame : ChannelOwner, IFrame
 
     internal async Task<FrameExpectResult> ExpectAsync(string? selector, string expression, FrameExpectOptions options)
     {
-        var result = await SendMessageToServerAsync("expect", new Dictionary<string, object?>
+        try
         {
-            ["selector"] = selector,
-            ["expression"] = expression,
-            ["expressionArg"] = options.ExpressionArg,
-            ["expectedText"] = options.ExpectedText,
-            ["expectedNumber"] = options.ExpectedNumber,
-            ["expectedValue"] = options.ExpectedValue,
-            ["useInnerText"] = options.UseInnerText,
-            ["isNot"] = options.IsNot,
-            ["timeout"] = options.Timeout,
-        }).ConfigureAwait(false);
-        var parsed = result!.Value.ToObject<FrameExpectResult>();
-        if (result!.Value.TryGetProperty("received", out var received) && received.ValueKind == JsonValueKind.Object)
-        {
-            if (received.TryGetProperty("value", out var receivedValue))
+            await SendMessageToServerAsync("expect", new Dictionary<string, object?>
             {
-                parsed.Received = ScriptsHelper.ParseEvaluateResult<object>(receivedValue);
-            }
-            if (received.TryGetProperty("ariaSnapshot", out var ariaSnapshot) && ariaSnapshot.ValueKind == JsonValueKind.String)
-            {
-                parsed.ReceivedAriaSnapshot = ariaSnapshot.GetString();
-            }
+                ["selector"] = selector,
+                ["expression"] = expression,
+                ["expressionArg"] = options.ExpressionArg,
+                ["expectedText"] = options.ExpectedText,
+                ["expectedNumber"] = options.ExpectedNumber,
+                ["expectedValue"] = options.ExpectedValue,
+                ["useInnerText"] = options.UseInnerText,
+                ["isNot"] = options.IsNot,
+                ["timeout"] = options.Timeout,
+            }).ConfigureAwait(false);
+            return new FrameExpectResult { Matches = !options.IsNot };
         }
-        return parsed;
+        catch (Exception e) when (e.Data.Contains(Connection.ErrorDetailsDataKey))
+        {
+            var result = new FrameExpectResult
+            {
+                Matches = options.IsNot,
+                Log = (e.Data[Connection.LogDataKey] as string[]) ?? Array.Empty<string>(),
+            };
+            if (e.Data[Connection.ErrorDetailsDataKey] is JsonElement details && details.ValueKind == JsonValueKind.Object)
+            {
+                if (details.TryGetProperty("customErrorMessage", out var customErrorMessage) && customErrorMessage.ValueKind == JsonValueKind.String)
+                {
+                    result.ErrorMessage = "Error: " + customErrorMessage.GetString();
+                }
+                if (details.TryGetProperty("received", out var received) && received.ValueKind == JsonValueKind.Object)
+                {
+                    if (received.TryGetProperty("value", out var receivedValue))
+                    {
+                        result.Received = ScriptsHelper.ParseEvaluateResult<object>(receivedValue);
+                    }
+                    if (received.TryGetProperty("ariaSnapshot", out var ariaSnapshot) && ariaSnapshot.ValueKind == JsonValueKind.String)
+                    {
+                        result.ReceivedAriaSnapshot = ariaSnapshot.GetString();
+                    }
+                }
+            }
+            return result;
+        }
     }
 
     private Task WaitForURLAsync(string? urlString, Regex? urlRegex, Func<string, bool>? urlFunc, FrameWaitForURLOptions? options = default)

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -521,10 +521,14 @@ internal class Locator : ILocator
         => _testIdAttributeName = attributeName;
 
     internal static string GetByTestIdSelector(string testIdAttributeName, string testId)
-        => $"internal:testid=[{testIdAttributeName}={EscapeForAttributeSelector(testId, true)}]";
+        => $"internal:testid=[{EncodeTestIdAttributeName(testIdAttributeName)}={EscapeForAttributeSelector(testId, true)}]";
 
     internal static string GetByTestIdSelector(string testIdAttributeName, Regex testId)
-        => $"internal:testid=[{testIdAttributeName}={EscapeForAttributeSelector(testId, true)}]";
+        => $"internal:testid=[{EncodeTestIdAttributeName(testIdAttributeName)}={EscapeForAttributeSelector(testId, true)}]";
+
+    // Multiple test id attribute names can be joined with a comma. Attribute names cannot contain commas.
+    private static string EncodeTestIdAttributeName(string testIdAttributeName)
+        => testIdAttributeName.Contains(",") ? JsonSerializer.Serialize(testIdAttributeName) : testIdAttributeName;
 
     internal static string GetByAttributeTextSelector(string attrName, string text, bool? exact)
         => $"internal:attr=[{attrName}={EscapeForAttributeSelector(text, exact ?? false)}]";

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -75,6 +75,8 @@ internal class Page : ChannelOwner, IPage
         _initializer = initializer;
         _video = new Video(this, _connection, initializer.Video);
         _screencast = new Screencast(this);
+        LocalStorage = new WebStorage(this, "local");
+        SessionStorage = new WebStorage(this, "session");
 
         Close += (_, _) => ClosedOrCrashedTcs.TrySetResult(true);
         Crash += (_, _) => ClosedOrCrashedTcs.TrySetResult(true);
@@ -191,6 +193,10 @@ internal class Page : ChannelOwner, IPage
 
     public IScreencast Screencast => _screencast;
 
+    public IWebStorage LocalStorage { get; }
+
+    public IWebStorage SessionStorage { get; }
+
     public IReadOnlyList<IWorker> Workers => _workers;
 
     public IVideo? Video
@@ -267,7 +273,7 @@ internal class Page : ChannelOwner, IPage
                 ViewportSize = new() { Width = size.Width, Height = size.Height };
                 break;
             case "screencastFrame":
-                _screencast.OnScreencastFrame(serverParams.GetProperty("data").GetBytesFromBase64());
+                _screencast.OnScreencastFrame(serverParams.ToObject<ScreencastFrame>(_connection.DefaultJsonSerializerOptions));
                 break;
             case "worker":
                 var worker = serverParams.GetProperty("worker").ToObject<Worker>(_connection.DefaultJsonSerializerOptions);
@@ -512,15 +518,22 @@ internal class Page : ChannelOwner, IPage
         CloseWasCalled = true;
         try
         {
-            await SendMessageToServerAsync(
-            "close",
-            new Dictionary<string, object?>
-            {
-                ["runBeforeUnload"] = options?.RunBeforeUnload ?? false,
-            }).ConfigureAwait(false);
             if (OwnedContext != null)
             {
                 await OwnedContext.CloseAsync().ConfigureAwait(false);
+            }
+            else if (options?.RunBeforeUnload == true)
+            {
+                await SendMessageToServerAsync("runBeforeUnload").ConfigureAwait(false);
+            }
+            else
+            {
+                await SendMessageToServerAsync(
+                "close",
+                new Dictionary<string, object?>
+                {
+                    ["reason"] = options?.Reason,
+                }).ConfigureAwait(false);
             }
         }
         catch (Exception e) when (DriverMessages.IsTargetClosedError(e) && options?.RunBeforeUnload != true)

--- a/src/Playwright/Core/Screencast.cs
+++ b/src/Playwright/Core/Screencast.cs
@@ -42,12 +42,12 @@ internal class Screencast : IScreencast
         _page = page;
     }
 
-    internal void OnScreencastFrame(byte[] data)
+    internal void OnScreencastFrame(ScreencastFrame frame)
     {
         var handler = _onFrame;
         if (handler != null)
         {
-            _ = handler(new ScreencastFrame { Data = data });
+            _ = handler(frame);
         }
     }
 
@@ -65,6 +65,7 @@ internal class Screencast : IScreencast
         }
         var result = await _page.SendMessageToServerAsync("screencastStart", new Dictionary<string, object?>
         {
+            ["size"] = options.Size,
             ["quality"] = options.Quality,
             ["sendFrames"] = options.OnFrame != null,
             ["record"] = options.Path != null,
@@ -120,6 +121,7 @@ internal class Screencast : IScreencast
             ["duration"] = options?.Duration,
             ["position"] = options?.Position,
             ["fontSize"] = options?.FontSize,
+            ["cursor"] = options?.Cursor,
         }).ConfigureAwait(false);
         return new DisposableStub(() => _page.SendMessageToServerAsync("screencastHideActions"));
     }

--- a/src/Playwright/Core/Waiter.cs
+++ b/src/Playwright/Core/Waiter.cs
@@ -52,15 +52,17 @@ internal class Waiter : IDisposable
 
         var beforeArgs = new Dictionary<string, object?>
         {
-            ["info"] = new Dictionary<string, object>
-            {
-                ["event"] = @event,
-                ["waitId"] = _waitId,
-                ["phase"] = "before",
-            },
+            ["event"] = @event,
+            ["waitId"] = _waitId,
+            ["phase"] = "before",
         };
         _failures.Add(Task.Delay(-1, _manualCts.Token));
-        _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "waitForEventInfo", beforeArgs).IgnoreException();
+        // An outer WrapApiCallAsync may have set its own title (e.g. "Wait for navigation");
+        // fall back to ours only when there is no outer zone.
+        _channelOwner.WrapApiCallAsync(
+            () => _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "__waitInfo__", beforeArgs),
+            false,
+            $"Wait for event \"{@event}\"").IgnoreException();
     }
 
     public void Dispose()
@@ -73,21 +75,17 @@ internal class Waiter : IDisposable
                 dispose();
             }
 
-            var info = new Dictionary<string, object>
+            var afterArgs = new Dictionary<string, object?>
             {
                 ["waitId"] = _waitId,
                 ["phase"] = "after",
             };
             if (!_error.IsNullOrEmpty())
             {
-                info["error"] = _error;
+                afterArgs["error"] = _error;
             }
-            var afterArgs = new Dictionary<string, object?>
-            {
-                ["info"] = info,
-            };
 
-            _channelOwner.WrapApiCallAsync(() => _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "waitForEventInfo", afterArgs), true).IgnoreException();
+            _channelOwner.WrapApiCallAsync(() => _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "__waitInfo__", afterArgs), true).IgnoreException();
 
             _onDisposeCts.Cancel();
             _onDisposeCts.Dispose();
@@ -102,14 +100,11 @@ internal class Waiter : IDisposable
 
         var logArgs = new Dictionary<string, object?>
         {
-            ["info"] = new Dictionary<string, object>
-            {
-                ["waitId"] = _waitId,
-                ["phase"] = "log",
-                ["message"] = log,
-            },
+            ["waitId"] = _waitId,
+            ["phase"] = "log",
+            ["message"] = log,
         };
-        _channelOwner.WrapApiCallAsync(() => _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "waitForEventInfo", logArgs), true).IgnoreException();
+        _channelOwner.WrapApiCallAsync(() => _channelOwner._connection.SendMessageToServerAsync(_channelOwner, "__waitInfo__", logArgs), true).IgnoreException();
     }
 
     internal void RejectImmediately(Exception exception)

--- a/src/Playwright/Core/WebStorage.cs
+++ b/src/Playwright/Core/WebStorage.cs
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Playwright.Helpers;
+
+namespace Microsoft.Playwright.Core;
+
+internal class WebStorage : IWebStorage
+{
+    private readonly Page _page;
+    private readonly string _kind;
+
+    public WebStorage(Page page, string kind)
+    {
+        _page = page;
+        _kind = kind;
+    }
+
+    public async Task<IReadOnlyList<WebStorageItem>> ItemsAsync()
+    {
+        var result = await _page.SendMessageToServerAsync("webStorageItems", new Dictionary<string, object?>
+        {
+            ["kind"] = _kind,
+        }).ConfigureAwait(false);
+        return result!.Value.GetProperty("items").ToObject<List<WebStorageItem>>(_page._connection.DefaultJsonSerializerOptions);
+    }
+
+    public async Task<string?> GetItemAsync(string name)
+    {
+        var result = await _page.SendMessageToServerAsync("webStorageGetItem", new Dictionary<string, object?>
+        {
+            ["kind"] = _kind,
+            ["name"] = name,
+        }).ConfigureAwait(false);
+        if (result?.TryGetProperty("value", out var value) == true && value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString();
+        }
+        return null;
+    }
+
+    public Task SetItemAsync(string name, string value)
+        => _page.SendMessageToServerAsync("webStorageSetItem", new Dictionary<string, object?>
+        {
+            ["kind"] = _kind,
+            ["name"] = name,
+            ["value"] = value,
+        });
+
+    public Task RemoveItemAsync(string name)
+        => _page.SendMessageToServerAsync("webStorageRemoveItem", new Dictionary<string, object?>
+        {
+            ["kind"] = _kind,
+            ["name"] = name,
+        });
+
+    public Task ClearAsync()
+        => _page.SendMessageToServerAsync("webStorageClear", new Dictionary<string, object?>
+        {
+            ["kind"] = _kind,
+        });
+}

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Playwright.Transport;
 
 internal class Connection : IDisposable
 {
+    // Keys used to attach server-provided error information to the exception,
+    // marking it as a server error. The details shape is declared in the protocol.
+    internal const string ErrorDetailsDataKey = "playwright.errorDetails";
+    internal const string LogDataKey = "playwright.log";
+
     private readonly ConcurrentDictionary<int, ConnectionCallback> _callbacks = new();
     private readonly Root _rootObject;
     private readonly TaskQueue _queue = new();
@@ -138,6 +143,13 @@ internal class Connection : IDisposable
         Dictionary<string, object?>? dictionary = null,
         bool keepNulls = false)
     {
+        // Fire-and-forget: server intentionally never replies to __waitInfo__,
+        // so silently drop it after the connection is closed or the object was collected.
+        bool isWaitInfo = method == "__waitInfo__";
+        if (isWaitInfo && (_closedError != null || @object?._wasCollected == true))
+        {
+            return default!;
+        }
         if (_closedError != null)
         {
             throw _closedError;
@@ -151,7 +163,10 @@ internal class Connection : IDisposable
         var tcs = new TaskCompletionSource<JsonElement?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var callback = new ConnectionCallback(tcs);
 
-        _callbacks.TryAdd(id, callback);
+        if (!isWaitInfo)
+        {
+            _callbacks.TryAdd(id, callback);
+        }
 
         var sanitizedArgs = new Dictionary<string, object>();
         if (dictionary?.Keys.Any(f => f != null) == true)
@@ -197,6 +212,12 @@ internal class Connection : IDisposable
             };
             return OnMessage(message, keepNulls);
         }).ConfigureAwait(false);
+
+        // Fire-and-forget: server intentionally never replies to __waitInfo__.
+        if (isWaitInfo)
+        {
+            return default!;
+        }
 
         var result = await tcs.Task.ConfigureAwait(false);
 
@@ -258,6 +279,8 @@ internal class Connection : IDisposable
             if (message.Error != null && message.Result == null)
             {
                 var exception = ParseException(message.Error.Error, FormatCallLog(message.Log));
+                exception.Data[ErrorDetailsDataKey] = message.ErrorDetails;
+                exception.Data[LogDataKey] = message.Log;
                 callback.TaskCompletionSource.TrySetException(exception);
             }
             else

--- a/src/Playwright/Transport/PlaywrightServerMessage.cs
+++ b/src/Playwright/Transport/PlaywrightServerMessage.cs
@@ -39,6 +39,8 @@ internal class PlaywrightServerMessage
 
     public ErrorEntry? Error { get; set; }
 
+    public JsonElement? ErrorDetails { get; set; }
+
     public string[]? Log { get; set; }
 }
 

--- a/src/Playwright/Transport/Protocol/Generated/APIResponse.cs
+++ b/src/Playwright/Transport/Protocol/Generated/APIResponse.cs
@@ -43,4 +43,10 @@ internal class APIResponse
 
     [JsonPropertyName("headers")]
     public List<NameValue> Headers { get; set; } = null!;
+
+    [JsonPropertyName("securityDetails")]
+    public SecurityDetails SecurityDetails { get; set; } = null!;
+
+    [JsonPropertyName("serverAddr")]
+    public RemoteAddr ServerAddr { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/AndroidDeviceInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/AndroidDeviceInitializer.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class AndroidDeviceInitializer : EventTargetInitializer
+internal class AndroidDeviceInitializer
 {
     [JsonPropertyName("model")]
     public string Model { get; set; } = null!;

--- a/src/Playwright/Transport/Protocol/Generated/BrowserContextInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/BrowserContextInitializer.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class BrowserContextInitializer : EventTargetInitializer
+internal class BrowserContextInitializer
 {
     [JsonPropertyName("debugger")]
     public Core.Debugger Debugger { get; set; } = null!;

--- a/src/Playwright/Transport/Protocol/Generated/DebuggerInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/DebuggerInitializer.cs
@@ -24,6 +24,6 @@
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class DebuggerInitializer : EventTargetInitializer
+internal class DebuggerInitializer
 {
 }

--- a/src/Playwright/Transport/Protocol/Generated/ElectronApplicationInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/ElectronApplicationInitializer.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class ElectronApplicationInitializer : EventTargetInitializer
+internal class ElectronApplicationInitializer
 {
     [JsonPropertyName("context")]
     public Core.BrowserContext Context { get; set; } = null!;

--- a/src/Playwright/Transport/Protocol/Generated/PageInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/PageInitializer.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class PageInitializer : EventTargetInitializer
+internal class PageInitializer
 {
     [JsonPropertyName("mainFrame")]
     public Core.Frame MainFrame { get; set; } = null!;

--- a/src/Playwright/Transport/Protocol/Generated/VirtualCredential.cs
+++ b/src/Playwright/Transport/Protocol/Generated/VirtualCredential.cs
@@ -26,8 +26,20 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class WebSocketInitializer
+internal class VirtualCredential
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = null!;
+
+    [JsonPropertyName("rpId")]
+    public string RpId { get; set; } = null!;
+
+    [JsonPropertyName("userHandle")]
+    public string UserHandle { get; set; } = null!;
+
+    [JsonPropertyName("privateKey")]
+    public string PrivateKey { get; set; } = null!;
+
+    [JsonPropertyName("publicKey")]
+    public string PublicKey { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WaitInfo.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WaitInfo.cs
@@ -26,8 +26,20 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class WebSocketInitializer
+internal class WaitInfo
 {
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    [JsonPropertyName("waitId")]
+    public string WaitId { get; set; } = null!;
+
+    [JsonPropertyName("phase")]
+    public string Phase { get; set; } = null!;
+
+    [JsonPropertyName("event")]
+    public string Event { get; set; } = null!;
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = null!;
+
+    [JsonPropertyName("error")]
+    public string Error { get; set; } = null!;
 }

--- a/src/Playwright/Transport/Protocol/Generated/WorkerInitializer.cs
+++ b/src/Playwright/Transport/Protocol/Generated/WorkerInitializer.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Playwright.Transport.Protocol;
 
-internal class WorkerInitializer : EventTargetInitializer
+internal class WorkerInitializer
 {
     [JsonPropertyName("url")]
     public string Url { get; set; } = null!;


### PR DESCRIPTION
## Summary

- Roll driver to 1.62.0-alpha-1781285727000.
- `Frame.expect` now throws on failure upstream; parse `errorDetails` from the protocol error and convert back to the expect result (microsoft/playwright#40801).
- Replace `waitForEventInfo` with the fire-and-forget `__waitInfo__` message (microsoft/playwright#40718).
- Split `Page.close` protocol into `close` and `runBeforeUnload` (microsoft/playwright#40780).
- New APIs: `Page.LocalStorage`/`Page.SessionStorage`, `BrowserContext.Credentials` (WebAuthn), `APIResponse.SecurityDetailsAsync`/`ServerAddrAsync`, comma-separated `testIdAttribute`, screencast `Size`/`Cursor` options and frame `Timestamp`, `connectOverCDP` `noDefaults`/`artifactsDir`.
- Align `WebSocketTests.ShouldEmitError` with upstream (microsoft/playwright#41015): Firefox now reports the handshake HTTP error instead of `CLOSE_ABNORMAL`.

The driver includes microsoft/playwright#41266 and microsoft/playwright#41267, which were uncovered by this roll.