### PR TITLE
feat(docker): add Ubuntu 26.04 (Resolute Raccoon) image

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor: [noble]
+        flavor: [noble, resolute]
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
     - uses: actions/checkout@v6

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -15,7 +15,7 @@ RUN apt-get update && \
     # clean apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Create the pwuser
-    adduser pwuser
+    useradd -m -s /bin/bash pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
 

--- a/utils/docker/Dockerfile.resolute
+++ b/utils/docker/Dockerfile.resolute
@@ -1,0 +1,37 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=America/Los_Angeles
+ARG DOCKER_IMAGE_NAME_TEMPLATE="mcr.microsoft.com/playwright/dotnet:v%version%-resolute"
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# === INSTALL dependencies ===
+
+RUN apt-get update && \
+    # Feature-parity with node.js base images.
+    apt-get install -y --no-install-recommends git openssh-client curl gpg && \
+    # clean apt cache
+    rm -rf /var/lib/apt/lists/* && \
+    # Create the pwuser
+    adduser pwuser
+
+# === BAKE BROWSERS INTO IMAGE ===
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 1. Add tip-of-tree Playwright package to install its browsers.
+#    The package should be built beforehand from tip-of-tree Playwright.
+COPY ./dist/ /tmp/playwright-dotnet
+
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
+RUN mkdir /ms-playwright && \
+    /tmp/playwright-dotnet/playwright.ps1 install --with-deps && \
+    /tmp/playwright-dotnet/playwright.ps1 mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    chmod -R 777 /ms-playwright

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -3,7 +3,7 @@ set -e
 set +x
 
 if [[ ($1 == '--help') || ($1 == '-h') || ($1 == '') || ($2 == '') ]]; then
-  echo "usage: $(basename $0) {--arm64,--amd64} {noble} playwright:localbuild-noble"
+  echo "usage: $(basename $0) {--arm64,--amd64} {noble,resolute} playwright:localbuild-noble"
   echo
   echo "Build Playwright docker image and tag it as 'playwright:localbuild-noble'."
   echo "Once image is built, you can run it with"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -28,6 +28,11 @@ NOBLE_TAGS=(
   "v${PW_VERSION}-noble"
 )
 
+# Ubuntu 26.04
+RESOLUTE_TAGS=(
+  "v${PW_VERSION}-resolute"
+)
+
 tag_and_push() {
   local source="$1"
   local target="$2"
@@ -62,8 +67,10 @@ publish_docker_images_with_arch_suffix() {
   local TAGS=()
   if [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be 'noble' or 'resolute'"
     exit 1
   fi
   local ARCH="$2"
@@ -86,8 +93,10 @@ publish_docker_manifest () {
   local TAGS=()
   if [[ "$FLAVOR" == "noble" ]]; then
     TAGS=("${NOBLE_TAGS[@]}")
+  elif [[ "$FLAVOR" == "resolute" ]]; then
+    TAGS=("${RESOLUTE_TAGS[@]}")
   else
-    echo "ERROR: unknown flavor - $FLAVOR. Must be 'noble'"
+    echo "ERROR: unknown flavor - $FLAVOR. Must be 'noble' or 'resolute'"
     exit 1
   fi
 
@@ -109,3 +118,7 @@ publish_docker_manifest () {
 publish_docker_images_with_arch_suffix noble amd64
 publish_docker_images_with_arch_suffix noble arm64
 publish_docker_manifest noble amd64 arm64
+
+publish_docker_images_with_arch_suffix resolute amd64
+publish_docker_images_with_arch_suffix resolute arm64
+publish_docker_manifest resolute amd64 arm64


### PR DESCRIPTION
## Summary
- Add `Dockerfile.resolute` based on `mcr.microsoft.com/dotnet/sdk:10.0-resolute` (Ubuntu 26.04 LTS, Resolute Raccoon).
- Wire the `resolute` flavor through `build.sh` and `publish_docker.sh` (new `v<version>-resolute` tag).
- Add `resolute` to the docker test matrix.