### PR TITLE
fix(transport): throw TargetClosedException for requests on disposed connections

### DIFF
--- a/src/Playwright.Tests/PlaywrightDisposeTests.cs
+++ b/src/Playwright.Tests/PlaywrightDisposeTests.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.Playwright.Tests;
+
+public class PlaywrightDisposeTests : PlaywrightTestEx
+{
+    [PlaywrightTest]
+    public async Task ShouldThrowTargetClosedExceptionAfterPlaywrightIsDisposed()
+    {
+        var localPlaywright = await Microsoft.Playwright.Playwright.CreateAsync();
+        var disposed = false;
+
+        try
+        {
+            var browser = await localPlaywright[BrowserName].LaunchAsync();
+            var page = await browser.NewPageAsync();
+
+            localPlaywright.Dispose();
+            disposed = true;
+
+            await PlaywrightAssert.ThrowsAsync<TargetClosedException>(() => page.TitleAsync());
+        }
+        finally
+        {
+            if (!disposed)
+            {
+                localPlaywright.Dispose();
+            }
+        }
+    }
+}

--- a/src/Playwright.Tests/PlaywrightDisposeTests.cs
+++ b/src/Playwright.Tests/PlaywrightDisposeTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Playwright.Tests;
+namespace Microsoft.Playwright.Tests;
 
 public class PlaywrightDisposeTests : PlaywrightTestEx
 {

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -54,6 +54,7 @@ internal class Connection : IDisposable
     private int _tracingCount;
     private int _lastId;
     private Exception? _closedError;
+    private bool _disposed;
 
     public Connection(LocalUtils? localUtils = null)
     {
@@ -444,15 +445,6 @@ internal class Connection : IDisposable
     internal void DoCloseImpl(Exception closeError)
     {
         _closedError = closeError;
-        foreach (var callback in _callbacks)
-        {
-            callback.Value.TaskCompletionSource.TrySetException(closeError.InnerException ?? closeError);
-            // We need to make sure that the task is handled otherwise it will be reported as unhandled on the caller side.
-            // Its still possible to get the exception from the task.
-            callback.Value.TaskCompletionSource.Task.IgnoreException();
-        }
-        _callbacks.Clear();
-
         Dispose();
     }
 
@@ -477,10 +469,22 @@ internal class Connection : IDisposable
 
     private void Dispose(bool disposing)
     {
-        if (!disposing)
+        if (!disposing || _disposed)
         {
             return;
         }
+
+        _disposed = true;
+        _closedError ??= new TargetClosedException("Connection disposed");
+
+        foreach (var callback in _callbacks)
+        {
+            callback.Value.TaskCompletionSource.TrySetException(_closedError);
+            // We need to make sure that the task is handled otherwise it will be reported as unhandled on the caller side.
+            // Its still possible to get the exception from the task.
+            callback.Value.TaskCompletionSource.Task.IgnoreException();
+        }
+        _callbacks.Clear();
 
         _queue.Dispose();
         Close?.Invoke(this, new TargetClosedException("Connection disposed"));


### PR DESCRIPTION
Fixed #3326 

## Summary
  * Return `TargetClosedException` for operations attempted after `IPlaywright.Dispose()`.
  * Prevent the internal `SemaphoreSlim` disposal error. (System.ObjectDisposedException)
  * Complete pending callbacks during connection disposal.

## Before
```mermaid
sequenceDiagram
      participant User as User Code
      participant PW as PlaywrightImpl
      participant Conn as Connection
      participant Queue as TaskQueue
      participant Handle as JSHandle

      User->>PW: playwright.Dispose()
      PW->>Conn: _connection.Dispose()
      Conn->>Queue: _queue.Dispose()
      Queue->>Queue: SemaphoreSlim.Dispose()
      Conn-->>PW: disposed

      User->>Handle: await handle.DisposeAsync()
      Handle->>Conn: SendMessageToServerAsync("dispose")
      Conn->>Conn: _closedError is null
      Conn->>Queue: EnqueueAsync()
      Queue->>Queue: SemaphoreSlim.WaitAsync()
      Queue--xConn: ObjectDisposedException
      Conn--xHandle: ObjectDisposedException
      Handle--xUser: ObjectDisposedException
```

  - `playwright.Dispose()` disposes the `TaskQueue` without `_closedError`.
  - A later handle cleanup attempts to access the disposed SemaphoreSlim.
  - The internal `ObjectDisposedException` is exposed to the user.
 
## After

```mermaid
sequenceDiagram
      participant User as User Code
      participant PW as PlaywrightImpl
      participant Conn as Connection
      participant Queue as TaskQueue
      participant Handle as JSHandle

      User->>PW: playwright.Dispose()
      PW->>Conn: _connection.Dispose()
      Conn->>Conn: Check and set _disposed
      Conn->>Conn: Set _closedError to TargetClosedException
      Conn->>Conn: Fail and clear pending callbacks
      Conn->>Queue: _queue.Dispose()
      Queue->>Queue: SemaphoreSlim.Dispose()
      Conn-->>PW: disposed

      User->>Handle: await handle.DisposeAsync()
      Handle->>Conn: SendMessageToServerAsync("dispose")
      Conn->>Conn: Detect _closedError
      Conn--xHandle: TargetClosedException
      Handle->>Handle: Catch target-closed error
      Handle-->>User: completed without exception
```

  - The connection is marked as closed before pending callbacks and resources are disposed.
  - Later requests fail with `TargetClosedException` without accessing the `TaskQueue`.
  - Handle cleanup recognizes the closed connection and completes without an exception.
