### PR TITLE
chore: roll driver to 1.61.1-beta-1782139630000

### DIFF
--- a/.claude/skills/playwright-roll/SKILL.md
+++ b/.claude/skills/playwright-roll/SKILL.md
@@ -20,13 +20,13 @@ Afterwards, walk through the upstream changes that affect the Java client and po
 
 ## Determining what to port
 
-List the upstream commits that touched a client-relevant path since the last release. The paths cover everything that can change the public Java surface or the wire protocol:
+List the upstream commits that touched a client-relevant path since the last roll. The paths cover everything that can change the public Java surface or the wire protocol:
 
 - `docs/src/api/` — the source of truth for `api.json`. Method/option additions, removals, and `langs:` filter changes flow from here.
 - `packages/playwright-core/src/client/` — the JS client implementation that the Java client mirrors.
 - `packages/isomorphic/` — selector engines, locator generation/parsing, and aria-snapshot logic shared between client and server. Changes here can affect client-side helpers like `getByRoleSelector`.
 - `packages/playwright/src/matchers/matchers.ts` — assertion-method definitions. Changes here usually correspond to new options on `LocatorAssertions` / `PageAssertions`.
-- `packages/protocol/src/protocol.yml` and `packages/protocol/spec/**.yml` — the wire protocol schema. Method/event additions, parameter renames, and result-shape changes affect what the .NET implementation classes need to send/receive.
+- `packages/protocol/spec/**.yml` — the wire protocol schema. Method/event additions, parameter renames, and result-shape changes affect what the .NET implementation classes need to send/receive.
 
 ```bash
 cd ~/playwright
@@ -36,8 +36,7 @@ git log "$PREV_TAG"..HEAD --oneline -- \
   'packages/playwright-core/src/client/' \
   'packages/isomorphic/' \
   'packages/playwright/src/matchers/matchers.ts' \
-  'packages/protocol/src/protocol.yml' \
-  'packages/protocol/spec/'
+  'packages/protocol/spec/**.yml'
 ```
 
 Walk that list top-to-bottom (oldest-first is easier — newest is at top, so reverse). For each commit:

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.60.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.62.0-alpha-1781285727000</DriverVersion>
+    <DriverVersion>1.61.1-beta-1782139630000</DriverVersion>
     <!-- The Node.js version bundled with the driver. Kept in sync with NODE_VERSION
          in upstream's utils/build/build-playwright-driver.sh by the roll script. -->
     <DriverNodeVersion>24.16.0</DriverNodeVersion>

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -7,19 +7,19 @@
     "": {
       "name": "playwright.testingharnesstest",
       "devDependencies": {
-        "@playwright/test": "1.62.0-alpha-1781285727000",
+        "@playwright/test": "1.61.1-beta-1782139630000",
         "@types/node": "^22.12.0",
         "fast-xml-parser": "^4.5.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-QnzOX5IfBz6xIaKqhKINbEFfzDwXEw/N54cP/QKAo+sSJP9R8ms+L4ZaQSFIOQkNiwiqV8Pgo4Q1WU3iaS5SAA==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-a4IIfD+EjVQB/8PR5rloMKsBljAN62m5/MO0ZBwDLGMgFBTXlmIvdcG9SDR6m9YAWPqizI7EMBcqWGu1jDrDxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0-alpha-1781285727000"
+        "playwright": "1.61.1-beta-1782139630000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -77,13 +77,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-8h6DFX7COprG+e1gr9QRJH1CBAeSkolThegV7Nre48W9SAPKGR0++l2olvETiz+TF0qA+GsJcaGHcCk0+lX5Aw==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-eh4FPRjtO9BxEnjcABkPMuB2LOLeXUIo6MOE3mQRIIxVFZYlRLJxk828nlT9dv8BbXnBCjAzoyAlqbURh1ptew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0-alpha-1781285727000"
+        "playwright-core": "1.61.1-beta-1782139630000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-NPwzQBFzNeKMHbh1kshW/o4DcPpLeRuLFv8cPToF6JcTYLEy242WXkAh9LwEMiEtRVS45xWQ3Y90LO4FJKCTzA==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-xQQR7v/sFoVdUGCWvGPRICNLfsOXOpI3+X8IuzaodXz5NgihKJquBEhkYDQBkcEDfhOAat1RXw8/SmDlhOZhfw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -124,12 +124,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-QnzOX5IfBz6xIaKqhKINbEFfzDwXEw/N54cP/QKAo+sSJP9R8ms+L4ZaQSFIOQkNiwiqV8Pgo4Q1WU3iaS5SAA==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-a4IIfD+EjVQB/8PR5rloMKsBljAN62m5/MO0ZBwDLGMgFBTXlmIvdcG9SDR6m9YAWPqizI7EMBcqWGu1jDrDxg==",
       "dev": true,
       "requires": {
-        "playwright": "1.62.0-alpha-1781285727000"
+        "playwright": "1.61.1-beta-1782139630000"
       }
     },
     "@types/node": {
@@ -158,19 +158,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-8h6DFX7COprG+e1gr9QRJH1CBAeSkolThegV7Nre48W9SAPKGR0++l2olvETiz+TF0qA+GsJcaGHcCk0+lX5Aw==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-eh4FPRjtO9BxEnjcABkPMuB2LOLeXUIo6MOE3mQRIIxVFZYlRLJxk828nlT9dv8BbXnBCjAzoyAlqbURh1ptew==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.62.0-alpha-1781285727000"
+        "playwright-core": "1.61.1-beta-1782139630000"
       }
     },
     "playwright-core": {
-      "version": "1.62.0-alpha-1781285727000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-1781285727000.tgz",
-      "integrity": "sha512-NPwzQBFzNeKMHbh1kshW/o4DcPpLeRuLFv8cPToF6JcTYLEy242WXkAh9LwEMiEtRVS45xWQ3Y90LO4FJKCTzA==",
+      "version": "1.61.1-beta-1782139630000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1-beta-1782139630000.tgz",
+      "integrity": "sha512-xQQR7v/sFoVdUGCWvGPRICNLfsOXOpI3+X8IuzaodXz5NgihKJquBEhkYDQBkcEDfhOAat1RXw8/SmDlhOZhfw==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.62.0-alpha-1781285727000",
+    "@playwright/test": "1.61.1-beta-1782139630000",
     "@types/node": "^22.12.0",
     "fast-xml-parser": "^4.5.0"
   }


### PR DESCRIPTION
## Summary
- Roll Playwright driver to `1.61.1-beta-1782139630000`. No API or transport-channel changes; clean roll. Chromium suite green (1820 passed, 33 skipped).
- Minor doc tweak to the `playwright-roll` skill.