### PR TITLE
feat(pag) Add outputLocation parameter to page.pause()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->149.0.7827.55<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->150.0.7871.24<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->26.5<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | Firefox <!-- GEN:firefox-version -->151.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 

--- a/src/Playwright.Tests/PauseTests.cs
+++ b/src/Playwright.Tests/PauseTests.cs
@@ -32,4 +32,13 @@ public class PauseTests : PageTestEx
         await Page.GotoAsync(Server.EmptyPage);
         await Page.PauseAsync();
     }
+
+    [Test]
+    public async Task ShouldNotFailWithOutputLocation()
+    {
+        await Page.GotoAsync(Server.EmptyPage);
+        using var dir = new TempDirectory();
+        string outputPath = Path.Combine(dir.Path, "output.cs");
+        await Page.PauseAsync(outputPath);
+    }
 }

--- a/src/Playwright/API/Supplements/IPage.cs
+++ b/src/Playwright/API/Supplements/IPage.cs
@@ -84,6 +84,7 @@ public partial interface IPage : IAsyncDisposable
     /// <inheritdoc cref="AddLocatorHandlerAsync(ILocator, Func{ILocator, Task}, PageAddLocatorHandlerOptions?)" />
     Task AddLocatorHandlerAsync(ILocator locator, Func<Task> handler, PageAddLocatorHandlerOptions? options = default);
 
-
+    /// <inheritdoc cref="PauseAsync()" />
+    /// <param name="outputLocation">File path where Playwright can save Inspector window content.</param>
     Task PauseAsync(string? outputLocation);
 }

--- a/src/Playwright/API/Supplements/IPage.cs
+++ b/src/Playwright/API/Supplements/IPage.cs
@@ -83,4 +83,7 @@ public partial interface IPage : IAsyncDisposable
 
     /// <inheritdoc cref="AddLocatorHandlerAsync(ILocator, Func{ILocator, Task}, PageAddLocatorHandlerOptions?)" />
     Task AddLocatorHandlerAsync(ILocator locator, Func<Task> handler, PageAddLocatorHandlerOptions? options = default);
+
+
+    Task PauseAsync(string? outputLocation);
 }

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -1173,10 +1173,10 @@ internal class Page : ChannelOwner, IPage
         Context.SetDefaultTimeout(0);
         try
         {
-            var args = new Dictionary<string, object?>();
+            Dictionary<string, object?>? args = null;
             if (outputLocation != null)
             {
-                args["outputFile"] = outputLocation;
+                args = new() { ["outputFile"] = outputLocation };
             }
             await Task.WhenAny(Context.SendMessageToServerAsync("pause", args), ClosedOrCrashedTcs.Task).ConfigureAwait(false);
         }

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -1162,7 +1162,10 @@ internal class Page : ChannelOwner, IPage
         });
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public async Task PauseAsync()
+    public async Task PauseAsync() => await PauseAsync(null).ConfigureAwait(false);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task PauseAsync(string? outputLocation)
     {
         var defaultNavigationTimeout = Context._timeoutSettings.DefaultNavigationTimeout;
         var defaultTimeout = Context._timeoutSettings.DefaultTimeout;
@@ -1170,7 +1173,12 @@ internal class Page : ChannelOwner, IPage
         Context.SetDefaultTimeout(0);
         try
         {
-            await Task.WhenAny(Context.SendMessageToServerAsync("pause"), ClosedOrCrashedTcs.Task).ConfigureAwait(false);
+            var args = new Dictionary<string, object?>();
+            if (outputLocation != null)
+            {
+                args["outputFile"] = outputLocation;
+            }
+            await Task.WhenAny(Context.SendMessageToServerAsync("pause", args), ClosedOrCrashedTcs.Task).ConfigureAwait(false);
         }
         finally
         {


### PR DESCRIPTION
Feature Issue Raised - https://github.com/microsoft/playwright/issues/41564

- Allows users to specify a file path where Playwright can save Inspector window content.
- Part of a Joint change with playwright to allow Page.PauseAsync to pass an output file path.