### PR TITLE
feat(mstest): add retry-aware failure tracing

### DIFF
--- a/src/Playwright.MSTest.v4/Playwright.MSTest.v4.csproj
+++ b/src/Playwright.MSTest.v4/Playwright.MSTest.v4.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25372.6" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Common\icon.png" Pack="true" Visible="false" PackagePath="icon.png" />

--- a/src/Playwright.MSTest/ContextTest.cs
+++ b/src/Playwright.MSTest/ContextTest.cs
@@ -22,6 +22,10 @@
  * SOFTWARE.
  */
 
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -30,12 +34,52 @@ namespace Microsoft.Playwright.MSTest;
 [TestClass]
 public class ContextTest : BrowserTest
 {
+    private static readonly ConcurrentDictionary<string, ConcurrentBag<string>> _failedTraces = new();
+
     public IBrowserContext Context { get; private set; } = null!;
+    private bool _isTracing;
 
     [TestInitialize]
     public async Task ContextSetup()
     {
         Context = await NewContextAsync(ContextOptions()).ConfigureAwait(false);
+        if (TracingOptions() is { } tracingOptions)
+        {
+            if (TestRunCount() == 1)
+            {
+                _failedTraces.TryRemove(TraceKey(), out _);
+            }
+            await Context.Tracing.StartAsync(tracingOptions).ConfigureAwait(false);
+            _isTracing = true;
+        }
+    }
+
+    [TestCleanup]
+    public async Task ContextTearDown()
+    {
+        if (!_isTracing)
+        {
+            return;
+        }
+
+        _isTracing = false;
+        if (!TestFailed())
+        {
+            await Context.Tracing.StopAsync().ConfigureAwait(false);
+            AttachFailedTraces();
+            return;
+        }
+
+        var resultsDirectory = TestContext.ResultsDirectory ?? Path.GetTempPath();
+        Directory.CreateDirectory(resultsDirectory);
+        var tracePath = Path.Combine(resultsDirectory, TraceFileName());
+        await Context.Tracing.StopAsync(new() { Path = tracePath }).ConfigureAwait(false);
+        var traces = _failedTraces.GetOrAdd(TraceKey(), _ => new());
+        traces.Add(tracePath);
+        foreach (var path in traces)
+        {
+            TestContext.AddResultFile(path);
+        }
     }
 
     public virtual BrowserNewContextOptions ContextOptions()
@@ -45,5 +89,49 @@ public class ContextTest : BrowserTest
             Locale = "en-US",
             ColorScheme = ColorScheme.Light,
         };
+    }
+
+    /// <summary>
+    /// Options used to record a trace that is retained and attached only when a test fails.
+    /// Return <see langword="null"/> to disable tracing.
+    /// </summary>
+    public virtual TracingStartOptions? TracingOptions() => null;
+
+    private string TraceFileName()
+    {
+        var invalidFileNameChars = Path.GetInvalidFileNameChars();
+        var testName = new string(TestDisplayName().Select(c => invalidFileNameChars.Contains(c) ? '_' : c).ToArray());
+        return $"{testName}-run-{TestRunCount()}-{Guid.NewGuid():N}.zip";
+    }
+
+    private void AttachFailedTraces()
+    {
+        if (_failedTraces.TryRemove(TraceKey(), out var traces))
+        {
+            foreach (var path in traces)
+            {
+                TestContext.AddResultFile(path);
+            }
+        }
+    }
+
+    private string TraceKey() => $"{TestContext.FullyQualifiedTestClassName}.{TestDisplayName()}";
+
+    private string TestDisplayName()
+    {
+        var property = TestContext.GetType().GetProperty("TestDisplayName");
+        return property?.GetValue(TestContext) as string ?? TestContext.TestName;
+    }
+
+    private bool TestFailed()
+    {
+        var property = TestContext.GetType().GetProperty("TestException");
+        return property?.GetValue(TestContext) is Exception || !TestOK();
+    }
+
+    private int TestRunCount()
+    {
+        var property = TestContext.GetType().GetProperty("TestRunCount");
+        return property?.GetValue(TestContext) is int testRunCount ? testRunCount : 1;
     }
 }

--- a/src/Playwright.TestAdapter/PlaywrightSettingsXml.cs
+++ b/src/Playwright.TestAdapter/PlaywrightSettingsXml.cs
@@ -167,6 +167,7 @@ public class PlaywrightSettingsXml
     public string? BrowserName { get; set; }
     public bool? Headless { get; set; }
     public float? ExpectTimeout { get; set; }
+
+    [Obsolete("Use MSTest RetryAttribute or Microsoft.Testing.Extensions.Retry instead.")]
     public int? Retries { get; set; }
 }
-

--- a/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
+++ b/src/Playwright.TestingHarnessTest/Playwright.TestingHarnessTest.csproj
@@ -20,8 +20,8 @@
     
     <!-- MSTest v4 -->
     <ProjectReference Include="..\Playwright.MSTest.v4\Playwright.MSTest.v4.csproj" Condition="'$(TEST_MODE)' == 'mstest.v4'" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25372.6" Condition="'$(TEST_MODE)' == 'mstest.v4'" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25372.6" Condition="'$(TEST_MODE)' == 'mstest.v4'" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" Condition="'$(TEST_MODE)' == 'mstest.v4'" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" Condition="'$(TEST_MODE)' == 'mstest.v4'" />
     
     <!-- NUnit -->
     <ProjectReference Include="..\Playwright.NUnit\Playwright.NUnit.csproj" Condition="'$(TEST_MODE)' == 'nunit'" />

--- a/src/Playwright.TestingHarnessTest/tests/mstest.v4.spec.ts
+++ b/src/Playwright.TestingHarnessTest/tests/mstest.v4.spec.ts
@@ -22,9 +22,75 @@
  * SOFTWARE.
  */
 
+import fs from 'fs';
+import path from 'path';
 import { test, expect } from './baseTest';
 
 test.use({ testMode: 'mstest.v4' });
+
+test('should retry tests using MSTest RetryAttribute', async ({ runTest }) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]
+      public class <class-name>
+      {
+          private static int _attempts;
+
+          [TestMethod]
+          [Retry(2)]
+          public void Test()
+          {
+              Assert.AreEqual(2, ++_attempts);
+          }
+      }`,
+  }, 'dotnet test');
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+  expect(result.total).toBe(1);
+});
+
+test('should attach traces for every failed retry', async ({ runTest }, testInfo) => {
+  const result = await runTest({
+    'ExampleTests.cs': `
+      using System.Threading.Tasks;
+      using Microsoft.Playwright;
+      using Microsoft.Playwright.MSTest;
+      using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+      namespace Playwright.TestingHarnessTest.MSTest;
+
+      [TestClass]
+      public class <class-name> : PageTest
+      {
+          [TestMethod]
+          [Retry(2)]
+          public async Task Test()
+          {
+              await Page.GotoAsync("about:blank");
+              Assert.Fail("Expected failure");
+          }
+
+          public override TracingStartOptions TracingOptions() => new()
+          {
+              Screenshots = true,
+              Snapshots = true,
+              Sources = true,
+          };
+      }`,
+  }, 'dotnet test --results-directory=.');
+  expect(result.passed).toBe(0);
+  expect(result.failed).toBe(1);
+  expect(result.total).toBe(1);
+
+  const trx = await fs.promises.readFile(path.join(testInfo.outputPath(), 'result.trx'), 'utf8');
+  expect(trx).toContain('-run-1-');
+  expect(trx).toContain('-run-2-');
+  expect(trx).toContain('-run-3-');
+});
 
 test('should be able to forward DEBUG=pw:api env var', async ({ runTest }) => {
   const result = await runTest({


### PR DESCRIPTION
## Summary
- update the MSTest v4 package and harness to stable MSTest 4.2.3
- deprecate the unused Playwright retry setting in favor of native MSTest/MTP retries
- add opt-in failure tracing with retry-safe MSTest result attachments

## Context

I am the owner of MSTest.