### PR TITLE
Route.FulfillAsync computes content-length from the base64-encoded bo…

### DIFF
--- a/src/Playwright.Tests/PageRequestFulfillTests.cs
+++ b/src/Playwright.Tests/PageRequestFulfillTests.cs
@@ -23,6 +23,7 @@
  */
 
 using System.Net;
+using System.Text;
 
 namespace Microsoft.Playwright.Tests;
 
@@ -88,6 +89,31 @@ public class PageRequestFulfillTests : PageTestEx
             }", Server.Prefix);
         var img = await Page.QuerySelectorAsync("img");
         PlaywrightAssert.ToMatchSnapshot("mock-binary-response.png", await img.ScreenshotAsync());
+    }
+
+    [PlaywrightTest("page-request-fulfill.spec.ts", "should set content-length from body bytes")]
+    public async Task ShouldSetContentLengthFromBodyBytes()
+    {
+        byte[] bodyBytes = Encoding.UTF8.GetBytes("1234567890");
+
+        await Page.RouteAsync("**/bytes", async route =>
+        {
+            await route.FulfillAsync(new()
+            {
+                ContentType = "text/plain",
+                BodyBytes = bodyBytes,
+            });
+        });
+
+        int[] lengths = await Page.EvaluateAsync<int[]>(@"async url => {
+            const response = await fetch(url);
+            const contentLengthHeader = Number(response.headers.get('content-length'));
+            const body = await response.arrayBuffer();
+            return [contentLengthHeader, body.byteLength];
+        }", Server.Prefix + "/bytes");
+
+        Assert.AreEqual(bodyBytes.Length, lengths[0]);
+        Assert.AreEqual(bodyBytes.Length, lengths[1]);
     }
 
     [PlaywrightTest("page-request-fulfill.spec.ts", "should allow mocking svg with charset")]

--- a/src/Playwright/Core/Route.cs
+++ b/src/Playwright/Core/Route.cs
@@ -28,6 +28,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Playwright.Helpers;
@@ -195,19 +196,19 @@ internal class Route : ChannelOwner, IRoute
             byte[] content = File.ReadAllBytes(path);
             resultBody = Convert.ToBase64String(content);
             isBase64 = true;
-            length = resultBody.Length;
+            length = content.Length;
         }
         else if (!body.IsNullOrEmpty())
         {
             resultBody = body;
             isBase64 = false;
-            length = resultBody.Length;
+            length = Encoding.UTF8.GetByteCount(resultBody);
         }
         else if (bodyContent != null)
         {
             resultBody = Convert.ToBase64String(bodyContent);
             isBase64 = true;
-            length = resultBody.Length;
+            length = bodyContent.Length;
         }
 
         var resultHeaders = new Dictionary<string, string>();


### PR DESCRIPTION
fix #3336 