### PR TITLE
chore(driver): roll to 1.62.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
-| Chromium <!-- GEN:chromium-version -->149.0.7827.55<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Chromium <!-- GEN:chromium-version -->151.0.7922.34<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 | WebKit <!-- GEN:webkit-version -->26.5<!-- GEN:stop --> | ✅ | ✅ | ✅ |
-| Firefox <!-- GEN:firefox-version -->151.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
+| Firefox <!-- GEN:firefox-version -->153.0<!-- GEN:stop --> | ✅ | ✅ | ✅ |
 
 Playwright for .NET is the official language port of [Playwright](https://playwright.dev), the library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,12 @@ function download_driver() {
 function roll_driver() {
   new_driver_version="$1"
   upstream_package_version=$(node -e "console.log(require('${upstream_repo_path}/package.json').version)")
-  new_node_version=$(sed -n 's/^NODE_VERSION="\([^"]*\)".*/\1/p' "${upstream_repo_path}/utils/build/build-playwright-driver.sh")
+  new_node_version=$(curl -fsSL "https://nodejs.org/dist/index.json" \
+    | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).find(r=>r.lts).version.slice(1)))")
+  if [[ -z "${new_node_version}" ]]; then
+    echo "Failed to determine the Node.js version for driver ${new_driver_version}"
+    exit 1
+  fi
   echo "Rolling .NET driver to driver ${new_driver_version} (Node.js ${new_node_version}) and upstream version ${upstream_package_version}..."
 
   xml_file_path="./src/Common/Version.props"

--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <AssemblyVersion>1.61.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
-    <DriverVersion>1.61.1-beta-1782139630000</DriverVersion>
-    <!-- The Node.js version bundled with the driver. Kept in sync with NODE_VERSION
-         in upstream's utils/build/build-playwright-driver.sh by the roll script. -->
-    <DriverNodeVersion>24.16.0</DriverNodeVersion>
+    <DriverVersion>1.62.0</DriverVersion>
+    <!-- The Node.js version bundled with the driver. Set by the roll script to the latest
+         Node.js LTS, matching upstream's utils/build/update-playwright-node.mjs. -->
+    <DriverNodeVersion>24.18.1</DriverNodeVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Playwright.TestingHarnessTest/package-lock.json
+++ b/src/Playwright.TestingHarnessTest/package-lock.json
@@ -7,25 +7,25 @@
     "": {
       "name": "playwright.testingharnesstest",
       "devDependencies": {
-        "@playwright/test": "1.61.1-beta-1782139630000",
+        "@playwright/test": "1.62.0",
         "@types/node": "^22.12.0",
         "fast-xml-parser": "^4.5.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-a4IIfD+EjVQB/8PR5rloMKsBljAN62m5/MO0ZBwDLGMgFBTXlmIvdcG9SDR6m9YAWPqizI7EMBcqWGu1jDrDxg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1-beta-1782139630000"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
@@ -77,35 +77,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-eh4FPRjtO9BxEnjcABkPMuB2LOLeXUIo6MOE3mQRIIxVFZYlRLJxk828nlT9dv8BbXnBCjAzoyAlqbURh1ptew==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1-beta-1782139630000"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-xQQR7v/sFoVdUGCWvGPRICNLfsOXOpI3+X8IuzaodXz5NgihKJquBEhkYDQBkcEDfhOAat1RXw8/SmDlhOZhfw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/strnum": {
@@ -124,12 +124,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-a4IIfD+EjVQB/8PR5rloMKsBljAN62m5/MO0ZBwDLGMgFBTXlmIvdcG9SDR6m9YAWPqizI7EMBcqWGu1jDrDxg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "requires": {
-        "playwright": "1.61.1-beta-1782139630000"
+        "playwright": "1.62.0"
       }
     },
     "@types/node": {
@@ -158,19 +158,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-eh4FPRjtO9BxEnjcABkPMuB2LOLeXUIo6MOE3mQRIIxVFZYlRLJxk828nlT9dv8BbXnBCjAzoyAlqbURh1ptew==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.61.1-beta-1782139630000"
+        "playwright-core": "1.62.0"
       }
     },
     "playwright-core": {
-      "version": "1.61.1-beta-1782139630000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1-beta-1782139630000.tgz",
-      "integrity": "sha512-xQQR7v/sFoVdUGCWvGPRICNLfsOXOpI3+X8IuzaodXz5NgihKJquBEhkYDQBkcEDfhOAat1RXw8/SmDlhOZhfw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true
     },
     "strnum": {

--- a/src/Playwright.TestingHarnessTest/package.json
+++ b/src/Playwright.TestingHarnessTest/package.json
@@ -2,7 +2,7 @@
   "name": "playwright.testingharnesstest",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "1.61.1-beta-1782139630000",
+    "@playwright/test": "1.62.0",
     "@types/node": "^22.12.0",
     "fast-xml-parser": "^4.5.0"
   }

--- a/src/Playwright.Tests/PageNetworkResponseTests.cs
+++ b/src/Playwright.Tests/PageNetworkResponseTests.cs
@@ -232,7 +232,7 @@ public class PageNetworkResponseTests : PageTestEx
         var response = await Page.GotoAsync(HttpsServer.EmptyPage);
         var details = await response.SecurityDetailsAsync();
 
-        var name = "puppeteer-tests";
+        var name = TestConstants.IsWebKit && TestConstants.IsWindows ? "true" : "puppeteer-tests";
         Assert.AreEqual(name, details.SubjectName);
         if (TestConstants.IsWebKit)
         {

--- a/src/Playwright.Tests/PageScreenshotTests.cs
+++ b/src/Playwright.Tests/PageScreenshotTests.cs
@@ -357,7 +357,7 @@ public class PageScreenshotTests : PageTestEx
         {
             try
             {
-                await Page.ScreenshotAsync();
+                await Page.ScreenshotAsync(new() { FullPage = true });
             }
             catch (Exception ex) when (ex.Message.Contains("Cannot take a screenshot while page is navigating"))
             {

--- a/src/Playwright.Tests/WorkersTests.cs
+++ b/src/Playwright.Tests/WorkersTests.cs
@@ -207,9 +207,7 @@ public class WorkersTests : PageTestEx
             page.WaitForWorkerAsync(),
             page.EvaluateAsync("() => new Worker(URL.createObjectURL(new Blob(['console.log(1)'], {type: 'application/javascript'})))"));
 
-        // https://github.com/microsoft/playwright/issues/38919
-        var expected = TestConstants.IsFirefox ? "10,000.2" : "10\u00A0000,2";
-        Assert.AreEqual(expected, await worker.EvaluateAsync<string>("() => (10000.20).toLocaleString()"));
+        Assert.AreEqual("10\u00A0000,2", await worker.EvaluateAsync<string>("() => (10000.20).toLocaleString()"));
     }
 
     [PlaywrightTest("workers.spec.ts", "should report console event on the worker")]

--- a/src/Playwright/API/Generated/Enums/ScreenshotType.cs
+++ b/src/Playwright/API/Generated/Enums/ScreenshotType.cs
@@ -32,4 +32,6 @@ public enum ScreenshotType
     Png,
     [EnumMember(Value = "jpeg")]
     Jpeg,
+    [EnumMember(Value = "webp")]
+    Webp,
 }

--- a/src/Playwright/API/Generated/Enums/ScrollMode.cs
+++ b/src/Playwright/API/Generated/Enums/ScrollMode.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,37 +22,14 @@
  * SOFTWARE.
  */
 
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
+using System.Runtime.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class APIResponse
+public enum ScrollMode
 {
-    [JsonPropertyName("fetchUid")]
-    public string FetchUid { get; set; } = null!;
-
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
-
-    [JsonPropertyName("status")]
-    public int Status { get; set; }
-
-    [JsonPropertyName("statusText")]
-    public string StatusText { get; set; } = null!;
-
-    [JsonPropertyName("headers")]
-    public List<NameValue> Headers { get; set; } = null!;
-
-    [JsonPropertyName("securityDetails")]
-    public SecurityDetails SecurityDetails { get; set; } = null!;
-
-    [JsonPropertyName("serverAddr")]
-    public RemoteAddr ServerAddr { get; set; } = null!;
-
-    [JsonPropertyName("timing")]
-    public RequestTimingResult Timing { get; set; } = null!;
-
-    [JsonPropertyName("responseEndTiming")]
-    public float ResponseEndTiming { get; set; }
+    [EnumMember(Value = "auto")]
+    Auto,
+    [EnumMember(Value = "none")]
+    None,
 }

--- a/src/Playwright/API/Generated/IAPIResponse.cs
+++ b/src/Playwright/API/Generated/IAPIResponse.cs
@@ -92,6 +92,18 @@ public partial interface IAPIResponse
     /// <summary><para>Returns the text representation of response body.</para></summary>
     Task<string> TextAsync();
 
+    /// <summary>
+    /// <para>
+    /// Returns resource timing information for given response. For redirected requests,
+    /// returns the information for the last request in the redirect chain. When the response
+    /// is served <a href="https://playwright.dev/dotnet/docs/mock#replaying-from-har">from
+    /// the HAR file</a>, timing information is not available and all the values are -1.
+    /// Find more information at <a href="https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming">Resource
+    /// Timing API</a>.
+    /// </para>
+    /// </summary>
+    RequestTimingResult Timing { get; }
+
     /// <summary><para>Contains the URL of the response.</para></summary>
     string Url { get; }
 }

--- a/src/Playwright/API/Generated/IBrowserContext.cs
+++ b/src/Playwright/API/Generated/IBrowserContext.cs
@@ -1010,7 +1010,7 @@ public partial interface IBrowserContext
     /// <summary>
     /// <para>
     /// Returns storage state for this browser context, contains current cookies, local
-    /// storage snapshot and IndexedDB snapshot.
+    /// storage snapshot, IndexedDB snapshot and virtual WebAuthn credentials.
     /// </para>
     /// </summary>
     /// <param name="options">Call options</param>
@@ -1018,8 +1018,10 @@ public partial interface IBrowserContext
 
     /// <summary>
     /// <para>
-    /// Clears the existing cookies, local storage and IndexedDB entries for all origins
-    /// and sets the new storage state.
+    /// Clears the existing cookies, local storage, IndexedDB entries and virtual WebAuthn
+    /// credentials, and sets the new storage state. When the storage state contains credentials,
+    /// the virtual WebAuthn authenticator is installed (equivalent to <see cref="ICredentials.InstallAsync"/>),
+    /// preventing all real authenticators from working in this context.
     /// </para>
     /// <para>**Usage**</para>
     /// <code>

--- a/src/Playwright/API/Generated/IBrowserType.cs
+++ b/src/Playwright/API/Generated/IBrowserType.cs
@@ -93,6 +93,11 @@ public partial interface IBrowserType
     /// via <see cref="IBrowserType.ConnectAsync"/>. If you are experiencing issues or attempting
     /// to use advanced functionality, you probably want to use <see cref="IBrowserType.ConnectAsync"/>.
     /// </para>
+    /// <para>
+    /// Playwright maintains a curated list of arguments for launching the browser. If you
+    /// launch the browser without Playwright and do not pass the exact same arguments,
+    /// some of Playwright functionality may be broken upon connecting to the browser.
+    /// </para>
     /// <para>**Usage**</para>
     /// <code>
     /// var browser = await playwright.Chromium.ConnectOverCDPAsync("http://localhost:9222");<br/>
@@ -110,6 +115,11 @@ public partial interface IBrowserType
     /// via <see cref="IBrowserType.ConnectAsync"/>. If you are experiencing issues or attempting
     /// to use advanced functionality, you probably want to use <see cref="IBrowserType.ConnectAsync"/>.
     ///
+    /// </para>
+    /// <para>
+    /// Playwright maintains a curated list of arguments for launching the browser. If you
+    /// launch the browser without Playwright and do not pass the exact same arguments,
+    /// some of Playwright functionality may be broken upon connecting to the browser.
     /// </para>
     /// </remarks>
     /// <param name="endpointURL">

--- a/src/Playwright/API/Generated/ICredentials.cs
+++ b/src/Playwright/API/Generated/ICredentials.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Playwright;
 /// / <c>navigator.credentials.get()</c> ceremonies in the page, without a real authenticator
 /// or hardware security key.
 /// </para>
-/// <para>There are two common ways to use it:</para>
+/// <para>There are three common ways to use it:</para>
 /// <para>**Usage: seed a known credential**</para>
 /// <code>
 /// var context = await browser.NewContextAsync();<br/>
@@ -53,7 +53,7 @@ namespace Microsoft.Playwright;
 /// await page.GotoAsync("https://example.com/login");<br/>
 /// // The page's navigator.credentials.get() is answered with the seeded passkey.
 /// </code>
-/// <para>**Usage: capture a passkey, then reuse it**</para>
+/// <para>**Usage: capture a credential, then reuse it**</para>
 /// <code>
 /// // setup test: let the app register a passkey, then save it.<br/>
 /// var context = await browser.NewContextAsync();<br/>
@@ -85,6 +85,11 @@ namespace Microsoft.Playwright;
 /// await page.GotoAsync("https://example.com/login");<br/>
 /// // navigator.credentials.get() resolves the captured passkey — already signed in.
 /// </code>
+/// <para>**Usage: save credentials in the storage state, restore later**</para>
+/// <para>
+/// See <a href="https://playwright.dev/dotnet/docs/auth">authentication guide</a> for
+/// examples of using saving and resotring the storage state.
+/// </para>
 /// <para>**Defaults**</para>
 /// </summary>
 public partial interface ICredentials

--- a/src/Playwright/API/Generated/ILocator.cs
+++ b/src/Playwright/API/Generated/ILocator.cs
@@ -1983,4 +1983,32 @@ public partial interface ILocator
     /// </summary>
     /// <param name="options">Call options</param>
     Task WaitForAsync(LocatorWaitForOptions? options = default);
+
+    /// <summary>
+    /// <para>
+    /// Returns when <see cref="ILocator.WaitForFunctionAsync"/> returns a truthy value,
+    /// called with the matching element as a first argument, and <see cref="ILocator.WaitForFunctionAsync"/>
+    /// as a second argument.
+    /// </para>
+    /// <para>
+    /// This is a generic way to wait for an element to reach a custom condition without
+    /// asserting it. The locator is re-resolved on each retry, so it tolerates the element
+    /// being re-rendered while waiting.
+    /// </para>
+    /// <para>
+    /// If <see cref="ILocator.WaitForFunctionAsync"/> returns a <see cref="Task"/>, this
+    /// method will wait for the promise to resolve before checking its value.
+    /// </para>
+    /// <para>If <see cref="ILocator.WaitForFunctionAsync"/> throws or rejects, this method throws.</para>
+    /// <para>**Usage**</para>
+    /// <para>Wait for an attribute to appear:</para>
+    /// <para>Passing argument to <see cref="ILocator.WaitForFunctionAsync"/>:</para>
+    /// </summary>
+    /// <param name="expression">
+    /// JavaScript expression to be evaluated in the browser context. If the expression
+    /// evaluates to a function, the function is automatically invoked.
+    /// </param>
+    /// <param name="arg">Optional argument to pass to <see cref="ILocator.WaitForFunctionAsync"/>.</param>
+    /// <param name="options">Call options</param>
+    Task WaitForFunctionAsync(string expression, object? arg = default, LocatorWaitForFunctionOptions? options = default);
 }

--- a/src/Playwright/API/Generated/IPage.cs
+++ b/src/Playwright/API/Generated/IPage.cs
@@ -1272,7 +1272,25 @@ public partial interface IPage
     /// <c>null</c>.
     /// </para>
     /// <para>Navigate to the previous page in history.</para>
+    /// <para>
+    /// **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright
+    /// disables the Back/Forward Cache across all browsers. Even if explicitly enabled,
+    /// Playwright's internal state relies on network-level navigation events. Because BFCache
+    /// restores unfreeze the DOM without firing these events, using <c>page.goBack()</c>
+    /// or <c>page.goForward()</c> to trigger a BFCache restore will result in timeouts
+    /// and a desynchronized <c>Page</c> state.
+    /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright
+    /// disables the Back/Forward Cache across all browsers. Even if explicitly enabled,
+    /// Playwright's internal state relies on network-level navigation events. Because BFCache
+    /// restores unfreeze the DOM without firing these events, using <c>page.goBack()</c>
+    /// or <c>page.goForward()</c> to trigger a BFCache restore will result in timeouts
+    /// and a desynchronized <c>Page</c> state.
+    /// </para>
+    /// </remarks>
     /// <param name="options">Call options</param>
     Task<IResponse?> GoBackAsync(PageGoBackOptions? options = default);
 
@@ -1283,7 +1301,25 @@ public partial interface IPage
     /// <c>null</c>.
     /// </para>
     /// <para>Navigate to the next page in history.</para>
+    /// <para>
+    /// **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright
+    /// disables the Back/Forward Cache across all browsers. Even if explicitly enabled,
+    /// Playwright's internal state relies on network-level navigation events. Because BFCache
+    /// restores unfreeze the DOM without firing these events, using <c>page.goBack()</c>
+    /// or <c>page.goForward()</c> to trigger a BFCache restore will result in timeouts
+    /// and a desynchronized <c>Page</c> state.
+    /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright
+    /// disables the Back/Forward Cache across all browsers. Even if explicitly enabled,
+    /// Playwright's internal state relies on network-level navigation events. Because BFCache
+    /// restores unfreeze the DOM without firing these events, using <c>page.goBack()</c>
+    /// or <c>page.goForward()</c> to trigger a BFCache restore will result in timeouts
+    /// and a desynchronized <c>Page</c> state.
+    /// </para>
+    /// </remarks>
     /// <param name="options">Call options</param>
     Task<IResponse?> GoForwardAsync(PageGoForwardOptions? options = default);
 

--- a/src/Playwright/API/Generated/Options/BrowserContextStorageStateOptions.cs
+++ b/src/Playwright/API/Generated/Options/BrowserContextStorageStateOptions.cs
@@ -37,9 +37,24 @@ public class BrowserContextStorageStateOptions
             return;
         }
 
+        Credentials = clone.Credentials;
         IndexedDB = clone.IndexedDB;
         Path = clone.Path;
     }
+
+    /// <summary>
+    /// <para>
+    /// Set to <c>true</c> to include the context's virtual WebAuthn <see cref="IBrowserContext.Credentials"/>
+    /// (passkeys) in the storage state snapshot. The captured credentials carry their private
+    /// keys, so they can be re-seeded into a later context via the <see cref="IBrowser.NewContextAsync"/>
+    /// option or <see cref="IBrowserContext.SetStorageStateAsync"/>. Note that restoring
+    /// the storage state that contains credentials will automatically install the virtual
+    /// WebAuthn authenticator (see <see cref="ICredentials.InstallAsync"/>), and prevent
+    /// all real authenticators from working in this context.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("credentials")]
+    public bool? Credentials { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleCheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleCheckOptions.cs
@@ -40,6 +40,7 @@ public class ElementHandleCheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class ElementHandleCheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleClickOptions.cs
@@ -45,6 +45,7 @@ public class ElementHandleClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Steps = clone.Steps;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -108,6 +109,19 @@ public class ElementHandleClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleDblClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleDblClickOptions.cs
@@ -44,6 +44,7 @@ public class ElementHandleDblClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Steps = clone.Steps;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -98,6 +99,19 @@ public class ElementHandleDblClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleHoverOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleHoverOptions.cs
@@ -42,6 +42,7 @@ public class ElementHandleHoverOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -82,6 +83,19 @@ public class ElementHandleHoverOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleInputValueOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleInputValueOptions.cs
@@ -40,13 +40,8 @@ public class ElementHandleInputValueOptions
         Timeout = clone.Timeout;
     }
 
-    /// <summary>
-    /// <para>
-    /// Maximum time in milliseconds. Defaults to <c>30000</c> (30 seconds). Pass <c>0</c>
-    /// to disable timeout. The default value can be changed by using the <see cref="IBrowserContext.SetDefaultTimeout"/>
-    /// or <see cref="IPage.SetDefaultTimeout"/> methods.
-    /// </para>
-    /// </summary>
+    /// <summary><para>**DEPRECATED** This option is ignored. The value is returned immediately.</para></summary>
     [JsonPropertyName("timeout")]
+    [System.Obsolete]
     public float? Timeout { get; set; }
 }

--- a/src/Playwright/API/Generated/Options/ElementHandleScreenshotOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleScreenshotOptions.cs
@@ -121,7 +121,13 @@ public class ElementHandleScreenshotOptions
     [JsonPropertyName("path")]
     public string? Path { get; set; }
 
-    /// <summary><para>The quality of the image, between 0-100. Not applicable to <c>png</c> images.</para></summary>
+    /// <summary>
+    /// <para>
+    /// The quality of the image, between 0-100. Not applicable to <c>png</c> images. For
+    /// <c>jpeg</c> the default is <c>80</c>. For <c>webp</c>, a quality of <c>100</c> (the
+    /// default) produces a lossless image, while lower values use lossy compression.
+    /// </para>
+    /// </summary>
     [JsonPropertyName("quality")]
     public int? Quality { get; set; }
 

--- a/src/Playwright/API/Generated/Options/ElementHandleSetCheckedOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleSetCheckedOptions.cs
@@ -40,6 +40,7 @@ public class ElementHandleSetCheckedOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class ElementHandleSetCheckedOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleTapOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleTapOptions.cs
@@ -42,6 +42,7 @@ public class ElementHandleTapOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -82,6 +83,19 @@ public class ElementHandleTapOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/ElementHandleUncheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/ElementHandleUncheckOptions.cs
@@ -40,6 +40,7 @@ public class ElementHandleUncheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class ElementHandleUncheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameCheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameCheckOptions.cs
@@ -40,6 +40,7 @@ public class FrameCheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class FrameCheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameClickOptions.cs
@@ -45,6 +45,7 @@ public class FrameClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -108,6 +109,19 @@ public class FrameClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameDblClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameDblClickOptions.cs
@@ -44,6 +44,7 @@ public class FrameDblClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -98,6 +99,19 @@ public class FrameDblClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameDragAndDropOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameDragAndDropOptions.cs
@@ -39,6 +39,7 @@ public class FrameDragAndDropOptions
 
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
+        Scroll = clone.Scroll;
         SourcePosition = clone.SourcePosition;
         Steps = clone.Steps;
         Strict = clone.Strict;
@@ -63,6 +64,19 @@ public class FrameDragAndDropOptions
     [JsonPropertyName("noWaitAfter")]
     [System.Obsolete]
     public bool? NoWaitAfter { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameHoverOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameHoverOptions.cs
@@ -42,6 +42,7 @@ public class FrameHoverOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -83,6 +84,19 @@ public class FrameHoverOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameSetCheckedOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameSetCheckedOptions.cs
@@ -40,6 +40,7 @@ public class FrameSetCheckedOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class FrameSetCheckedOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameTapOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameTapOptions.cs
@@ -42,6 +42,7 @@ public class FrameTapOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -83,6 +84,19 @@ public class FrameTapOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/FrameUncheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/FrameUncheckOptions.cs
@@ -40,6 +40,7 @@ public class FrameUncheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class FrameUncheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorCheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorCheckOptions.cs
@@ -40,6 +40,7 @@ public class LocatorCheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class LocatorCheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorClickOptions.cs
@@ -45,6 +45,7 @@ public class LocatorClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Steps = clone.Steps;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -108,6 +109,19 @@ public class LocatorClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorDblClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorDblClickOptions.cs
@@ -44,6 +44,7 @@ public class LocatorDblClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Steps = clone.Steps;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -98,6 +99,19 @@ public class LocatorDblClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorDragToOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorDragToOptions.cs
@@ -39,6 +39,7 @@ public class LocatorDragToOptions
 
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
+        Scroll = clone.Scroll;
         SourcePosition = clone.SourcePosition;
         Steps = clone.Steps;
         TargetPosition = clone.TargetPosition;
@@ -62,6 +63,19 @@ public class LocatorDragToOptions
     [JsonPropertyName("noWaitAfter")]
     [System.Obsolete]
     public bool? NoWaitAfter { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorHoverOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorHoverOptions.cs
@@ -42,6 +42,7 @@ public class LocatorHoverOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -82,6 +83,19 @@ public class LocatorHoverOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorScreenshotOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorScreenshotOptions.cs
@@ -121,7 +121,13 @@ public class LocatorScreenshotOptions
     [JsonPropertyName("path")]
     public string? Path { get; set; }
 
-    /// <summary><para>The quality of the image, between 0-100. Not applicable to <c>png</c> images.</para></summary>
+    /// <summary>
+    /// <para>
+    /// The quality of the image, between 0-100. Not applicable to <c>png</c> images. For
+    /// <c>jpeg</c> the default is <c>80</c>. For <c>webp</c>, a quality of <c>100</c> (the
+    /// default) produces a lossless image, while lower values use lossy compression.
+    /// </para>
+    /// </summary>
     [JsonPropertyName("quality")]
     public int? Quality { get; set; }
 

--- a/src/Playwright/API/Generated/Options/LocatorSetCheckedOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorSetCheckedOptions.cs
@@ -40,6 +40,7 @@ public class LocatorSetCheckedOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class LocatorSetCheckedOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorTapOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorTapOptions.cs
@@ -42,6 +42,7 @@ public class LocatorTapOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -82,6 +83,19 @@ public class LocatorTapOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorUncheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorUncheckOptions.cs
@@ -40,6 +40,7 @@ public class LocatorUncheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
     }
@@ -69,6 +70,19 @@ public class LocatorUncheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/LocatorWaitForFunctionOptions.cs
+++ b/src/Playwright/API/Generated/Options/LocatorWaitForFunctionOptions.cs
@@ -6,7 +6,7 @@
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
@@ -22,37 +22,32 @@
  * SOFTWARE.
  */
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Playwright.Transport.Protocol;
+namespace Microsoft.Playwright;
 
-internal class APIResponse
+public class LocatorWaitForFunctionOptions
 {
-    [JsonPropertyName("fetchUid")]
-    public string FetchUid { get; set; } = null!;
+    public LocatorWaitForFunctionOptions() { }
 
-    [JsonPropertyName("url")]
-    public string Url { get; set; } = null!;
+    public LocatorWaitForFunctionOptions(LocatorWaitForFunctionOptions clone)
+    {
+        if (clone == null)
+        {
+            return;
+        }
 
-    [JsonPropertyName("status")]
-    public int Status { get; set; }
+        Timeout = clone.Timeout;
+    }
 
-    [JsonPropertyName("statusText")]
-    public string StatusText { get; set; } = null!;
-
-    [JsonPropertyName("headers")]
-    public List<NameValue> Headers { get; set; } = null!;
-
-    [JsonPropertyName("securityDetails")]
-    public SecurityDetails SecurityDetails { get; set; } = null!;
-
-    [JsonPropertyName("serverAddr")]
-    public RemoteAddr ServerAddr { get; set; } = null!;
-
-    [JsonPropertyName("timing")]
-    public RequestTimingResult Timing { get; set; } = null!;
-
-    [JsonPropertyName("responseEndTiming")]
-    public float ResponseEndTiming { get; set; }
+    /// <summary>
+    /// <para>
+    /// Maximum time to wait for in milliseconds. Defaults to <c>30000</c> (30 seconds).
+    /// Pass <c>0</c> to disable timeout. The default value can be changed by using the
+    /// <see cref="IBrowserContext.SetDefaultTimeout"/> or <see cref="IPage.SetDefaultTimeout"/>
+    /// methods.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("timeout")]
+    public float? Timeout { get; set; }
 }

--- a/src/Playwright/API/Generated/Options/PageCheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageCheckOptions.cs
@@ -40,6 +40,7 @@ public class PageCheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class PageCheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageClickOptions.cs
@@ -45,6 +45,7 @@ public class PageClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -108,6 +109,19 @@ public class PageClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageDblClickOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageDblClickOptions.cs
@@ -44,6 +44,7 @@ public class PageDblClickOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -98,6 +99,19 @@ public class PageDblClickOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageDragAndDropOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageDragAndDropOptions.cs
@@ -39,6 +39,7 @@ public class PageDragAndDropOptions
 
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
+        Scroll = clone.Scroll;
         SourcePosition = clone.SourcePosition;
         Steps = clone.Steps;
         Strict = clone.Strict;
@@ -63,6 +64,19 @@ public class PageDragAndDropOptions
     [JsonPropertyName("noWaitAfter")]
     [System.Obsolete]
     public bool? NoWaitAfter { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageHoverOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageHoverOptions.cs
@@ -42,6 +42,7 @@ public class PageHoverOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -83,6 +84,19 @@ public class PageHoverOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageScreenshotOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageScreenshotOptions.cs
@@ -136,7 +136,13 @@ public class PageScreenshotOptions
     [JsonPropertyName("path")]
     public string? Path { get; set; }
 
-    /// <summary><para>The quality of the image, between 0-100. Not applicable to <c>png</c> images.</para></summary>
+    /// <summary>
+    /// <para>
+    /// The quality of the image, between 0-100. Not applicable to <c>png</c> images. For
+    /// <c>jpeg</c> the default is <c>80</c>. For <c>webp</c>, a quality of <c>100</c> (the
+    /// default) produces a lossless image, while lower values use lossy compression.
+    /// </para>
+    /// </summary>
     [JsonPropertyName("quality")]
     public int? Quality { get; set; }
 

--- a/src/Playwright/API/Generated/Options/PageSetCheckedOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageSetCheckedOptions.cs
@@ -40,6 +40,7 @@ public class PageSetCheckedOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class PageSetCheckedOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageTapOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageTapOptions.cs
@@ -42,6 +42,7 @@ public class PageTapOptions
         Modifiers = clone.Modifiers;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -83,6 +84,19 @@ public class PageTapOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Options/PageUncheckOptions.cs
+++ b/src/Playwright/API/Generated/Options/PageUncheckOptions.cs
@@ -40,6 +40,7 @@ public class PageUncheckOptions
         Force = clone.Force;
         NoWaitAfter = clone.NoWaitAfter;
         Position = clone.Position;
+        Scroll = clone.Scroll;
         Strict = clone.Strict;
         Timeout = clone.Timeout;
         Trial = clone.Trial;
@@ -70,6 +71,19 @@ public class PageUncheckOptions
     /// </summary>
     [JsonPropertyName("position")]
     public Position? Position { get; set; }
+
+    /// <summary>
+    /// <para>
+    /// Controls whether Playwright scrolls the element into view before performing the
+    /// action. Defaults to <c>"auto"</c>, which scrolls the element into view when necessary,
+    /// including scrolling nested scrollable containers. When set to <c>"none"</c>, Playwright
+    /// does not scroll the element and the action fails if the element is not already in
+    /// the viewport. This is useful to assert that an element is reachable by the user
+    /// without additional scrolling.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("scroll")]
+    public ScrollMode? Scroll { get; set; }
 
     /// <summary>
     /// <para>

--- a/src/Playwright/API/Generated/Types/RequestTimingResult.cs
+++ b/src/Playwright/API/Generated/Types/RequestTimingResult.cs
@@ -36,7 +36,7 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately before the browser starts the domain name lookup for the resource.
+    /// Time immediately before the client starts the domain name lookup for the resource.
     /// The value is given in milliseconds relative to <c>startTime</c>, -1 if not available.
     /// </para>
     /// </summary>
@@ -46,7 +46,7 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately after the browser starts the domain name lookup for the resource.
+    /// Time immediately after the client ends the domain name lookup for the resource.
     /// The value is given in milliseconds relative to <c>startTime</c>, -1 if not available.
     /// </para>
     /// </summary>
@@ -56,9 +56,9 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately before the user agent starts establishing the connection to the
-    /// server to retrieve the resource. The value is given in milliseconds relative to
-    /// <c>startTime</c>, -1 if not available.
+    /// Time immediately before the client starts establishing the connection to the server
+    /// to retrieve the resource. The value is given in milliseconds relative to <c>startTime</c>,
+    /// -1 if not available.
     /// </para>
     /// </summary>
     [Required]
@@ -67,7 +67,7 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately before the browser starts the handshake process to secure the current
+    /// Time immediately before the client starts the handshake process to secure the current
     /// connection. The value is given in milliseconds relative to <c>startTime</c>, -1
     /// if not available.
     /// </para>
@@ -78,9 +78,9 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately before the user agent starts establishing the connection to the
-    /// server to retrieve the resource. The value is given in milliseconds relative to
-    /// <c>startTime</c>, -1 if not available.
+    /// Time immediately after the client establishes the connection to the server to retrieve
+    /// the resource. The value is given in milliseconds relative to <c>startTime</c>, -1
+    /// if not available.
     /// </para>
     /// </summary>
     [Required]
@@ -89,7 +89,7 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately before the browser starts requesting the resource from the server,
+    /// Time immediately before the client starts requesting the resource from the server,
     /// cache, or local resource. The value is given in milliseconds relative to <c>startTime</c>,
     /// -1 if not available.
     /// </para>
@@ -100,9 +100,9 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately after the browser receives the first byte of the response from
-    /// the server, cache, or local resource. The value is given in milliseconds relative
-    /// to <c>startTime</c>, -1 if not available.
+    /// Time immediately after the client receives the first byte of the response from the
+    /// server, cache, or local resource. The value is given in milliseconds relative to
+    /// <c>startTime</c>, -1 if not available.
     /// </para>
     /// </summary>
     [Required]
@@ -111,7 +111,7 @@ public partial class RequestTimingResult
 
     /// <summary>
     /// <para>
-    /// Time immediately after the browser receives the last byte of the resource or immediately
+    /// Time immediately after the client receives the last byte of the resource or immediately
     /// before the transport connection is closed, whichever comes first. The value is given
     /// in milliseconds relative to <c>startTime</c>, -1 if not available.
     /// </para>

--- a/src/Playwright/Core/APIResponse.cs
+++ b/src/Playwright/Core/APIResponse.cs
@@ -57,6 +57,26 @@ internal class APIResponse : IAPIResponse
 
     public string Url => _initializer.Url;
 
+    public RequestTimingResult Timing
+    {
+        get
+        {
+            var timing = _initializer.Timing;
+            return new RequestTimingResult
+            {
+                StartTime = timing?.StartTime ?? -1,
+                DomainLookupStart = timing?.DomainLookupStart ?? -1,
+                DomainLookupEnd = timing?.DomainLookupEnd ?? -1,
+                ConnectStart = timing?.ConnectStart ?? -1,
+                SecureConnectionStart = timing?.SecureConnectionStart ?? -1,
+                ConnectEnd = timing?.ConnectEnd ?? -1,
+                RequestStart = timing?.RequestStart ?? -1,
+                ResponseStart = timing?.ResponseStart ?? -1,
+                ResponseEnd = timing == null ? -1 : _initializer.ResponseEndTiming,
+            };
+        }
+    }
+
     public Task<ResponseSecurityDetailsResult?> SecurityDetailsAsync()
         => Task.FromResult(_initializer.SecurityDetails == null ? null : new ResponseSecurityDetailsResult
         {

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -398,6 +398,18 @@ internal class Locator : ILocator
         });
     }
 
+    public Task WaitForFunctionAsync(string expression, object? arg = default, LocatorWaitForFunctionOptions? options = default)
+    {
+        return _frame.SendMessageToServerAsync("waitForFunction", new Dictionary<string, object?>
+        {
+            ["selector"] = _selector,
+            ["strict"] = true,
+            ["expression"] = expression,
+            ["arg"] = ScriptsHelper.SerializedArgument(arg),
+            ["timeout"] = _frame.Timeout(options?.Timeout),
+        });
+    }
+
     internal Task<FrameExpectResult> ExpectAsync(string expression, FrameExpectOptions options, string? title)
         => this._frame.WrapApiCallAsync(
               () => _frame.ExpectAsync(_selector, expression, options),

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -181,6 +181,11 @@ internal class Connection : IDisposable
             ["internal"] = isInternal,
             ["wallTime"] = DateTimeOffset.Now.ToUnixTimeMilliseconds(),
         };
+        if (sanitizedArgs.TryGetValue("timeout", out var timeout))
+        {
+            sanitizedArgs.Remove("timeout");
+            metadata["timeout"] = timeout;
+        }
         if (!string.IsNullOrEmpty(title))
         {
             metadata["title"] = title;

--- a/src/Playwright/Transport/Protocol/Generated/Metadata.cs
+++ b/src/Playwright/Transport/Protocol/Generated/Metadata.cs
@@ -39,4 +39,7 @@ internal class Metadata
 
     [JsonPropertyName("stepId")]
     public string StepId { get; set; } = null!;
+
+    [JsonPropertyName("timeout")]
+    public float Timeout { get; set; }
 }

--- a/src/Playwright/Transport/Protocol/Generated/SerializedValue.cs
+++ b/src/Playwright/Transport/Protocol/Generated/SerializedValue.cs
@@ -68,6 +68,9 @@ internal class SerializedValue
     [JsonPropertyName("h")]
     public int? H { get; set; }
 
+    [JsonPropertyName("fn")]
+    public string Fn { get; set; } = null!;
+
     [JsonPropertyName("id")]
     public int? Id { get; set; }
 


### PR DESCRIPTION
Rolls Playwright for .NET to driver `1.62.0` with Chromium `151.0.7922.34`, Firefox `153.0`, WebKit `26.5`, and Node.js `24.18.1`.

### Protocol timeout migration

`1.62` removes per method `timeout` parameters and carries the call timeout in `Metadata.timeout`.  The .NET client still sent `timeout` as a parameter, so the `1.62.0` server ignored every server dispatched operation timeout.

`Connection.InnerSendMessageToServerAsync` now moves the resolved `timeout` parameter into the metadata before sending the message.  `waitForTimeout` remains unaffected because it uses `waitTimeout`.

The follow-up <https://github.com/microsoft/playwright-dotnet/pull/3339> passes the timeout as a separate `SendMessageToServerAsync` argument instead of extracting it from the parameter dictionary.

| | Failed | Passed | Duration |
| :--- | :---: | :---: | :---: |
| Before | 24 | 278 | 12m 15s |
| After | 0 | 302 | 1m 49s |

### Rolling tooling

Upstream removed `utils/build/build-playwright-driver.sh` in <https://github.com/microsoft/playwright/pull/41518>, so `roll_driver` could no longer read the Node.js version.  It now reads the latest Node.js LTS from <https://nodejs.org/dist/index.json>, matching `utils/build/update-playwright-node.mjs`.

### API and browser updates

- Adds the handwritten `IAPIResponse.Timing` implementation required by the generated interface
- Adds the handwritten `ILocator.WaitForFunctionAsync` implementation required by the generated interface
- Removes the Firefox specific worker locale expectation because Firefox `153` fixes <https://github.com/microsoft/playwright/issues/38919>
- Expects the certificate subject `true` from WebKit on Windows, matching the `1.62.0` upstream test
- Aligns `ShouldWorkWhileNavigating` with the upstream full page screenshot test

Upstream marks `timing` and `responseEndTiming` optional and emits them together, while the .NET channel generator emits `ResponseEndTiming` as a non nullable `float`.  `APIResponse.Timing` therefore uses `timing == null` to select the `-1` fallback for `ResponseEnd`.

The viewport version of `ShouldWorkWhileNavigating` passed with `1.61.1-beta` in <https://github.com/microsoft/playwright-dotnet/actions/runs/28052877970>, but waits out its timeout with `1.62.0`.  An explicit `Timeout = 1000` is honored after approximately `1000` milliseconds, so the test now matches the upstream full page scenario.

Validation:

- `dotnet build src/Playwright` succeeds with no warnings or errors
- `dotnet format ./src/ --verify-no-changes` succeeds
- The targeted WebKit security details tests pass
- The Chromium suite passes with `1818` tests and `33` skipped tests
- The only two local failures require `pwsh`, which is not installed on the validation machine