### PR TITLE
chore(transport): pass the call timeout as an argument

### DIFF
--- a/src/Playwright/Core/APIRequestContext.cs
+++ b/src/Playwright/Core/APIRequestContext.cs
@@ -147,7 +147,6 @@ internal class APIRequestContext : ChannelOwner, IAPIRequestContext
             ["ignoreHTTPSErrors"] = options?.IgnoreHTTPSErrors,
             ["maxRedirects"] = options?.MaxRedirects,
             ["maxRetries"] = options?.MaxRetries,
-            ["timeout"] = _timeoutSettings.Timeout(options?.Timeout),
             ["params"] = options?.Params?.ToDictionary(x => x.Key, x => x.Value.ToString()).ToProtocol(),
             ["encodedParams"] = options?.ParamsString,
             ["headers"] = options?.Headers?.ToProtocol(),
@@ -157,7 +156,7 @@ internal class APIRequestContext : ChannelOwner, IAPIRequestContext
             ["multipartData"] = (options?.Multipart as FormData)?.ToProtocol(),
         };
 
-        var response = await SendMessageToServerAsync("fetch", message).ConfigureAwait(false);
+        var response = await SendMessageToServerAsync("fetch", message, timeout: _timeoutSettings.Timeout(options?.Timeout)).ConfigureAwait(false);
         return new APIResponse(this, response?.GetProperty("response").ToObject<Transport.Protocol.APIResponse>()!);
     }
 

--- a/src/Playwright/Core/BrowserType.cs
+++ b/src/Playwright/Core/BrowserType.cs
@@ -74,8 +74,8 @@ internal class BrowserType : ChannelOwner, IBrowserType
                 { "firefoxUserPrefs", options.FirefoxUserPrefs },
                 { "chromiumSandbox", options.ChromiumSandbox },
                 { "slowMo", options.SlowMo },
-                { "timeout", TimeoutSettings.LaunchTimeout(options.Timeout) },
-            }).ConfigureAwait(false);
+            },
+            timeout: TimeoutSettings.LaunchTimeout(options.Timeout)).ConfigureAwait(false);
         browser.ConnectToBrowserType(this, options.TracesDir);
         return browser;
     }
@@ -100,7 +100,6 @@ internal class BrowserType : ChannelOwner, IBrowserType
             ["handleSIGINT"] = options.HandleSIGINT,
             ["handleSIGTERM"] = options.HandleSIGTERM,
             ["handleSIGHUP"] = options.HandleSIGHUP,
-            ["timeout"] = TimeoutSettings.LaunchTimeout(options.Timeout),
             ["env"] = options.Env?.ToProtocol(),
             ["slowMo"] = options.SlowMo,
             ["ignoreHTTPSErrors"] = options.IgnoreHTTPSErrors,
@@ -147,7 +146,7 @@ internal class BrowserType : ChannelOwner, IBrowserType
             channelArgs.Add("viewport", options.ViewportSize);
         }
 
-        JsonElement result = await SendMessageToServerAsync<JsonElement>("launchPersistentContext", channelArgs).ConfigureAwait(false);
+        JsonElement result = await SendMessageToServerAsync<JsonElement>("launchPersistentContext", channelArgs, timeout: TimeoutSettings.LaunchTimeout(options.Timeout)).ConfigureAwait(false);
         var browser = result.GetProperty("browser").ToObject<Browser>(_connection.DefaultJsonSerializerOptions)!;
         browser.ConnectToBrowserType(this, options.TracesDir);
         var context = result.GetProperty("context").ToObject<BrowserContext>(_connection.DefaultJsonSerializerOptions)!;
@@ -263,16 +262,18 @@ internal class BrowserType : ChannelOwner, IBrowserType
             throw new ArgumentException("Connecting over CDP is only supported in Chromium.");
         }
         options ??= new BrowserTypeConnectOverCDPOptions();
-        JsonElement result = await SendMessageToServerAsync<JsonElement>("connectOverCDP", new Dictionary<string, object?>
-            {
-                { "endpointURL", endpointURL },
-                { "headers", options.Headers?.ToProtocol() },
-                { "slowMo", options.SlowMo },
-                { "timeout", TimeoutSettings.LaunchTimeout(options.Timeout) },
-                { "isLocal", options.IsLocal },
-                { "noDefaults", options.NoDefaults },
-                { "artifactsDir", options.ArtifactsDir },
-            }).ConfigureAwait(false);
+        JsonElement result = await SendMessageToServerAsync<JsonElement>(
+                "connectOverCDP",
+                new Dictionary<string, object?>
+                {
+                    { "endpointURL", endpointURL },
+                    { "headers", options.Headers?.ToProtocol() },
+                    { "slowMo", options.SlowMo },
+                    { "isLocal", options.IsLocal },
+                    { "noDefaults", options.NoDefaults },
+                    { "artifactsDir", options.ArtifactsDir },
+                },
+                timeout: TimeoutSettings.LaunchTimeout(options.Timeout)).ConfigureAwait(false);
         Browser browser = result.GetProperty("browser").ToObject<Browser>(_connection.DefaultJsonSerializerOptions);
         browser.ConnectToBrowserType(this, null);
         return browser;

--- a/src/Playwright/Core/ElementHandle.cs
+++ b/src/Playwright/Core/ElementHandle.cs
@@ -59,36 +59,42 @@ internal class ElementHandle : JSHandle, IElementHandle
             new Dictionary<string, object?>
             {
                 ["selector"] = selector,
-                ["timeout"] = _frame.Timeout(options?.Timeout),
                 ["state"] = options?.State,
                 ["strict"] = options?.Strict,
-            }).ConfigureAwait(false);
+            },
+            timeout: _frame.Timeout(options?.Timeout)).ConfigureAwait(false);
 
     public Task WaitForElementStateAsync(ElementState state, ElementHandleWaitForElementStateOptions? options = default)
-        => SendMessageToServerAsync("waitForElementState", new Dictionary<string, object?>
-        {
-            ["state"] = state,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "waitForElementState",
+            new Dictionary<string, object?>
+            {
+                ["state"] = state,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task PressAsync(string key, ElementHandlePressOptions? options = default)
-        => SendMessageToServerAsync("press", new Dictionary<string, object?>
-        {
-            ["key"] = key,
-            ["delay"] = options?.Delay,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
+        => SendMessageToServerAsync(
+            "press",
+            new Dictionary<string, object?>
+            {
+                ["key"] = key,
+                ["delay"] = options?.Delay,
 #pragma warning disable CS0612 // Type or member is obsolete
-            ["noWaitAfter"] = options?.NoWaitAfter,
+                ["noWaitAfter"] = options?.NoWaitAfter,
 #pragma warning restore CS0612 // Type or member is obsolete
-        });
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task TypeAsync(string text, ElementHandleTypeOptions? options = default)
-        => SendMessageToServerAsync("type", new Dictionary<string, object?>
-        {
-            ["text"] = text,
-            ["delay"] = options?.Delay,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "type",
+            new Dictionary<string, object?>
+            {
+                ["text"] = text,
+                ["delay"] = options?.Delay,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public async Task<byte[]> ScreenshotAsync(ElementHandleScreenshotOptions? options = default)
     {
@@ -103,7 +109,6 @@ internal class ElementHandle : JSHandle, IElementHandle
             ["type"] = options.Type,
             ["omitBackground"] = options.OmitBackground,
             ["path"] = options.Path,
-            ["timeout"] = _frame.Timeout(options.Timeout),
             ["animations"] = options.Animations,
             ["caret"] = options.Caret,
             ["scale"] = options.Scale,
@@ -120,7 +125,7 @@ internal class ElementHandle : JSHandle, IElementHandle
             }).ToArray();
         }
 
-        var result = (await SendMessageToServerAsync("screenshot", args).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
+        var result = (await SendMessageToServerAsync("screenshot", args, timeout: _frame.Timeout(options.Timeout)).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
 
         if (!string.IsNullOrEmpty(options.Path))
         {
@@ -132,30 +137,36 @@ internal class ElementHandle : JSHandle, IElementHandle
     }
 
     public Task FillAsync(string value, ElementHandleFillOptions? options = default)
-        => SendMessageToServerAsync("fill", new Dictionary<string, object?>
-        {
-            ["value"] = value,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["force"] = options?.Force,
-        });
+        => SendMessageToServerAsync(
+            "fill",
+            new Dictionary<string, object?>
+            {
+                ["value"] = value,
+                ["force"] = options?.Force,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public async Task<IFrame?> ContentFrameAsync() => await SendMessageToServerAsync<Frame>("contentFrame").ConfigureAwait(false);
 
     public Task HoverAsync(ElementHandleHoverOptions? options = default)
-        => SendMessageToServerAsync<JsonElement?>("hover", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["trial"] = options?.Trial,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-        });
+        => SendMessageToServerAsync<JsonElement?>(
+            "hover",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task ScrollIntoViewIfNeededAsync(ElementHandleScrollIntoViewIfNeededOptions? options = default)
-        => SendMessageToServerAsync("scrollIntoViewIfNeeded", new Dictionary<string, object?>
-        {
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "scrollIntoViewIfNeeded",
+            new Dictionary<string, object?>
+            {
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public async Task<IFrame?> OwnerFrameAsync() => await SendMessageToServerAsync<Frame>("ownerFrame").ConfigureAwait(false);
 
@@ -170,34 +181,38 @@ internal class ElementHandle : JSHandle, IElementHandle
     }
 
     public Task ClickAsync(ElementHandleClickOptions? options = default)
-        => SendMessageToServerAsync("click", new Dictionary<string, object?>
-        {
-            ["delay"] = options?.Delay,
-            ["button"] = options?.Button,
-            ["clickCount"] = options?.ClickCount,
-            ["force"] = options?.Force,
+        => SendMessageToServerAsync(
+            "click",
+            new Dictionary<string, object?>
+            {
+                ["delay"] = options?.Delay,
+                ["button"] = options?.Button,
+                ["clickCount"] = options?.ClickCount,
+                ["force"] = options?.Force,
 #pragma warning disable CS0612 // Type or member is obsolete
-            ["noWaitAfter"] = options?.NoWaitAfter,
+                ["noWaitAfter"] = options?.NoWaitAfter,
 #pragma warning restore CS0612 // Type or member is obsolete
-            ["steps"] = options?.Steps,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["trial"] = options?.Trial,
-            ["position"] = options?.Position,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-        });
+                ["steps"] = options?.Steps,
+                ["trial"] = options?.Trial,
+                ["position"] = options?.Position,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task DblClickAsync(ElementHandleDblClickOptions? options = default)
-        => SendMessageToServerAsync("dblclick", new Dictionary<string, object?>
-        {
-            ["delay"] = options?.Delay,
-            ["button"] = options?.Button,
-            ["force"] = options?.Force,
-            ["steps"] = options?.Steps,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["trial"] = options?.Trial,
-            ["position"] = options?.Position,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-        });
+        => SendMessageToServerAsync(
+            "dblclick",
+            new Dictionary<string, object?>
+            {
+                ["delay"] = options?.Delay,
+                ["button"] = options?.Button,
+                ["force"] = options?.Force,
+                ["steps"] = options?.Steps,
+                ["trial"] = options?.Trial,
+                ["position"] = options?.Position,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task SetInputFilesAsync(string files, ElementHandleSetInputFilesOptions? options = default)
         => SetInputFilesAsync(new[] { files }, options);
@@ -210,15 +225,17 @@ internal class ElementHandle : JSHandle, IElementHandle
             throw new PlaywrightException("Cannot set input files to detached element.");
         }
         var converted = await SetInputFilesHelpers.ConvertInputFilesAsync(files, (BrowserContext)frame.Page.Context).ConfigureAwait(false);
-        await SendMessageToServerAsync("setInputFiles", new Dictionary<string, object?>
-        {
-            ["payloads"] = converted.Payloads,
-            ["localPaths"] = converted.LocalPaths,
-            ["localDirectory"] = converted.LocalDirectory,
-            ["streams"] = converted.Streams,
-            ["directoryStream"] = converted.DirectoryStream,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        }).ConfigureAwait(false);
+        await SendMessageToServerAsync(
+            "setInputFiles",
+            new Dictionary<string, object?>
+            {
+                ["payloads"] = converted.Payloads,
+                ["localPaths"] = converted.LocalPaths,
+                ["localDirectory"] = converted.LocalDirectory,
+                ["streams"] = converted.Streams,
+                ["directoryStream"] = converted.DirectoryStream,
+            },
+            timeout: _frame.Timeout(options?.Timeout)).ConfigureAwait(false);
     }
 
     public Task SetInputFilesAsync(FilePayload files, ElementHandleSetInputFilesOptions? options = default)
@@ -227,13 +244,15 @@ internal class ElementHandle : JSHandle, IElementHandle
     public async Task SetInputFilesAsync(IEnumerable<FilePayload> files, ElementHandleSetInputFilesOptions? options = default)
     {
         var converted = SetInputFilesHelpers.ConvertInputFiles(files);
-        await SendMessageToServerAsync("setInputFiles", new Dictionary<string, object?>
-        {
-            ["payloads"] = converted.Payloads,
-            ["localPaths"] = converted.LocalPaths,
-            ["streams"] = converted.Streams,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        }).ConfigureAwait(false);
+        await SendMessageToServerAsync(
+            "setInputFiles",
+            new Dictionary<string, object?>
+            {
+                ["payloads"] = converted.Payloads,
+                ["localPaths"] = converted.LocalPaths,
+                ["streams"] = converted.Streams,
+            },
+            timeout: _frame.Timeout(options?.Timeout)).ConfigureAwait(false);
     }
 
     public async Task<IElementHandle?> QuerySelectorAsync(string selector)
@@ -310,11 +329,13 @@ internal class ElementHandle : JSHandle, IElementHandle
     public async Task<string?> TextContentAsync() => (await SendMessageToServerAsync("textContent").ConfigureAwait(false))?.GetProperty("value").ToString();
 
     public Task SelectTextAsync(ElementHandleSelectTextOptions? options = default)
-        => SendMessageToServerAsync("selectText", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "selectText",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task<IReadOnlyList<string>> SelectOptionAsync(string value, ElementHandleSelectOptionOptions? options = default)
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -348,51 +369,61 @@ internal class ElementHandle : JSHandle, IElementHandle
 
     private async Task<IReadOnlyList<string>> _selectOptionAsync(IEnumerable<SelectOptionValueProtocol> values, bool? noWaitAfter, bool? force, float? timeout)
     {
-        return (await SendMessageToServerAsync("selectOption", new Dictionary<string, object?>
-        {
-            ["options"] = values,
-            ["force"] = force,
-            ["timeout"] = _frame.Timeout(timeout),
-        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
+        return (await SendMessageToServerAsync(
+            "selectOption",
+            new Dictionary<string, object?>
+            {
+                ["options"] = values,
+                ["force"] = force,
+            },
+            timeout: _frame.Timeout(timeout)).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
     }
 
     private async Task<IReadOnlyList<string>> _selectOptionAsync(IEnumerable<IElementHandle> values, bool? noWaitAfter, bool? force, float? timeout)
     {
-        return (await SendMessageToServerAsync("selectOption", new Dictionary<string, object?>
-        {
-            ["elements"] = values,
-            ["force"] = force,
-            ["timeout"] = _frame.Timeout(timeout),
-        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
+        return (await SendMessageToServerAsync(
+            "selectOption",
+            new Dictionary<string, object?>
+            {
+                ["elements"] = values,
+                ["force"] = force,
+            },
+            timeout: _frame.Timeout(timeout)).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>();
     }
 
     public Task CheckAsync(ElementHandleCheckOptions? options = default)
-        => SendMessageToServerAsync("check", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "check",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task UncheckAsync(ElementHandleUncheckOptions? options = default)
-        => SendMessageToServerAsync("uncheck", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "uncheck",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task TapAsync(ElementHandleTapOptions? options = default)
-        => SendMessageToServerAsync("tap", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-            ["trial"] = options?.Trial,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "tap",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+                ["trial"] = options?.Trial,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public async Task<bool> IsCheckedAsync() => (await SendMessageToServerAsync("isChecked").ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
@@ -410,13 +441,15 @@ internal class ElementHandle : JSHandle, IElementHandle
         => (await SendMessageToServerAsync("inputValue").ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     public Task SetCheckedAsync(bool checkedState, ElementHandleSetCheckedOptions? options = null)
-        => SendMessageToServerAsync(checkedState ? "check" : "uncheck", new Dictionary<string, object?>
-        {
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            checkedState ? "check" : "uncheck",
+            new Dictionary<string, object?>
+            {
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     internal static ScreenshotType DetermineScreenshotType(string path)
     {

--- a/src/Playwright/Core/Frame.cs
+++ b/src/Playwright/Core/Frame.cs
@@ -187,14 +187,16 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<IElementHandle> values, FrameSelectOptionOptions? options = default)
-        => (await SendMessageToServerAsync("selectOption", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["elements"] = values.Select(x => x as ElementHandle),
-            ["strict"] = options?.Strict,
-            ["force"] = options?.Force,
-            ["timeout"] = Timeout(options?.Timeout),
-        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
+        => (await SendMessageToServerAsync(
+            "selectOption",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["elements"] = values.Select(x => x as ElementHandle),
+                ["strict"] = options?.Strict,
+                ["force"] = options?.Force,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task<IReadOnlyList<string>> SelectOptionAsync(string selector, SelectOptionValue values, FrameSelectOptionOptions? options = default)
@@ -205,17 +207,19 @@ internal class Frame : ChannelOwner, IFrame
         => SelectOptionAsync(selector, values.Select(value => SelectOptionValueProtocol.From(value)), options);
 
     internal async Task<IReadOnlyList<string>> SelectOptionAsync(string selector, IEnumerable<SelectOptionValueProtocol> values, FrameSelectOptionOptions? options = default)
-        => (await SendMessageToServerAsync("selectOption", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["options"] = values,
+        => (await SendMessageToServerAsync(
+            "selectOption",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["options"] = values,
 #pragma warning disable CS0612 // Type or member is obsolete
-            ["noWaitAfter"] = options?.NoWaitAfter,
+                ["noWaitAfter"] = options?.NoWaitAfter,
 #pragma warning restore CS0612 // Type or member is obsolete
-            ["strict"] = options?.Strict,
-            ["force"] = options?.Force,
-            ["timeout"] = Timeout(options?.Timeout),
-        }).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
+                ["strict"] = options?.Strict,
+                ["force"] = options?.Force,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))!.Value.GetProperty("values").ToObject<string[]>().ToList().AsReadOnly();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task WaitForLoadStateAsync(LoadState? state = default, FrameWaitForLoadStateOptions? options = default)
@@ -347,16 +351,18 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TapAsync(string selector, FrameTapOptions? options = default)
-        => SendMessageToServerAsync("tap", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["force"] = options?.Force,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["position"] = options?.Position,
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "tap",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["force"] = options?.Force,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+                ["trial"] = options?.Trial,
+                ["position"] = options?.Position,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     internal async Task<int> QueryCountAsync(string selector)
     {
@@ -373,34 +379,40 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FocusAsync(string selector, FrameFocusOptions? options = default)
-        => SendMessageToServerAsync("focus", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "focus",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task TypeAsync(string selector, string text, FrameTypeOptions? options = default)
-        => SendMessageToServerAsync("type", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["text"] = text,
-            ["delay"] = options?.Delay,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "type",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["text"] = text,
+                ["delay"] = options?.Delay,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string?> GetAttributeAsync(string selector, string name, FrameGetAttributeOptions? options = default)
     {
-        if ((await SendMessageToServerAsync("getAttribute", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["name"] = name,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.TryGetProperty("value", out JsonElement retValue) ?? false)
+        if ((await SendMessageToServerAsync(
+            "getAttribute",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["name"] = name,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.TryGetProperty("value", out JsonElement retValue) ?? false)
         {
             return retValue.ToString();
         }
@@ -409,79 +421,93 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> InnerHTMLAsync(string selector, FrameInnerHTMLOptions? options = default)
-        => (await SendMessageToServerAsync("innerHTML", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync(
+            "innerHTML",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> InnerTextAsync(string selector, FrameInnerTextOptions? options = default)
-        => (await SendMessageToServerAsync("innerText", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync(
+            "innerText",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string?> TextContentAsync(string selector, FrameTextContentOptions? options = default)
-        => (await SendMessageToServerAsync("textContent", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync(
+            "textContent",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task HoverAsync(string selector, FrameHoverOptions? options = default)
-        => SendMessageToServerAsync("hover", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["force"] = options?.Force,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "hover",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["force"] = options?.Force,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task PressAsync(string selector, string key, FramePressOptions? options = default)
-        => SendMessageToServerAsync("press", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["key"] = key,
-            ["delay"] = options?.Delay,
-            ["timeout"] = Timeout(options?.Timeout),
+        => SendMessageToServerAsync(
+            "press",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["key"] = key,
+                ["delay"] = options?.Delay,
 #pragma warning disable CS0612 // Type or member is obsolete
-            ["noWaitAfter"] = options?.NoWaitAfter,
+                ["noWaitAfter"] = options?.NoWaitAfter,
 #pragma warning restore CS0612 // Type or member is obsolete
-            ["strict"] = options?.Strict,
-        });
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DispatchEventAsync(string selector, string type, object? eventInit = default, FrameDispatchEventOptions? options = default)
-        => SendMessageToServerAsync("dispatchEvent", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["type"] = type,
-            ["eventInit"] = ScriptsHelper.SerializedArgument(eventInit),
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "dispatchEvent",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["type"] = type,
+                ["eventInit"] = ScriptsHelper.SerializedArgument(eventInit),
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task FillAsync(string selector, string value, FrameFillOptions? options = default)
-        => SendMessageToServerAsync("fill", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["value"] = value,
-            ["force"] = options?.Force,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "fill",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["value"] = value,
+                ["force"] = options?.Force,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> AddScriptTagAsync(FrameAddScriptTagOptions? options = default)
@@ -547,17 +573,19 @@ internal class Frame : ChannelOwner, IFrame
 
     private async Task _setInputFilesAsync(string selector, SetInputFilesFiles files, bool? noWaitAfter, float? timeout, bool? strict)
     {
-        await SendMessageToServerAsync("setInputFiles", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["payloads"] = files.Payloads,
-            ["localPaths"] = files.LocalPaths,
-            ["localDirectory"] = files.LocalDirectory,
-            ["streams"] = files.Streams,
-            ["directoryStream"] = files.DirectoryStream,
-            ["timeout"] = Timeout(timeout),
-            ["strict"] = strict,
-        }).ConfigureAwait(false);
+        await SendMessageToServerAsync(
+            "setInputFiles",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["payloads"] = files.Payloads,
+                ["localPaths"] = files.LocalPaths,
+                ["localDirectory"] = files.LocalDirectory,
+                ["streams"] = files.Streams,
+                ["directoryStream"] = files.DirectoryStream,
+                ["strict"] = strict,
+            },
+            timeout: Timeout(timeout)).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -565,96 +593,110 @@ internal class Frame : ChannelOwner, IFrame
         => ClickInternalAsync(selector, options, null);
 
     internal Task ClickInternalAsync(string selector, FrameClickOptions? options, int? steps)
-        => SendMessageToServerAsync("click", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["button"] = options?.Button,
-            ["force"] = options?.Force,
-            ["delay"] = options?.Delay,
-            ["clickCount"] = options?.ClickCount,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-            ["position"] = options?.Position,
+        => SendMessageToServerAsync(
+            "click",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["button"] = options?.Button,
+                ["force"] = options?.Force,
+                ["delay"] = options?.Delay,
+                ["clickCount"] = options?.ClickCount,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+                ["position"] = options?.Position,
 #pragma warning disable CS0612 // Type or member is obsolete
-            ["noWaitAfter"] = options?.NoWaitAfter,
+                ["noWaitAfter"] = options?.NoWaitAfter,
 #pragma warning restore CS0612 // Type or member is obsolete
-            ["steps"] = steps,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+                ["steps"] = steps,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DblClickAsync(string selector, FrameDblClickOptions? options = default)
         => DblClickInternalAsync(selector, options, null);
 
     internal Task DblClickInternalAsync(string selector, FrameDblClickOptions? options, int? steps)
-        => SendMessageToServerAsync("dblclick", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["button"] = options?.Button,
-            ["delay"] = options?.Delay,
-            ["force"] = options?.Force,
-            ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
-            ["position"] = options?.Position,
-            ["steps"] = steps,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "dblclick",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["button"] = options?.Button,
+                ["delay"] = options?.Delay,
+                ["force"] = options?.Force,
+                ["modifiers"] = options?.Modifiers?.Select(m => m.ToValueString()),
+                ["position"] = options?.Position,
+                ["steps"] = steps,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task CheckAsync(string selector, FrameCheckOptions? options = default)
-        => SendMessageToServerAsync("check", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "check",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task UncheckAsync(string selector, FrameUncheckOptions? options = default)
-        => SendMessageToServerAsync("uncheck", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            "uncheck",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetCheckedAsync(string selector, bool checkedState, FrameSetCheckedOptions? options = null)
-        => SendMessageToServerAsync(checkedState ? "check" : "uncheck", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["force"] = options?.Force,
-            ["position"] = options?.Position,
-            ["trial"] = options?.Trial,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        });
+        => SendMessageToServerAsync(
+            checkedState ? "check" : "uncheck",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["force"] = options?.Force,
+                ["position"] = options?.Position,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task SetContentAsync(string html, FrameSetContentOptions? options = default)
-        => SendMessageToServerAsync("setContent", new Dictionary<string, object?>
-        {
-            ["html"] = html,
-            ["waitUntil"] = options?.WaitUntil,
-            ["timeout"] = Timeout(options?.Timeout),
-        });
+        => SendMessageToServerAsync(
+            "setContent",
+            new Dictionary<string, object?>
+            {
+                ["html"] = html,
+                ["waitUntil"] = options?.WaitUntil,
+            },
+            timeout: Timeout(options?.Timeout));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> InputValueAsync(string selector, FrameInputValueOptions? options = null)
-        => (await SendMessageToServerAsync("inputValue", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
+        => (await SendMessageToServerAsync(
+            "inputValue",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))!.Value.GetProperty("value").ToString();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle> QuerySelectorAsync(string selector)
@@ -680,9 +722,9 @@ internal class Frame : ChannelOwner, IFrame
             {
                 ["expression"] = expression,
                 ["arg"] = ScriptsHelper.SerializedArgument(arg),
-                ["timeout"] = Timeout(options?.Timeout),
                 ["pollingInterval"] = options?.PollingInterval,
-            }).ConfigureAwait(false);
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IElementHandle?> WaitForSelectorAsync(string selector, FrameWaitForSelectorOptions? options = default)
@@ -691,11 +733,11 @@ internal class Frame : ChannelOwner, IFrame
             new Dictionary<string, object?>
             {
                 ["selector"] = selector,
-                ["timeout"] = Timeout(options?.Timeout),
                 ["state"] = options?.State,
                 ["strict"] = options?.Strict,
                 ["omitReturnValue"] = false,
-            }).ConfigureAwait(false);
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IJSHandle> EvaluateHandleAsync(string script, object? args = null)
@@ -812,49 +854,59 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse?> GotoAsync(string url, FrameGotoOptions? options = default)
-        => await SendMessageToServerAsync<Response>("goto", new Dictionary<string, object?>
-        {
-            ["url"] = url,
-            ["timeout"] = NavigationTimeout(options?.Timeout),
-            ["waitUntil"] = options?.WaitUntil,
-            ["referer"] = options?.Referer,
-        }).ConfigureAwait(false);
+        => await SendMessageToServerAsync<Response>(
+            "goto",
+            new Dictionary<string, object?>
+            {
+                ["url"] = url,
+                ["waitUntil"] = options?.WaitUntil,
+                ["referer"] = options?.Referer,
+            },
+            timeout: NavigationTimeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<bool> IsCheckedAsync(string selector, FrameIsCheckedOptions? options = default)
-        => (await SendMessageToServerAsync("isChecked", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
+        => (await SendMessageToServerAsync(
+            "isChecked",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<bool> IsDisabledAsync(string selector, FrameIsDisabledOptions? options = default)
-        => (await SendMessageToServerAsync("isDisabled", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
+        => (await SendMessageToServerAsync(
+            "isDisabled",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<bool> IsEditableAsync(string selector, FrameIsEditableOptions? options = default)
-        => (await SendMessageToServerAsync("isEditable", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
+        => (await SendMessageToServerAsync(
+            "isEditable",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<bool> IsEnabledAsync(string selector, FrameIsEnabledOptions? options = default)
-        => (await SendMessageToServerAsync("isEnabled", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["strict"] = options?.Strict,
-        }).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
+        => (await SendMessageToServerAsync(
+            "isEnabled",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = options?.Strict,
+            },
+            timeout: Timeout(options?.Timeout)).ConfigureAwait(false))?.GetProperty("value").GetBoolean() ?? default;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<bool> IsHiddenAsync(string selector, FrameIsHiddenOptions? options = default)
@@ -886,18 +938,20 @@ internal class Frame : ChannelOwner, IFrame
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task DragAndDropAsync(string source, string target, FrameDragAndDropOptions? options = null)
-        => SendMessageToServerAsync("dragAndDrop", new Dictionary<string, object?>
-        {
-            ["source"] = source,
-            ["target"] = target,
-            ["force"] = options?.Force,
-            ["steps"] = options?.Steps,
-            ["timeout"] = Timeout(options?.Timeout),
-            ["trial"] = options?.Trial,
-            ["strict"] = options?.Strict,
-            ["sourcePosition"] = options?.SourcePosition,
-            ["targetPosition"] = options?.TargetPosition,
-        });
+        => SendMessageToServerAsync(
+            "dragAndDrop",
+            new Dictionary<string, object?>
+            {
+                ["source"] = source,
+                ["target"] = target,
+                ["force"] = options?.Force,
+                ["steps"] = options?.Steps,
+                ["trial"] = options?.Trial,
+                ["strict"] = options?.Strict,
+                ["sourcePosition"] = options?.SourcePosition,
+                ["targetPosition"] = options?.TargetPosition,
+            },
+            timeout: Timeout(options?.Timeout));
 
     internal async Task DropAsync(string selector, DropPayload payload, Position? position, float? timeout, bool strict)
     {
@@ -917,35 +971,39 @@ internal class Frame : ChannelOwner, IFrame
             ["value"] = kv.Value,
         }).ToArray();
 
-        await SendMessageToServerAsync("drop", new Dictionary<string, object?>
-        {
-            ["selector"] = selector,
-            ["strict"] = strict,
-            ["position"] = position,
-            ["payloads"] = fileParams?.Payloads,
-            ["localPaths"] = fileParams?.LocalPaths,
-            ["streams"] = fileParams?.Streams,
-            ["data"] = data,
-            ["timeout"] = Timeout(timeout),
-        }).ConfigureAwait(false);
+        await SendMessageToServerAsync(
+            "drop",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = selector,
+                ["strict"] = strict,
+                ["position"] = position,
+                ["payloads"] = fileParams?.Payloads,
+                ["localPaths"] = fileParams?.LocalPaths,
+                ["streams"] = fileParams?.Streams,
+                ["data"] = data,
+            },
+            timeout: Timeout(timeout)).ConfigureAwait(false);
     }
 
     internal async Task<FrameExpectResult> ExpectAsync(string? selector, string expression, FrameExpectOptions options)
     {
         try
         {
-            await SendMessageToServerAsync("expect", new Dictionary<string, object?>
-            {
-                ["selector"] = selector,
-                ["expression"] = expression,
-                ["expressionArg"] = options.ExpressionArg,
-                ["expectedText"] = options.ExpectedText,
-                ["expectedNumber"] = options.ExpectedNumber,
-                ["expectedValue"] = options.ExpectedValue,
-                ["useInnerText"] = options.UseInnerText,
-                ["isNot"] = options.IsNot,
-                ["timeout"] = options.Timeout,
-            }).ConfigureAwait(false);
+            await SendMessageToServerAsync(
+                "expect",
+                new Dictionary<string, object?>
+                {
+                    ["selector"] = selector,
+                    ["expression"] = expression,
+                    ["expressionArg"] = options.ExpressionArg,
+                    ["expectedText"] = options.ExpectedText,
+                    ["expectedNumber"] = options.ExpectedNumber,
+                    ["expectedValue"] = options.ExpectedValue,
+                    ["useInnerText"] = options.UseInnerText,
+                    ["isNot"] = options.IsNot,
+                },
+                timeout: options.Timeout).ConfigureAwait(false);
             return new FrameExpectResult { Matches = !options.IsNot };
         }
         catch (Exception e) when (e.Data.Contains(Connection.ErrorDetailsDataKey))

--- a/src/Playwright/Core/LocalUtils.cs
+++ b/src/Playwright/Core/LocalUtils.cs
@@ -93,14 +93,16 @@ internal class LocalUtils : ChannelOwner
         });
 
     internal async Task<JsonPipe> ConnectAsync(string wsEndpoint, IEnumerable<KeyValuePair<string, string>>? headers = default, float? slowMo = default, float? timeout = default, string? exposeNetwork = default)
-         => (await SendMessageToServerAsync("connect", new Dictionary<string, object?>
-            {
-                { "endpoint", wsEndpoint },
-                { "headers", headers },
-                { "slowMo", slowMo },
-                { "timeout", timeout ?? 0 },
-                { "exposeNetwork", exposeNetwork },
-            }).ConfigureAwait(false))!.Value.GetObject<JsonPipe>("pipe", _connection);
+         => (await SendMessageToServerAsync(
+                "connect",
+                new Dictionary<string, object?>
+                {
+                    { "endpoint", wsEndpoint },
+                    { "headers", headers },
+                    { "slowMo", slowMo },
+                    { "exposeNetwork", exposeNetwork },
+                },
+                timeout: timeout ?? 0).ConfigureAwait(false))!.Value.GetObject<JsonPipe>("pipe", _connection);
 
     internal void AddStackToTracingNoReply(List<StackFrame> stack, int id)
          => SendMessageToServerAsync("addStackToTracingNoReply", new Dictionary<string, object?>

--- a/src/Playwright/Core/Locator.cs
+++ b/src/Playwright/Core/Locator.cs
@@ -278,9 +278,9 @@ internal class Locator : ILocator
             new Dictionary<string, object?>
             {
                 ["selector"] = _selector,
-                ["timeout"] = _frame.Timeout(options?.Timeout),
                 ["strict"] = true,
-            });
+            },
+            timeout: _frame.Timeout(options?.Timeout));
 
     public Task<int> CountAsync()
         => _frame.QueryCountAsync(_selector);
@@ -388,26 +388,30 @@ internal class Locator : ILocator
 
     public Task WaitForAsync(LocatorWaitForOptions? options = null)
     {
-        return _frame.SendMessageToServerAsync("waitForSelector", new Dictionary<string, object?>
-        {
-            ["selector"] = _selector,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["state"] = options?.State,
-            ["strict"] = true,
-            ["omitReturnValue"] = true,
-        });
+        return _frame.SendMessageToServerAsync(
+            "waitForSelector",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = _selector,
+                ["state"] = options?.State,
+                ["strict"] = true,
+                ["omitReturnValue"] = true,
+            },
+            timeout: _frame.Timeout(options?.Timeout));
     }
 
     public Task WaitForFunctionAsync(string expression, object? arg = default, LocatorWaitForFunctionOptions? options = default)
     {
-        return _frame.SendMessageToServerAsync("waitForFunction", new Dictionary<string, object?>
-        {
-            ["selector"] = _selector,
-            ["strict"] = true,
-            ["expression"] = expression,
-            ["arg"] = ScriptsHelper.SerializedArgument(arg),
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-        });
+        return _frame.SendMessageToServerAsync(
+            "waitForFunction",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = _selector,
+                ["strict"] = true,
+                ["expression"] = expression,
+                ["arg"] = ScriptsHelper.SerializedArgument(arg),
+            },
+            timeout: _frame.Timeout(options?.Timeout));
     }
 
     internal Task<FrameExpectResult> ExpectAsync(string expression, FrameExpectOptions options, string? title)
@@ -448,13 +452,15 @@ internal class Locator : ILocator
         return this._frame.WrapApiCallAsync(
             async () =>
         {
-            var handle = await _frame.SendMessageToServerAsync<ElementHandle>("waitForSelector", new Dictionary<string, object?>
-            {
-                ["selector"] = this._selector,
-                ["state"] = WaitForSelectorState.Attached,
-                ["timeout"] = timeout,
-                ["strict"] = true,
-            }).ConfigureAwait(false);
+            var handle = await _frame.SendMessageToServerAsync<ElementHandle>(
+                "waitForSelector",
+                new Dictionary<string, object?>
+                {
+                    ["selector"] = this._selector,
+                    ["state"] = WaitForSelectorState.Attached,
+                    ["strict"] = true,
+                },
+                timeout: timeout).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new PlaywrightException($"Could not resolve {this._selector} to DOM Element");
@@ -661,13 +667,15 @@ internal class Locator : ILocator
 
     public async Task<string> AriaSnapshotAsync(LocatorAriaSnapshotOptions? options = null)
     {
-        var result = await _frame.SendMessageToServerAsync("ariaSnapshot", new Dictionary<string, object?>
-        {
-            ["selector"] = _selector,
-            ["timeout"] = _frame.Timeout(options?.Timeout),
-            ["mode"] = options?.Mode,
-            ["depth"] = options?.Depth,
-        }).ConfigureAwait(false);
+        var result = await _frame.SendMessageToServerAsync(
+            "ariaSnapshot",
+            new Dictionary<string, object?>
+            {
+                ["selector"] = _selector,
+                ["mode"] = options?.Mode,
+                ["depth"] = options?.Depth,
+            },
+            timeout: _frame.Timeout(options?.Timeout)).ConfigureAwait(false);
         return result!.Value.GetProperty("snapshot").ToString();
     }
 

--- a/src/Playwright/Core/Page.cs
+++ b/src/Playwright/Core/Page.cs
@@ -707,26 +707,28 @@ internal class Page : ChannelOwner, IPage
             options.Type = ElementHandle.DetermineScreenshotType(options.Path);
         }
 
-        var result = (await SendMessageToServerAsync("screenshot", new Dictionary<string, object?>
-        {
-            ["fullPage"] = options.FullPage,
-            ["omitBackground"] = options.OmitBackground,
-            ["clip"] = options.Clip,
-            ["path"] = options.Path,
-            ["type"] = options.Type,
-            ["timeout"] = _timeoutSettings.Timeout(options.Timeout),
-            ["animations"] = options.Animations,
-            ["caret"] = options.Caret,
-            ["scale"] = options.Scale,
-            ["quality"] = options.Quality,
-            ["maskColor"] = options.MaskColor,
-            ["style"] = options.Style,
-            ["mask"] = options.Mask?.Select(locator => new Dictionary<string, object>
+        var result = (await SendMessageToServerAsync(
+            "screenshot",
+            new Dictionary<string, object?>
             {
-                ["frame"] = ((Locator)locator)._frame,
-                ["selector"] = ((Locator)locator)._selector,
-            }).ToArray(),
-        }).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
+                ["fullPage"] = options.FullPage,
+                ["omitBackground"] = options.OmitBackground,
+                ["clip"] = options.Clip,
+                ["path"] = options.Path,
+                ["type"] = options.Type,
+                ["animations"] = options.Animations,
+                ["caret"] = options.Caret,
+                ["scale"] = options.Scale,
+                ["quality"] = options.Quality,
+                ["maskColor"] = options.MaskColor,
+                ["style"] = options.Style,
+                ["mask"] = options.Mask?.Select(locator => new Dictionary<string, object>
+                {
+                    ["frame"] = ((Locator)locator)._frame,
+                    ["selector"] = ((Locator)locator)._selector,
+                }).ToArray(),
+            },
+            timeout: _timeoutSettings.Timeout(options.Timeout)).ConfigureAwait(false))!.Value.GetProperty("binary").GetBytesFromBase64();
 
         if (!string.IsNullOrEmpty(options.Path))
         {
@@ -818,27 +820,33 @@ internal class Page : ChannelOwner, IPage
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse?> GoBackAsync(PageGoBackOptions? options = default)
-        => await SendMessageToServerAsync<Response>("goBack", new Dictionary<string, object?>
-        {
-            ["timeout"] = _timeoutSettings.NavigationTimeout(options?.Timeout),
-            ["waitUntil"] = options?.WaitUntil,
-        }).ConfigureAwait(false);
+        => await SendMessageToServerAsync<Response>(
+            "goBack",
+            new Dictionary<string, object?>
+            {
+                ["waitUntil"] = options?.WaitUntil,
+            },
+            timeout: _timeoutSettings.NavigationTimeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse?> GoForwardAsync(PageGoForwardOptions? options = default)
-        => await SendMessageToServerAsync<Response>("goForward", new Dictionary<string, object?>
-        {
-            ["timeout"] = _timeoutSettings.NavigationTimeout(options?.Timeout),
-            ["waitUntil"] = options?.WaitUntil,
-        }).ConfigureAwait(false);
+        => await SendMessageToServerAsync<Response>(
+            "goForward",
+            new Dictionary<string, object?>
+            {
+                ["waitUntil"] = options?.WaitUntil,
+            },
+            timeout: _timeoutSettings.NavigationTimeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<IResponse?> ReloadAsync(PageReloadOptions? options = default)
-        => await SendMessageToServerAsync<Response>("reload", new Dictionary<string, object?>
-        {
-            ["timeout"] = _timeoutSettings.NavigationTimeout(options?.Timeout),
-            ["waitUntil"] = options?.WaitUntil,
-        }).ConfigureAwait(false);
+        => await SendMessageToServerAsync<Response>(
+            "reload",
+            new Dictionary<string, object?>
+            {
+                ["waitUntil"] = options?.WaitUntil,
+            },
+            timeout: _timeoutSettings.NavigationTimeout(options?.Timeout)).ConfigureAwait(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public Task HideHighlightAsync() => SendMessageToServerAsync("hideHighlight");
@@ -1558,12 +1566,14 @@ internal class Page : ChannelOwner, IPage
     [MethodImpl(MethodImplOptions.NoInlining)]
     public async Task<string> AriaSnapshotAsync(PageAriaSnapshotOptions? options = default)
     {
-        var result = await MainFrame.SendMessageToServerAsync("ariaSnapshot", new Dictionary<string, object?>
-        {
-            ["timeout"] = MainFrame.Timeout(options?.Timeout),
-            ["mode"] = options?.Mode,
-            ["depth"] = options?.Depth,
-        }).ConfigureAwait(false);
+        var result = await MainFrame.SendMessageToServerAsync(
+            "ariaSnapshot",
+            new Dictionary<string, object?>
+            {
+                ["mode"] = options?.Mode,
+                ["depth"] = options?.Depth,
+            },
+            timeout: MainFrame.Timeout(options?.Timeout)).ConfigureAwait(false);
         return result!.Value.GetProperty("snapshot").ToString();
     }
 

--- a/src/Playwright/Transport/ChannelOwner.cs
+++ b/src/Playwright/Transport/ChannelOwner.cs
@@ -127,11 +127,13 @@ internal class ChannelOwner
     internal Task<JsonElement?> SendMessageToServerAsync(
         string method,
         Dictionary<string, object?>? args = null,
-        bool keepNulls = false)
-        => SendMessageToServerAsync<JsonElement?>(method, args, keepNulls);
+        bool keepNulls = false,
+        float? timeout = null)
+        => SendMessageToServerAsync<JsonElement?>(method, args, keepNulls, timeout);
 
     internal Task<T> SendMessageToServerAsync<T>(
         string method,
         Dictionary<string, object?>? args = null,
-        bool keepNulls = false) => _connection.SendMessageToServerAsync<T>(this, method, args, keepNulls);
+        bool keepNulls = false,
+        float? timeout = null) => _connection.SendMessageToServerAsync<T>(this, method, args, keepNulls, timeout);
 }

--- a/src/Playwright/Transport/Connection.cs
+++ b/src/Playwright/Transport/Connection.cs
@@ -128,20 +128,23 @@ internal class Connection : IDisposable
         ChannelOwner? @object,
         string method,
         Dictionary<string, object?>? args = null,
-        bool keepNulls = false)
-        => SendMessageToServerAsync<JsonElement?>(@object, method, args, keepNulls);
+        bool keepNulls = false,
+        float? timeout = null)
+        => SendMessageToServerAsync<JsonElement?>(@object, method, args, keepNulls, timeout);
 
     internal Task<T> SendMessageToServerAsync<T>(
         ChannelOwner? @object,
         string method,
         Dictionary<string, object?>? args = null,
-        bool keepNulls = false) => WrapApiCallAsync(() => InnerSendMessageToServerAsync<T>(@object, method, args, keepNulls), false, null);
+        bool keepNulls = false,
+        float? timeout = null) => WrapApiCallAsync(() => InnerSendMessageToServerAsync<T>(@object, method, args, keepNulls, timeout), false, null);
 
     private async Task<T> InnerSendMessageToServerAsync<T>(
         ChannelOwner? @object,
         string method,
         Dictionary<string, object?>? dictionary = null,
-        bool keepNulls = false)
+        bool keepNulls = false,
+        float? timeout = null)
     {
         // Fire-and-forget: server intentionally never replies to __waitInfo__,
         // so silently drop it after the connection is closed or the object was collected.
@@ -181,10 +184,9 @@ internal class Connection : IDisposable
             ["internal"] = isInternal,
             ["wallTime"] = DateTimeOffset.Now.ToUnixTimeMilliseconds(),
         };
-        if (sanitizedArgs.TryGetValue("timeout", out var timeout))
+        if (timeout.HasValue)
         {
-            sanitizedArgs.Remove("timeout");
-            metadata["timeout"] = timeout;
+            metadata["timeout"] = timeout.Value;
         }
         if (!string.IsNullOrEmpty(title))
         {


### PR DESCRIPTION
Passes the call timeout as a separate `SendMessageToServerAsync` argument instead of extracting a `timeout` entry from the parameter dictionary.

This matches the Java and JavaScript clients and avoids claiming any future protocol field named `timeout`.

The full Chromium suite remains at `1818` passed tests and `33` skipped tests.  The only two local failures require `pwsh`, which is not installed on the validation machine.