### PR TITLE
chore(release): mark 1.62.0

### DIFF
--- a/src/Common/Version.props
+++ b/src/Common/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>1.61.0</AssemblyVersion>
+    <AssemblyVersion>1.62.0</AssemblyVersion>
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <DriverVersion>1.62.0</DriverVersion>
     <!-- The Node.js version bundled with the driver. Set by the roll script to the latest


### PR DESCRIPTION
`AssemblyVersion` remained at `1.61.0` after the driver roll.

Sets it to `1.62.0`, which also updates `PackageVersion`, `ReleaseVersion`, and `FileVersion` because they reference `AssemblyVersion`.
