### PR TITLE
devops(docker): run docker tests against net10.0

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Check formatting
       run: dotnet format ./src/ --verify-no-changes -v:diag
     - name: Download driver

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -31,7 +31,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Install prerequisites and download drivers
       shell: bash
       run: ./build.sh --download-driver
@@ -42,8 +44,10 @@ jobs:
     - name: Cleanup
       run: dotnet clean src/ || true
     - name: Test
+      # The docker image no longer set DOTNET_ROLL_FORWARD=Major, so net8.0 test binaries cannot run.
+      # See https://github.com/dotnet/dotnet-docker/issues/7255 and https://github.com/dotnet/dotnet-docker/pull/7256.
       run: |
         CONTAINER_ID="$(docker run --rm -e CI --ipc=host -v $(pwd):/root/playwright --name playwright-docker-test --workdir /root/playwright/ -e CI -d -t playwright-dotnet:localbuild-${{ matrix.flavor }} /bin/bash)"
-        docker exec -e BROWSER=chromium "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug --logger:"console;verbosity=detailed"
-        docker exec -e BROWSER=firefox "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug --logger:"console;verbosity=detailed"
-        docker exec -e BROWSER=webkit "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug --logger:"console;verbosity=detailed"
+        docker exec -e BROWSER=chromium "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net10.0 --logger:"console;verbosity=detailed"
+        docker exec -e BROWSER=firefox "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net10.0 --logger:"console;verbosity=detailed"
+        docker exec -e BROWSER=webkit "${CONTAINER_ID}" xvfb-run dotnet test ./src/Playwright.Tests/Playwright.Tests.csproj -c Debug -f net10.0 --logger:"console;verbosity=detailed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Install prerequisites and download drivers
         shell: bash
         run: ./build.sh --download-driver

--- a/.github/workflows/tests_harness.yml
+++ b/.github/workflows/tests_harness.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/validate-nuget-packages.yml
+++ b/.github/workflows/validate-nuget-packages.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Download driver
       run: ./build.sh --download-driver
     - name: Validate NuGet packages

--- a/src/Playwright.Tests/Playwright.Tests.csproj
+++ b/src/Playwright.Tests/Playwright.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <LangVersion>12</LangVersion>
         <IsTestProject>true</IsTestProject>
         <ReleaseVersion>0.0.0</ReleaseVersion>


### PR DESCRIPTION
## Summary
- The .NET 10 SDK images no longer set `DOTNET_ROLL_FORWARD=Major` (dotnet/dotnet-docker#7255, dotnet/dotnet-docker#7256), so net8.0 test binaries cannot run inside the docker image anymore.
- Run docker tests with `-f net10.0` and add a `net10.0` target to `Playwright.Tests`.
- Install the .NET 10 SDK alongside 8.0 in workflows that build the solution.