### PR TITLE
devops(publish): install .NET 10 SDK in the publish pipeline

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -61,6 +61,11 @@ extends:
           inputs:
             packageType: sdk
             version: 8.x
+        - task: UseDotNet@2
+          displayName: 'Use .NET 10 SDK'
+          inputs:
+            packageType: sdk
+            version: 10.x
         # We need to download the driver first, so we can build
         - task: DotNetCoreCLI@2
           displayName: Download the driver


### PR DESCRIPTION
## Summary
- Playwright.Tests targets net10.0 since #3341, but the publish pipeline only installs the .NET 8 SDK, so the v1.62.0 release build failed with NETSDK1045.
- Install the .NET 10 SDK alongside .NET 8, mirroring the GitHub workflows.