### PR TITLE
fix(webSocketRoute): handle close events without code/reason

### DIFF
--- a/src/Playwright.Tests/PageRouteWebSocketTests.cs
+++ b/src/Playwright.Tests/PageRouteWebSocketTests.cs
@@ -287,6 +287,51 @@ public class PageRouteWebSocketTests : PageTestEx
         ]);
     }
 
+    [PlaywrightTest("route-web-socket.spec.ts", "should emit close upon frame navigation")]
+    public async Task ShouldEmitCloseUponFrameNavigation()
+    {
+        var tcs = new TaskCompletionSource<IWebSocketRoute>();
+        await Page.RouteWebSocketAsync(new Regex(".*"), ws =>
+        {
+            ws.ConnectToServer();
+            tcs.SetResult(ws);
+        });
+
+        await SetupWS(Page, Server.Port, "blob");
+
+        var route = await tcs.Task;
+        route.Send("hello");
+
+        await AssertAreEqualWithRetriesAsync(() => Page.EvaluateAsync<string[]>("() => window.log"), new[]
+        {
+            "open",
+            $"message: data=hello origin=ws://localhost:{Server.Port} lastEventId=",
+        });
+
+        var closedTcs = new TaskCompletionSource();
+        route.OnClose((code, reason) => closedTcs.TrySetResult());
+        await Page.GotoAsync(Server.EmptyPage);
+        await closedTcs.Task;
+    }
+
+    [PlaywrightTest("route-web-socket.spec.ts", "should not throw after page closure")]
+    public async Task ShouldNotThrowAfterPageClosure()
+    {
+        var tcs = new TaskCompletionSource<IWebSocketRoute>();
+        await Page.RouteWebSocketAsync(new Regex(".*"), ws =>
+        {
+            ws.ConnectToServer();
+            tcs.SetResult(ws);
+        });
+
+        await SetupWS(Page, Server.Port, "blob");
+
+        var route = await tcs.Task;
+        var closeTask = Page.CloseAsync();
+        route.Send("hello");
+        await closeTask;
+    }
+
     [PlaywrightTest("page-route-web-socket.spec.ts", "should work with baseURL")]
     public async Task ShouldWorkWithBaseURL()
     {

--- a/src/Playwright/Core/WebSocketRoute.cs
+++ b/src/Playwright/Core/WebSocketRoute.cs
@@ -90,35 +90,43 @@ internal class WebSocketRoute : ChannelOwner, IWebSocketRoute
                 }
                 break;
             case "closePage":
-                if (_onPageClose != null)
                 {
-                    _onPageClose(serverParams.GetProperty("code").GetInt32(), serverParams.GetProperty("reason").GetString());
-                }
-                else
-                {
-                    SendMessageToServerAsync("closeServer", new Dictionary<string, object?>
+                    int? code = serverParams.TryGetProperty("code", out var codeElement) && codeElement.ValueKind == JsonValueKind.Number ? codeElement.GetInt32() : null;
+                    string? reason = serverParams.TryGetProperty("reason", out var reasonElement) && reasonElement.ValueKind == JsonValueKind.String ? reasonElement.GetString() : null;
+                    if (_onPageClose != null)
                     {
-                        ["code"] = serverParams.GetProperty("code").GetInt32(),
-                        ["reason"] = serverParams.GetProperty("reason").GetString(),
-                        ["wasClean"] = serverParams.GetProperty("wasClean").GetBoolean(),
-                    }).IgnoreException();
+                        _onPageClose(code, reason);
+                    }
+                    else
+                    {
+                        SendMessageToServerAsync("closeServer", new Dictionary<string, object?>
+                        {
+                            ["code"] = code,
+                            ["reason"] = reason,
+                            ["wasClean"] = serverParams.GetProperty("wasClean").GetBoolean(),
+                        }).IgnoreException();
+                    }
+                    break;
                 }
-                break;
             case "closeServer":
-                if (_onServerClose != null)
                 {
-                    _onServerClose(serverParams.GetProperty("code").GetInt32(), serverParams.GetProperty("reason").GetString());
-                }
-                else
-                {
-                    SendMessageToServerAsync("closePage", new Dictionary<string, object?>
+                    int? code = serverParams.TryGetProperty("code", out var codeElement) && codeElement.ValueKind == JsonValueKind.Number ? codeElement.GetInt32() : null;
+                    string? reason = serverParams.TryGetProperty("reason", out var reasonElement) && reasonElement.ValueKind == JsonValueKind.String ? reasonElement.GetString() : null;
+                    if (_onServerClose != null)
                     {
-                        ["code"] = serverParams.GetProperty("code").GetInt32(),
-                        ["reason"] = serverParams.GetProperty("reason").GetString(),
-                        ["wasClean"] = serverParams.GetProperty("wasClean").GetBoolean(),
-                    }).IgnoreException();
+                        _onServerClose(code, reason);
+                    }
+                    else
+                    {
+                        SendMessageToServerAsync("closePage", new Dictionary<string, object?>
+                        {
+                            ["code"] = code,
+                            ["reason"] = reason,
+                            ["wasClean"] = serverParams.GetProperty("wasClean").GetBoolean(),
+                        }).IgnoreException();
+                    }
+                    break;
                 }
-                break;
         }
     }
 


### PR DESCRIPTION
## Summary
- `closePage` / `closeServer` events carry optional `code`/`reason` in the protocol, but were read with throwing accessors — a routed WebSocket closed by navigation or page closure threw `KeyNotFoundException` inside `Connection.Dispatch` and killed the whole connection.
- Read them with `TryGetProperty` and pass `null` through, matching the TypeScript client.
- Port `should emit close upon frame navigation` and `should not throw after page closure` tests from upstream; both reproduced the crash before the fix.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3333